### PR TITLE
added basic signal handling: this allows to see how far did we go in our...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](https://raw.github.com/philsquared/Catch/Integration/catch-logo-small.png)
 
-## CATCH v0.9 build 30 (integration branch)
+## CATCH v0.9 build 31 (integration branch)
 An automated test framework for C, C++ and Objective-C.
 
 This branch may contain code that is experimental or not yet fully tested.

--- a/include/internal/catch_default_main.hpp
+++ b/include/internal/catch_default_main.hpp
@@ -10,9 +10,69 @@
 
 #ifndef __OBJC__
 
+
+#ifndef DO_NOT_USE_SIGNALS
+#include <signal.h>
+#include <iostream>
+#include <sstream>
+
+// handler for signals
+void handle_signal(int sig) {
+    std::stringstream s;
+    s << "\n\n=================\n\n";
+
+    switch (sig) {
+    case SIGINT:
+        s << "Interactive attention";
+        break;
+    case SIGILL:
+        s << "Illegal instruction";
+        break;
+    case SIGFPE:
+        s << "Floating point error";
+        break;
+    case SIGSEGV:
+        s << "Segmentation violation";
+        break;
+    case SIGTERM:
+        s << "Termination request";
+        break;
+    case SIGABRT:
+        s << "Abnormal termination (abort)";
+        break;
+    default:
+        break;
+    }
+
+    // print info about current test
+    Catch::IResultCapture& result = Catch::getCurrentContext().getResultCapture();
+    const Catch::AssertionResult* r = result.getLastResult();
+    s << "\n\nwhile executing test: \"" << result.getCurrentTestName() << "\"\n";
+    s << "\n(last successful check was: \"" << r->getExpression() << "\"\n";
+    s << " in: " << r->getSourceInfo().file << ", ";
+    s << "line: " << static_cast<int>(r->getSourceInfo().line) << ")\n\n";
+
+    std::cout << s.str();
+
+    Catch::cleanUp();
+    exit(-sig);
+}
+#endif /*!DO_NOT_USE_SIGNALS*/
+
 // Standard C/C++ main entry point
-int main (int argc, char * const argv[]) {
-    return Catch::Main( argc, argv );    
+int main(int argc, char* const argv[]) {
+#ifndef DO_NOT_USE_SIGNALS
+    signal(SIGSEGV, handle_signal);
+    signal(SIGABRT, handle_signal);
+    signal(SIGINT, handle_signal);
+    signal(SIGILL, handle_signal);
+    signal(SIGFPE, handle_signal);
+    signal(SIGSEGV, handle_signal);
+    signal(SIGTERM, handle_signal);
+    signal(SIGABRT, handle_signal);
+#endif /*!DO_NOT_USE_SIGNALS*/
+
+    return Catch::Main(argc, argv);
 }
 
 #else // __OBJC__

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -13,7 +13,7 @@
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 0, 9, 30, "integration" );
+    Version libraryVersion( 0, 9, 31, "integration" );
 }
 
 #endif // TWOBLUECUBES_CATCH_VERSION_HPP_INCLUDED

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  CATCH v0.9 build 30 (integration branch)
- *  Generated: 2013-04-01 11:26:11.785709
+ *  CATCH v0.9 build 31 (integration branch)
+ *  Generated: 2013-04-03 15:00:33.606753
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -6077,7 +6077,7 @@ namespace Catch {
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 0, 9, 30, "integration" );
+    Version libraryVersion( 0, 9, 31, "integration" );
 }
 
 // #included from: catch_line_wrap.hpp
@@ -7639,9 +7639,68 @@ namespace Catch {
 
 #ifndef __OBJC__
 
+#ifndef DO_NOT_USE_SIGNALS
+#include <signal.h>
+#include <iostream>
+#include <sstream>
+
+// handler for signals
+void handle_signal(int sig) {
+    std::stringstream s;
+    s << "\n\n=================\n\n";
+
+    switch (sig) {
+    case SIGINT:
+        s << "Interactive attention";
+        break;
+    case SIGILL:
+        s << "Illegal instruction";
+        break;
+    case SIGFPE:
+        s << "Floating point error";
+        break;
+    case SIGSEGV:
+        s << "Segmentation violation";
+        break;
+    case SIGTERM:
+        s << "Termination request";
+        break;
+    case SIGABRT:
+        s << "Abnormal termination (abort)";
+        break;
+    default:
+        break;
+    }
+
+    // print info about current test
+    Catch::IResultCapture& result = Catch::getCurrentContext().getResultCapture();
+    const Catch::AssertionResult* r = result.getLastResult();
+    s << "\n\nwhile executing test: \"" << result.getCurrentTestName() << "\"\n";
+    s << "\n(last successful check was: \"" << r->getExpression() << "\"\n";
+    s << " in: " << r->getSourceInfo().file << ", ";
+    s << "line: " << static_cast<int>(r->getSourceInfo().line) << ")\n\n";
+
+    std::cout << s.str();
+
+    Catch::cleanUp();
+    exit(-sig);
+}
+#endif /*!DO_NOT_USE_SIGNALS*/
+
 // Standard C/C++ main entry point
-int main (int argc, char * const argv[]) {
-    return Catch::Main( argc, argv );
+int main(int argc, char* const argv[]) {
+#ifndef DO_NOT_USE_SIGNALS
+    signal(SIGSEGV, handle_signal);
+    signal(SIGABRT, handle_signal);
+    signal(SIGINT, handle_signal);
+    signal(SIGILL, handle_signal);
+    signal(SIGFPE, handle_signal);
+    signal(SIGSEGV, handle_signal);
+    signal(SIGTERM, handle_signal);
+    signal(SIGABRT, handle_signal);
+#endif /*!DO_NOT_USE_SIGNALS*/
+
+    return Catch::Main(argc, argv);
 }
 
 #else // __OBJC__


### PR DESCRIPTION
... testing if, eg. the code under test hits a seg-fault.

First of all - thanks for a great test-framework! I find it very useful - both at work and when writing open-source c++ stuff.

I have seen my code hitting a segmentation fault few times, and had to add debug-code to my existing test cases to see what test was invoking the buggy code.

I created a wrapper, that was simply registering signal handler(s), and from this handler I simply printed out some info on what was the last test / check that has executed successfully, and this gives a huge hint on where to look for the fault cause. (please have a look if this is the right thing - perhaps it should be done differently?)

I thought this could be in catch, thus my pull request.

below is my example code, which reveals also a possible bug?. But this (and few other ideas) are probably for other pull requests I guess:)

Cheers,
Lukasz.

test code:

``` C++
#define CATCH_CONFIG_MAIN
#include <catch.hpp>

#define REQUIRE_NOT_NULL( expr ) REQUIRE((expr) != (void*)NULL)
#define REQUIRE_NULL( expr ) REQUIRE((expr) == (void*)NULL)

#include <string.h>

TEST_CASE("my testcase", "should pass")
{
    char* ptr1 = NULL;
    char* ptr2 = ptr1++;

    REQUIRE_NOTHROW(ptr2++);

    // these two cause seg-fault (similarly for xxNOT_NULL with ptr2):
    // (it worked with previous versions of catch, so it might be a BUG of some sort?)
    REQUIRE(ptr1 == NULL);
    REQUIRE_NULL(ptr1);


    // this one is expected to fail, obviously..
    REQUIRE_NOTHROW(ptr2[32]  = 'd');
}
```

and this gives me following info, when executing:

 ./example_test 
# 

Segmentation violation

while executing test: "my testcase"

(last successful check was: "ptr2++"
 in: example_test.cpp, line: 26)
