### PR TITLE
Warning "unused parameter" silenced

### DIFF
--- a/include/internal/catch_tostring.hpp
+++ b/include/internal/catch_tostring.hpp
@@ -116,7 +116,7 @@ inline std::string toString( bool value ) {
 }
 
 #ifdef CATCH_CONFIG_CPP11_NULLPTR
-inline std::string toString( std::nullptr_t null ) {
+inline std::string toString( std::nullptr_t ) {
     return "nullptr";
 }
 #endif


### PR DESCRIPTION
The current head of Catch doesn’t compile with `-Wall -Werror` due to the unused parameter. This patch fixes that.

There’s another warning/error due to a missing virtual destructor in `IContext` but adding an empty virtual destructor results in a segfault that I cannot explain.
