### PR TITLE
Fix missing parameter for comparisons between long and unsigned X.

### DIFF
--- a/include/internal/catch_evaluate.hpp
+++ b/include/internal/catch_evaluate.hpp
@@ -160,15 +160,15 @@ namespace Internal
     // long to unsigned X
     template<Operator Op> bool compare( long lhs, unsigned int rhs )
     {
-        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ) );
+        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ), rhs );
     }
     template<Operator Op> bool compare( long lhs, unsigned long rhs )
     {
-        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ) );
+        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ), rhs );
     }
     template<Operator Op> bool compare( long lhs, unsigned char rhs )
     {
-        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ) );
+        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ), rhs );
     }
 
     template<Operator Op, typename T>

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1265,15 +1265,15 @@ namespace Internal
     // long to unsigned X
     template<Operator Op> bool compare( long lhs, unsigned int rhs )
     {
-        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ) );
+        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ), rhs );
     }
     template<Operator Op> bool compare( long lhs, unsigned long rhs )
     {
-        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ) );
+        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ), rhs );
     }
     template<Operator Op> bool compare( long lhs, unsigned char rhs )
     {
-        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ) );
+        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ), rhs );
     }
 
     template<Operator Op, typename T>


### PR DESCRIPTION
A simple test case to reproduce the issue: https://gist.github.com/2511325

Also note that `REQUIRE( long_var == unsigned_long_var );` makes **llvm-g++-4.2** issue the warning "_comparison between signed and unsigned integer expressions_". I don't see the reason, since the correct overload is provided and it's correctly invoked. Perhaps you have a hint?
