### PR TITLE
Fix -Wunused-private-field warnings

### DIFF
--- a/include/internal/catch_console_colour.hpp
+++ b/include/internal/catch_console_colour.hpp
@@ -35,8 +35,10 @@ namespace Catch {
         void set( Colours colour );
         ~TextColour();
         
+#if !defined( CATCH_CONFIG_USE_ANSI_COLOUR_CODES ) && defined ( CATCH_PLATFORM_WINDOWS )
     private:
         ConsoleColourImpl* m_impl;
+#endif
     };
     
 } // end namespace Catch

--- a/include/reporters/catch_reporter_junit.hpp
+++ b/include/reporters/catch_reporter_junit.hpp
@@ -234,7 +234,6 @@ namespace Catch {
         
     private:
         ReporterConfig m_config;
-        bool m_currentTestSuccess;
         
         Stats m_testSuiteStats;
         Stats* m_currentStats;


### PR DESCRIPTION
Resolved following issues when using _Clang_ with `-Wall`:
- catch_console_colour private field `m_impl` only used on Windows when no ANSI
- catch_reporter_junit private field `m_currentTestSuccess` is not used at all

```
In file included from t.cpp:3:
In file included from ../lib/catch/include/catch.hpp:39:
In file included from ../lib/catch/include/internal/catch_impl.hpp:23:
In file included from ../lib/catch/include/internal/catch_console_colour_impl.hpp:11:
../lib/catch/include/internal/catch_console_colour.hpp:39:28: warning: private field 'm_impl' is not
      used [-Wunused-private-field]
        ConsoleColourImpl* m_impl;
                           ^
In file included from t.cpp:3:
In file included from ../lib/catch/include/catch.hpp:39:
In file included from ../lib/catch/include/internal/catch_impl.hpp:35:
../lib/catch/include/internal/../reporters/catch_reporter_junit.hpp:237:14: warning: private field
      'm_currentTestSuccess' is not used [-Wunused-private-field]
        bool m_currentTestSuccess;
```
