### PR TITLE
Define toString template before using toString calls

### DIFF
--- a/include/internal/catch_tostring.hpp
+++ b/include/internal/catch_tostring.hpp
@@ -97,6 +97,11 @@ struct StringMaker<T*> {
 };
 
 template<typename T>
+std::string toString( T const& value ) {
+    return StringMaker<T>::convert( value );
+}
+
+template<typename T>
 struct StringMaker<std::vector<T> > {
     static std::string convert( std::vector<T> const& v ) {
         std::ostringstream oss;
@@ -125,10 +130,7 @@ namespace Detail {
 /// that and writes {?}.
 /// Overload (not specialise) this template for custom typs that you don't want
 /// to provide an ostream overload for.
-template<typename T>
-std::string toString( T const& value ) {
-    return StringMaker<T>::convert( value );
-}
+
 
 // Built in overloads
 


### PR DESCRIPTION
A way to avoid (gcc 4.8.1) 

```
test/vector_tile.cpp:121:5:   required from here
test/internal/catch_tostring.hpp:105:35: error: ‘toString’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
             oss << toString( v[i] );
                                   ^
test/internal/catch_tostring.hpp:204:20: note: ‘std::string Catch::toString(unsigned char)’ declared here, later in the translation unit
 inline std::string toString( unsigned char value ) {
                    ^
```
