### PR TITLE
fix missing operator== by using a member predicate instead

### DIFF
--- a/include/internal/catch_interfaces_reporter.h
+++ b/include/internal/catch_interfaces_reporter.h
@@ -303,9 +303,14 @@ namespace Catch
             std::string stdOut;
             std::string stdErr;
         };
-        friend bool operator == ( Ptr<SectionNode> const& node, SectionInfo const& other ) {
-            return node->stats.sectionInfo.lineInfo == other.lineInfo;
-        }
+        struct BySectionInfo {
+            BySectionInfo( SectionInfo const& other ) : other( other ) {}
+            bool operator() ( Ptr<SectionNode> const& node ) const { 
+                return node->stats.sectionInfo.lineInfo == other.lineInfo;
+            }
+        private:
+            SectionInfo const& other;
+        };
 
         typedef Node<TestCaseStats, SectionNode> TestCaseNode;
         typedef Node<TestGroupStats, TestCaseNode> TestGroupNode;
@@ -333,7 +338,8 @@ namespace Catch
             else {
                 SectionNode& parentNode = *m_sectionStack.back();
                 SectionNode::ChildSections::const_iterator it =
-                    std::find( parentNode.childSections.begin(), parentNode.childSections.end(), sectionInfo );
+                    std::find_if( parentNode.childSections.begin(), parentNode.childSections.end(), 
+                                  BySectionInfo(sectionInfo) );
                 if( it == parentNode.childSections.end() ) {
                     node = new SectionNode( incompleteStats );
                     parentNode.childSections.push_back( node );


### PR DESCRIPTION
On at least one compiler (`g++ (GCC) 4.1.2 20080704 (Red Hat 4.1.2-54)`), 
including catch.hpp yields multiple 

```
no match for ‘operator==’ in ‘__first.__gnu_cxx::__normal_iterator<_Iterat
or, _Container>::operator* [with _Iterator = Catch::Ptr<Catch::CumulativeR
eporterBase::SectionNode>*, _Container = std::vector<Catch::Ptr<Catch::Cum
ulativeReporterBase::SectionNode>, std::allocator<Catch::Ptr<Catch::Cumula
tiveReporterBase::SectionNode> > >]() == __val’. 
```

This commit fixes the issue by replacing the friend comparison operator with a functor.
