### PR TITLE
-Wglobal-constructors should be ignored after push

### DIFF
--- a/include/catch.hpp
+++ b/include/catch.hpp
@@ -10,9 +10,8 @@
 #define TWOBLUECUBES_CATCH_HPP_INCLUDED
 
 #ifdef __clang__
-#pragma clang diagnostic ignored "-Wno-global-constructors"
-
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wglobal-constructors"
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
 


### PR DESCRIPTION
Actually it is `-Wglobal-constructors` which is supposed to be ignored, not `-Wno-global-constructors`. Moreover we should ignore it after push, otherwise we will ruin user settings.

Currently without this fix we get warning compiling on Clang:

```
../lib/catch/include/catch.hpp:14:34: warning: unknown warning group '-Wno-global-constructors',
      ignored [-Wunknown-pragmas]
#pragma clang diagnostic ignored "-Wno-global-constructors"
```
