### PR TITLE
integration branch does not compile

### DIFF
--- a/include/internal/catch_expression_lhs.hpp
+++ b/include/internal/catch_expression_lhs.hpp
@@ -22,7 +22,7 @@ class ExpressionLhs {
 	void operator = ( const ExpressionLhs& );
 
 public:
-    ExpressionLhs( const T& lhs ) : m_lhs( lhs ) {}
+    ExpressionLhs( T lhs ) : m_lhs( lhs ) {}
 
     template<typename RhsT>
     ExpressionResultBuilder& operator == ( const RhsT& rhs ) {

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -938,7 +938,7 @@ class ExpressionLhs {
 	void operator = ( const ExpressionLhs& );
 
 public:
-    ExpressionLhs( const T& lhs ) : m_lhs( lhs ) {}
+    ExpressionLhs( T lhs ) : m_lhs( lhs ) {}
 
     template<typename RhsT>
     ExpressionResultBuilder& operator == ( const RhsT& rhs ) {


### PR DESCRIPTION
I wanted to try your fix for #5, but the current single include from the integration branch does not compile for me:

```
../../include/catch/catch.hpp: In instantiation of ‘Catch::ExpressionLhs<const unsigned int&>’:
../../src/tests/article.cc:15:   instantiated from here
../../include/catch/catch.hpp:942: error: forming reference to reference type ‘const unsigned int&’
../../include/catch/catch.hpp: In member function ‘Catch::ExpressionLhs<const T&> Catch::ExpressionDecomposer::operator->*(const T&) [with T = unsigned int]’:
../../src/tests/article.cc:15:   instantiated from here
../../include/catch/catch.hpp:1022: error: no matching function for call to ‘Catch::ExpressionLhs<const unsigned int&>::ExpressionLhs(const unsigned int&)’
../../include/catch/catch.hpp:938: note: candidates are: Catch::ExpressionLhs<const unsigned int&>::ExpressionLhs(const Catch::ExpressionLhs<const unsigned int&>&)
../../include/catch/catch.hpp: In member function ‘Catch::ExpressionLhs<const T&> Catch::ExpressionDecomposer::operator->*(const T&) [with T = stylist::Article::article_type]’:
../../src/tests/article.cc:16:   instantiated from here
../../include/catch/catch.hpp:1022: error: no matching function for call to ‘Catch::ExpressionLhs<const stylist::Article::article_type&>::ExpressionLhs(const stylist::Article::article_type&)’
../../include/catch/catch.hpp:938: note: candidates are: Catch::ExpressionLhs<const stylist::Article::article_type&>::ExpressionLhs(const Catch::ExpressionLhs<const stylist::Article::article_type&>&)
../../include/catch/catch.hpp: In member function ‘Catch::ExpressionLhs<const T&> Catch::ExpressionDecomposer::operator->*(const T&) [with T = int]’:
../../src/tests/article.cc:17:   instantiated from here
../../include/catch/catch.hpp:1022: error: no matching function for call to ‘Catch::ExpressionLhs<const int&>::ExpressionLhs(const int&)’
../../include/catch/catch.hpp:938: note: candidates are: Catch::ExpressionLhs<const int&>::ExpressionLhs(const Catch::ExpressionLhs<const int&>&)
../../include/catch/catch.hpp: In member function ‘Catch::ExpressionLhs<const T&> Catch::ExpressionDecomposer::operator->*(const T&) [with T = float]’:
../../src/tests/article.cc:20:   instantiated from here
../../include/catch/catch.hpp:1022: error: no matching function for call to ‘Catch::ExpressionLhs<const float&>::ExpressionLhs(const float&)’
../../include/catch/catch.hpp:938: note: candidates are: Catch::ExpressionLhs<const float&>::ExpressionLhs(const Catch::ExpressionLhs<const float&>&)
../../include/catch/catch.hpp: In member function ‘Catch::ExpressionLhs<const T&> Catch::ExpressionDecomposer::operator->*(const T&) [with T = time_t]’:
../../src/tests/article.cc:24:   instantiated from here
../../include/catch/catch.hpp:1022: error: no matching function for call to ‘Catch::ExpressionLhs<const time_t&>::ExpressionLhs(const long int&)’
../../include/catch/catch.hpp:938: note: candidates are: Catch::ExpressionLhs<const time_t&>::ExpressionLhs(const Catch::ExpressionLhs<const time_t&>&)
../../include/catch/catch.hpp: In member function ‘Catch::ExpressionLhs<const T&> Catch::ExpressionDecomposer::operator->*(const T&) [with T = size_t]’:
../../src/tests/article.cc:249:   instantiated from here
../../include/catch/catch.hpp:1022: error: no matching function for call to ‘Catch::ExpressionLhs<const size_t&>::ExpressionLhs(const long unsigned int&)’
../../include/catch/catch.hpp:938: note: candidates are: Catch::ExpressionLhs<const size_t&>::ExpressionLhs(const Catch::ExpressionLhs<const size_t&>&)
...
```
