### PR TITLE
MSVC reporter and a couple of changes to remove MSVC warnings when using /Wall

### DIFF
--- a/include/catch_runner.hpp
+++ b/include/catch_runner.hpp
@@ -13,6 +13,7 @@
 #include "internal/catch_commandline.hpp"
 #include "internal/catch_list.hpp"
 #include "reporters/catch_reporter_basic.hpp"
+#include "reporters/catch_reporter_msvc.hpp"
 #include "reporters/catch_reporter_xml.hpp"
 #include "reporters/catch_reporter_junit.hpp"
 
@@ -22,7 +23,8 @@
 
 namespace Catch {
 
-    INTERNAL_CATCH_REGISTER_REPORTER( "basic", BasicReporter )
+	INTERNAL_CATCH_REGISTER_REPORTER( "basic", BasicReporter )
+	INTERNAL_CATCH_REGISTER_REPORTER( "msvc", MsvcReporter )
     INTERNAL_CATCH_REGISTER_REPORTER( "xml", XmlReporter )
     INTERNAL_CATCH_REGISTER_REPORTER( "junit", JunitReporter )
     

--- a/include/catch_runner.hpp
+++ b/include/catch_runner.hpp
@@ -23,8 +23,8 @@
 
 namespace Catch {
 
-	INTERNAL_CATCH_REGISTER_REPORTER( "basic", BasicReporter )
-	INTERNAL_CATCH_REGISTER_REPORTER( "msvc", MsvcReporter )
+    INTERNAL_CATCH_REGISTER_REPORTER( "basic", BasicReporter )
+    INTERNAL_CATCH_REGISTER_REPORTER( "msvc", MsvcReporter )
     INTERNAL_CATCH_REGISTER_REPORTER( "xml", XmlReporter )
     INTERNAL_CATCH_REGISTER_REPORTER( "junit", JunitReporter )
     

--- a/include/internal/catch_common.h
+++ b/include/internal/catch_common.h
@@ -118,12 +118,12 @@ namespace Catch {
     }
 }
 
-#define CATCH_INTERNAL_ERROR( msg ) throwLogicError( msg, __FILE__, __LINE__ );
+#define CATCH_INTERNAL_ERROR( msg ) throwLogicError( msg, __FILE__, static_cast<std::size_t>(__LINE__) );
 
 //#ifdef __FUNCTION__
-//#define CATCH_INTERNAL_LINEINFO ::Catch::SourceLineInfo( __FUNCTION__, __FILE__, __LINE__ )
+//#define CATCH_INTERNAL_LINEINFO ::Catch::SourceLineInfo( __FUNCTION__, __FILE__, static_cast<std::size_t>(__LINE__) )
 //#else
-#define CATCH_INTERNAL_LINEINFO ::Catch::SourceLineInfo( __FILE__, __LINE__ )
+#define CATCH_INTERNAL_LINEINFO ::Catch::SourceLineInfo( __FILE__, static_cast<std::size_t>(__LINE__) )
 //#endif
 
 #endif // TWOBLUECUBES_CATCH_COMMON_H_INCLUDED

--- a/include/internal/catch_console_colour_impl.hpp
+++ b/include/internal/catch_console_colour_impl.hpp
@@ -34,7 +34,7 @@ namespace Catch {
                     return FOREGROUND_BLUE | FOREGROUND_GREEN;      // turquoise
                 case TextColour::ReconstructedExpression:    
                     return FOREGROUND_RED | FOREGROUND_GREEN;       // greeny-yellow
-				case TextColour::None:
+                case TextColour::None:
                 default: return 0;
             }
         }

--- a/include/internal/catch_console_colour_impl.hpp
+++ b/include/internal/catch_console_colour_impl.hpp
@@ -34,6 +34,7 @@ namespace Catch {
                     return FOREGROUND_BLUE | FOREGROUND_GREEN;      // turquoise
                 case TextColour::ReconstructedExpression:    
                     return FOREGROUND_RED | FOREGROUND_GREEN;       // greeny-yellow
+				case TextColour::None:
                 default: return 0;
             }
         }

--- a/include/internal/catch_interfaces_reporter.h
+++ b/include/internal/catch_interfaces_reporter.h
@@ -31,6 +31,11 @@ namespace Catch
         std::string name;
         std::ostream& stream;
         bool includeSuccessfulResults;
+
+	private:
+		// Explicitly disable copy constructor to prevent compiler warning on MSVC 2010.
+		// warning C4512: 'class' : assignment operator could not be generated
+		ReporterConfig& operator=( const ReporterConfig& );
     };    
     
     class TestCaseInfo;

--- a/include/reporters/catch_reporter_basic.hpp
+++ b/include/reporters/catch_reporter_basic.hpp
@@ -67,6 +67,16 @@ namespace Catch {
 
     private:
 
+		virtual const char* GetErrorPrefix() const {
+			return "";
+		}
+
+		virtual const char* GetWarningPrefix() const {		
+			return "warning:\n";
+		}
+
+	private:
+
         void ReportCounts( const std::string& label, const Counts& counts, const std::string& allPrefix = "All " ) {
             if( counts.passed )
                 m_config.stream << counts.failed << " of " << counts.total() << " " << label << "s failed";
@@ -110,13 +120,17 @@ namespace Catch {
         }
 
         virtual void EndTesting( const Totals& totals ) {
+			m_config.stream << "\n";
+			if( totals.assertions.failed ) {
+				m_config.stream << GetErrorPrefix();
+			}
             // Output the overall test results even if "Started Testing" was not emitted
             if( m_aborted ) {
-                m_config.stream << "\n[Testing aborted. ";
+                m_config.stream << "[Testing aborted. ";
                 ReportCounts( totals, "The first " );
             }
             else {
-                m_config.stream << "\n[Testing completed. ";
+                m_config.stream << "[Testing completed. ";
                 ReportCounts( totals );
             }
             m_config.stream << "]\n" << std::endl;
@@ -167,14 +181,17 @@ namespace Catch {
                 return;
             
             StartSpansLazily();
-            
-            if( !resultInfo.getFilename().empty() ) {
-                TextColour colour( TextColour::FileName );
-                m_config.stream << SourceLineInfo( resultInfo.getFilename(), resultInfo.getLine() );
-            }
+
+			if( !resultInfo.getFilename().empty() ) {
+				TextColour colour( TextColour::FileName );
+				m_config.stream << SourceLineInfo( resultInfo.getFilename(), resultInfo.getLine() );
+			}
             
             if( resultInfo.hasExpression() ) {
                 TextColour colour( TextColour::OriginalExpression );
+				if( !resultInfo.ok() ) {
+					m_config.stream << GetErrorPrefix();
+				}
                 m_config.stream << resultInfo.getExpression();
                 if( resultInfo.ok() ) {
                     TextColour successColour( TextColour::Success );
@@ -209,7 +226,7 @@ namespace Catch {
                     streamVariableLengthText( "info", resultInfo.getMessage() );
                     break;
                 case ResultWas::Warning:
-                    m_config.stream << "warning:\n'" << resultInfo.getMessage() << "'";
+                    m_config.stream << GetWarningPrefix() << "'" << resultInfo.getMessage() << "'";
                     break;
                 case ResultWas::ExplicitFailure:
                 {

--- a/include/reporters/catch_reporter_basic.hpp
+++ b/include/reporters/catch_reporter_basic.hpp
@@ -67,15 +67,15 @@ namespace Catch {
 
     private:
 
-		virtual const char* GetErrorPrefix() const {
-			return "";
-		}
+        virtual const char* GetErrorPrefix() const {
+            return "";
+        }
 
-		virtual const char* GetWarningPrefix() const {		
-			return "warning:\n";
-		}
+        virtual const char* GetWarningPrefix() const {
+            return "warning:\n";
+        }
 
-	private:
+    private:
 
         void ReportCounts( const std::string& label, const Counts& counts, const std::string& allPrefix = "All " ) {
             if( counts.passed )
@@ -120,10 +120,10 @@ namespace Catch {
         }
 
         virtual void EndTesting( const Totals& totals ) {
-			m_config.stream << "\n";
-			if( totals.assertions.failed ) {
-				m_config.stream << GetErrorPrefix();
-			}
+            m_config.stream << "\n";
+            if( totals.assertions.failed ) {
+                m_config.stream << GetErrorPrefix();
+            }
             // Output the overall test results even if "Started Testing" was not emitted
             if( m_aborted ) {
                 m_config.stream << "[Testing aborted. ";
@@ -182,16 +182,16 @@ namespace Catch {
             
             StartSpansLazily();
 
-			if( !resultInfo.getFilename().empty() ) {
-				TextColour colour( TextColour::FileName );
-				m_config.stream << SourceLineInfo( resultInfo.getFilename(), resultInfo.getLine() );
-			}
+            if( !resultInfo.getFilename().empty() ) {
+                TextColour colour( TextColour::FileName );
+                m_config.stream << SourceLineInfo( resultInfo.getFilename(), resultInfo.getLine() );
+            }
             
             if( resultInfo.hasExpression() ) {
                 TextColour colour( TextColour::OriginalExpression );
-				if( !resultInfo.ok() ) {
-					m_config.stream << GetErrorPrefix();
-				}
+                if( !resultInfo.ok() ) {
+                    m_config.stream << GetErrorPrefix();
+                }
                 m_config.stream << resultInfo.getExpression();
                 if( resultInfo.ok() ) {
                     TextColour successColour( TextColour::Success );

--- a/include/reporters/catch_reporter_msvc.hpp
+++ b/include/reporters/catch_reporter_msvc.hpp
@@ -16,27 +16,27 @@
 
 namespace Catch {
 
-	class MsvcReporter : public BasicReporter {
+    class MsvcReporter : public BasicReporter {
 
-	public:
-		MsvcReporter( const IReporterConfig& config )
-		:	BasicReporter(config)
-		{}
+    public:
+        MsvcReporter( const IReporterConfig& config )
+        :    BasicReporter(config)
+        {}
 
-		static std::string getDescription() {
-			return "Reports test results as lines of text formatted for Microsoft Visual Studio's output window";
-		}
+        static std::string getDescription() {
+            return "Reports test results as lines of text formatted for Microsoft Visual Studio's output window";
+        }
 
-	private:
+    private:
 
-		virtual const char* GetErrorPrefix() const {
-			return "error: ";
-		}
+        virtual const char* GetErrorPrefix() const {
+            return "error: ";
+        }
 
-		virtual const char* GetWarningPrefix() const {		
-			return "warning: ";
-		}
-	};
+        virtual const char* GetWarningPrefix() const {        
+            return "warning: ";
+        }
+    };
         
 } // end namespace Catch
 

--- a/include/reporters/catch_reporter_msvc.hpp
+++ b/include/reporters/catch_reporter_msvc.hpp
@@ -19,7 +19,7 @@ namespace Catch {
     class MsvcReporter : public BasicReporter {
 
     public:
-        MsvcReporter( const IReporterConfig& config )
+        MsvcReporter( const ReporterConfig& config )
         :    BasicReporter(config)
         {}
 

--- a/include/reporters/catch_reporter_msvc.hpp
+++ b/include/reporters/catch_reporter_msvc.hpp
@@ -1,0 +1,43 @@
+/*
+ *  Created by Phil on 28/10/2010.
+ *  Copyright 2010 Two Blue Cubes Ltd. All rights reserved.
+ *
+ *  Distributed under the Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+#ifndef TWOBLUECUBES_CATCH_REPORTER_MSVC_HPP_INCLUDED
+#define TWOBLUECUBES_CATCH_REPORTER_MSVC_HPP_INCLUDED
+
+#include "../internal/catch_capture.hpp"
+#include "../internal/catch_interfaces_reporter.h"
+#include "../internal/catch_reporter_registrars.hpp"
+#include "../internal/catch_console_colour.hpp"
+#include "catch_reporter_basic.hpp"
+
+namespace Catch {
+
+	class MsvcReporter : public BasicReporter {
+
+	public:
+		MsvcReporter( const IReporterConfig& config )
+		:	BasicReporter(config)
+		{}
+
+		static std::string getDescription() {
+			return "Reports test results as lines of text formatted for Microsoft Visual Studio's output window";
+		}
+
+	private:
+
+		virtual const char* GetErrorPrefix() const {
+			return "error: ";
+		}
+
+		virtual const char* GetWarningPrefix() const {		
+			return "warning: ";
+		}
+	};
+        
+} // end namespace Catch
+
+#endif // TWOBLUECUBES_CATCH_REPORTER_MSVC_HPP_INCLUDED

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,5 +1,5 @@
 /*
- *  Generated: 2012-07-25 23:10:58.030000
+ *  Generated: 2012-07-25 23:26:33.753000
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -287,6 +287,11 @@ namespace Catch
         std::string name;
         std::ostream& stream;
         bool includeSuccessfulResults;
+
+	private:
+		// Explicitly disable copy constructor to prevent compiler warning on MSVC 2010.
+		// warning C4512: 'class' : assignment operator could not be generated
+		ReporterConfig& operator=( const ReporterConfig& );
     };
 
     class TestCaseInfo;
@@ -4074,7 +4079,7 @@ namespace Catch {
     class MsvcReporter : public BasicReporter {
 
     public:
-        MsvcReporter( const IReporterConfig& config )
+        MsvcReporter( const ReporterConfig& config )
         :    BasicReporter(config)
         {}
 

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,5 +1,5 @@
 /*
- *  Generated: 2012-07-25 23:26:33.753000
+ *  Generated: 2012-07-26 00:07:30.124000
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -126,12 +126,12 @@ namespace Catch {
     }
 }
 
-#define CATCH_INTERNAL_ERROR( msg ) throwLogicError( msg, __FILE__, __LINE__ );
+#define CATCH_INTERNAL_ERROR( msg ) throwLogicError( msg, __FILE__, static_cast<std::size_t>(__LINE__) );
 
 //#ifdef __FUNCTION__
-//#define CATCH_INTERNAL_LINEINFO ::Catch::SourceLineInfo( __FUNCTION__, __FILE__, __LINE__ )
+//#define CATCH_INTERNAL_LINEINFO ::Catch::SourceLineInfo( __FUNCTION__, __FILE__, static_cast<std::size_t>(__LINE__) )
 //#else
-#define CATCH_INTERNAL_LINEINFO ::Catch::SourceLineInfo( __FILE__, __LINE__ )
+#define CATCH_INTERNAL_LINEINFO ::Catch::SourceLineInfo( __FILE__, static_cast<std::size_t>(__LINE__) )
 //#endif
 
 // #included from: catch_totals.hpp


### PR DESCRIPTION
The primary change here is adding a new reporter type to print errors and warnings in a format that can be parsed by Visual Studio and put into the Error List window.

This is useful because I set the test executable to be run automatically as a post-build step so the build is considered failed if any of the tests fail.  With the MSVC reporter the errors and warnings show up in the Error List window just like compiler errors and double clicking on them takes me directly to the failing test.

The MSVC reporter output is almost identical to the basic reporter so I extended that rather than copy/pasting the code.  I did have to make some changes to the basic reporter code however the output from the basic reporter should remain unchanged.
