### PR TITLE
Only add wstring versions of toString if wchar_t has been defined.

### DIFF
--- a/include/internal/catch_tostring.hpp
+++ b/include/internal/catch_tostring.hpp
@@ -73,6 +73,7 @@ inline std::string toString( const std::string& value ) {
     return "\"" + value + "\"";
 }
 
+#ifndef CATCH_CONFIG_NO_WSTRING
 inline std::string toString( const std::wstring& value ) {
     std::ostringstream oss;
     oss << "\"";
@@ -81,6 +82,7 @@ inline std::string toString( const std::wstring& value ) {
     oss << "\"";
     return oss.str();
 }
+#endif
 
 inline std::string toString( const char* const value ) {
     return value ? Catch::toString( std::string( value ) ) : std::string( "{null string}" );


### PR DESCRIPTION
When trying to use Catch in an embedded environment I noticed that std::wstring isn't availble. This patch wraps the wstring variants of toString in #ifdef on wchar_t. There most likely is a cleaner way to check this but I just couldn't figure it out :)
