### PR TITLE
std::auto_ptr is deprecated in c++11/c++0x

### DIFF
--- a/include/internal/clara.h
+++ b/include/internal/clara.h
@@ -305,6 +305,13 @@ namespace Clara {
             int position;
         };
 
+        // NOTE: std::auto_ptr is deprecated in c++11/c++0x
+#if defined(__cplusplus) && __cplusplus > 199711L
+        typedef std::unique_ptr<Arg> ArgAutoPtr;
+#else
+        typedef std::auto_ptr<Arg> ArgAutoPtr;
+#endif
+
         class ArgBinder {
         public:
             template<typename F>
@@ -329,7 +336,7 @@ namespace Clara {
                     else if( m_arg.isAnyPositional() ) {
                         if( m_cl->m_arg.get() )
                             throw std::logic_error( "Only one unpositional argument can be added" );
-                        m_cl->m_arg = std::auto_ptr<Arg>( new Arg( m_arg ) );
+                        m_cl->m_arg = ArgAutoPtr( new Arg( m_arg ) );
                     }
                     else
                         m_cl->m_options.push_back( m_arg );
@@ -373,7 +380,7 @@ namespace Clara {
             m_highestSpecifiedArgPosition( other.m_highestSpecifiedArgPosition )
         {
             if( other.m_arg.get() )
-                m_arg = std::auto_ptr<Arg>( new Arg( *other.m_arg ) );
+                m_arg = ArgAutoPtr( new Arg( *other.m_arg ) );
         }
 
         template<typename F>
@@ -543,7 +550,7 @@ namespace Clara {
         Detail::BoundArgFunction<ConfigT> m_boundProcessName;
         std::vector<Arg> m_options;
         std::map<int, Arg> m_positionalArgs;
-        std::auto_ptr<Arg> m_arg;
+        ArgAutoPtr m_arg;
         int m_highestSpecifiedArgPosition;
     };
 


### PR DESCRIPTION
This will use std::unique_ptr on C++11 and remove deprecation warning.

ICC & GCC currently show warning when using `-Wall`.
