### PR TITLE
Fix compiler warnings

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -559,7 +559,8 @@ public:
         const char* expr = "",
         bool isNot = false
     )
-    : m_result( expr, isNot, filename, line, macroName )
+    : m_result( expr, isNot, filename, line, macroName ),
+      m_messageStream()
     {}
     
     ///////////////////////////////////////////////////////////////////////////
@@ -659,7 +660,7 @@ class ScopedInfo
 public:
     ///////////////////////////////////////////////////////////////////////////
     ScopedInfo
-    ()
+    () : m_oss()
     {
         Hub::getResultCapture().pushScopedInfo( this );
     }

--- a/include/internal/catch_common.h
+++ b/include/internal/catch_common.h
@@ -38,6 +38,7 @@ namespace Catch
 		void operator = ( const NonCopyable& );
 	protected:
 		NonCopyable(){}
+		virtual ~NonCopyable() {}
 	};
     
     typedef char NoType;

--- a/include/internal/catch_resultinfo.hpp
+++ b/include/internal/catch_resultinfo.hpp
@@ -24,7 +24,14 @@ namespace Catch
         ///////////////////////////////////////////////////////////////////////////
         ResultInfo
         ()
-        :   m_line( 0 ),
+        :   m_macroName(),
+            m_filename(),
+            m_line( 0 ),
+            m_expr(),
+            m_lhs(),
+            m_rhs(),
+            m_op(),
+            m_message(),
             m_result( ResultWas::Unknown ),
             m_isNot( false )
         {}
@@ -44,6 +51,8 @@ namespace Catch
             m_filename( filename ),
             m_line( line ),
             m_expr( expr ),
+	    m_lhs(),
+	    m_rhs(),
             m_op( isNotExpression( expr ) ? "!" : "" ),
             m_message( message ),
             m_result( result ),
@@ -53,6 +62,11 @@ namespace Catch
                 m_expr = "!" + m_expr;
         }
         
+        ///////////////////////////////////////////////////////////////////////////
+	virtual ~ResultInfo
+        ()
+	{
+	}
         ///////////////////////////////////////////////////////////////////////////
         bool ok
         ()

--- a/include/internal/catch_section.hpp
+++ b/include/internal/catch_section.hpp
@@ -31,6 +31,8 @@ namespace Catch
             std::size_t line
         )
         :   m_name( name ),
+            m_successes(0),
+            m_failures(0),
             m_sectionIncluded( Hub::getResultCapture().sectionStarted( name, description, filename, line, m_successes, m_failures ) )
         {
         }

--- a/include/internal/catch_test_case_info.hpp
+++ b/include/internal/catch_test_case_info.hpp
@@ -42,7 +42,11 @@ namespace Catch
         ///////////////////////////////////////////////////////////////////////
         TestCaseInfo
         ()
-        :   m_test( NULL )
+        :   m_test( NULL ),
+            m_name(),
+            m_description(),
+            m_filename(),
+            m_line( 0 )
         {
         }
         


### PR DESCRIPTION
I tend to compile my source with a fairly full set of g++ warning options (``-O2 -Wall -Wextra -Winit-self -Wmissing-include-dirs -Wswitch-enum -Wunused -Wfloat-equal -Wundef -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -Wconversion -Wsign-conversion -Wredundant-decls -Wsign-promo -Weffc++` to be exact), which result in a lot of warnings from Catch. This pull request addresses several of those.

There are still a couple remaining that I'm not sure how to fix, since they're in a fairly magical part of the Catch logic:

```
include/internal/catch_capture.hpp:306:5: warning: user-defined ‘Catch::STATIC_ASSERT_Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison& Catch::MutableResultInfo::operator||(const RhsT&)’ always evaluates both arguments
include/internal/catch_capture.hpp:313:5: warning: user-defined ‘Catch::STATIC_ASSERT_Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison& Catch::MutableResultInfo::operator&&(const RhsT&)’ always evaluates both arguments
include/internal/catch_capture.hpp:467:5: warning: ‘Catch::STATIC_ASSERT_Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison& Catch::Expression<T>::operator+(const RhsT&)’ should return by value
include/internal/catch_capture.hpp:474:5: warning: ‘Catch::STATIC_ASSERT_Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison& Catch::Expression<T>::operator-(const RhsT&)’ should return by value
```
