### PR TITLE
Fix CATCH Issue #61, Assembler Error on iOS/ARM

### DIFF
--- a/include/internal/catch_debugger.hpp
+++ b/include/internal/catch_debugger.hpp
@@ -16,8 +16,10 @@
 
 #include <iostream>
 
-#if defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
+#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
 #define CATCH_PLATFORM_MAC
+#elif  defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#define CATCH_PLATFORM_IPHONE
 #elif defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER)
 #define CATCH_PLATFORM_WINDOWS
 #endif


### PR DESCRIPTION
Fix assembler error in catch_debugger.hpp on iOS on ARM that occurs trying to use assembly for Intel because CATCH_PLATFORM_MAC is defined. Define CATCH_PLATFORM_MAC using #if defined(**MAC_OS_X_VERSION_MIN_REQUIRED) instead of #if defined(macintosh) || defined(__APPLE**) || defined(**APPLE_CC**). Add new CATCH_PLATFORM_IPHONE defined using #elif  defined(__IPHONE_OS_VERSION_MIN_REQUIRED) for future use. The BreakIntoDebugger and isDebuggerActive functions remain without implementations for iOS.
