### PR TITLE
Fix harmless but annoying MSVC warnings.

### DIFF
--- a/include/internal/catch_tags.hpp
+++ b/include/internal/catch_tags.hpp
@@ -74,6 +74,10 @@ namespace Catch {
             m_remainder += c;
         }
 
+        // Suppress assignment operator to avoid warnings from MSVC saying that
+        // it can't be implicitly synthesized.
+        TagExtracter& operator=(const TagExtracter&);
+
         std::set<std::string>& m_tags;
         std::string m_remainder;
     };
@@ -176,6 +180,10 @@ namespace Catch {
             if( !m_currentTagSet.empty() )
                 m_exp.m_tagSets.push_back( m_currentTagSet );
         }
+
+        // Suppress assignment operator to avoid warnings from MSVC saying that
+        // it can't be implicitly synthesized.
+        TagExpressionParser& operator=(const TagExpressionParser&);
 
         bool m_isNegated;
         TagSet m_currentTagSet;

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,5 +1,5 @@
 /*
- *  Generated: 2012-10-12 18:17:54.059305
+ *  Generated: 2012-10-31 19:15:51.281013
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -1755,6 +1755,10 @@ namespace Catch {
             m_remainder += c;
         }
 
+        // Suppress assignment operator to avoid warnings from MSVC saying that
+        // it can't be implicitly synthesized.
+        TagExtracter& operator=(const TagExtracter&);
+
         std::set<std::string>& m_tags;
         std::string m_remainder;
     };
@@ -1857,6 +1861,10 @@ namespace Catch {
             if( !m_currentTagSet.empty() )
                 m_exp.m_tagSets.push_back( m_currentTagSet );
         }
+
+        // Suppress assignment operator to avoid warnings from MSVC saying that
+        // it can't be implicitly synthesized.
+        TagExpressionParser& operator=(const TagExpressionParser&);
 
         bool m_isNegated;
         TagSet m_currentTagSet;


### PR DESCRIPTION
Suppress

catch.hpp(1760) : warning C4512: 'Catch::TagExtracter' : assignment operator could not be generated
catch.hpp(1864) : warning C4512: 'Catch::TagExpressionParser' : assignment operator could not be generated

warnings given by MSVC 9 (and probably other version too) compiler with /W4 switch.

The warnings are given because the compiler can't synthesize the assignment
operators for the classes with members of reference type, so simply explicitly
declare (without defining) these operators ourselves to suppress them.
