### PR TITLE
Fixed compiler error with undefined BreakIntoDebugger()

### DIFF
--- a/internal/catch_debugger.hpp
+++ b/internal/catch_debugger.hpp
@@ -76,6 +76,8 @@
         #else
             #define BreakIntoDebugger() if( Catch::AmIBeingDebugged() ) {__asm__("int $3\n" : : );}
         #endif
+    #else
+        #define BreakIntoDebugger()
     #endif
 
 #elif defined(__WIN32__) && defined(_MSC_VER)


### PR DESCRIPTION
When compiling on a Mac with DEBUG not defined, the compiler would throw the following error for each call to REQUIRE():

error: 'BreakIntoDebugger' was not declared in this scope

Following the last three lines of the code at http://cocoawithlove.com/2008/03/break-into-debugger.html I added an #else to define an empty BreakIntoDebugger() in this case. The resulting function isn't terribly useful, but ensures the code can be compiled when not in debug mode.
