### PR TITLE
Fix crash on Mac OS X, accessing stdout during static initialisation.

### DIFF
--- a/include/internal/catch_console_colour_impl.hpp
+++ b/include/internal/catch_console_colour_impl.hpp
@@ -126,19 +126,22 @@ namespace Catch {
             void use( Colour::Code ) {}
         };
         NoColourImpl noColourImpl;        
-        static const bool shouldUseColour = shouldUseColourForPlatform() &&
-                                            !isDebuggerActive();
     }
 
     Colour::Colour( Code _colourCode ){ use( _colourCode ); }
     Colour::~Colour(){ use( None ); }
     void Colour::use( Code _colourCode ) {
+
+		if (impl == NULL) {
+			impl = (shouldUseColourForPlatform() && !isDebuggerActive())
+            	? static_cast<Detail::IColourImpl*>( &platformColourImpl )
+            	: static_cast<Detail::IColourImpl*>( &noColourImpl );
+		}
+
         impl->use( _colourCode );
     }
 
-    Detail::IColourImpl* Colour::impl = shouldUseColour
-            ? static_cast<Detail::IColourImpl*>( &platformColourImpl )
-            : static_cast<Detail::IColourImpl*>( &noColourImpl );
+    Detail::IColourImpl* Colour::impl = NULL;
 
 } // end namespace Catch
 


### PR DESCRIPTION
I was seeing a crash during static initialisation on Mac OS X, inside the non-Windows shouldUseColourForPlatform (which uses isatty(fileno(stdout)) to determine if stdout is a tty).

That appeared to work OK on one machine, but running the same tests on another Mac would frequently crash inside fileno at that point (my guess is that since stdout is an extern FILE\* on Mac OS X, it hasn't been initialised yet).

This patch defers creating the IColourImpl (and hence testing stdout) until we first use it.
