### PR TITLE
Add documentation for the CMake build system

### DIFF
--- a/docs/build-systems.md
+++ b/docs/build-systems.md
@@ -1,0 +1,36 @@
+# Integration with build systems
+
+## CMake
+
+You can use the following CMake script to automatically fetch Catch from github and configure it as an external project:
+
+```CMake
+cmake_minimum_required(VERSION 2.8.8)
+project(catch_builder CXX)
+include(ExternalProject)
+
+ExternalProject_Add(
+    catch
+    PREFIX ${CMAKE_BINARY_DIR}/catch
+    GIT_REPOSITORY https://github.com/philsquared/Catch.git
+    TIMEOUT 10
+    UPDATE_COMMAND ${GIT_EXECUTABLE} pull
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    LOG_DOWNLOAD ON
+   )
+
+# Expose required variable (CATCH_INCLUDE_DIR) to parent scope
+ExternalProject_Get_Property(catch source_dir)
+set(CATCH_INCLUDE_DIR ${source_dir}/include CACHE INTERNAL "Path to include folder for Catch")
+```
+
+If you put it in, e.g., `${PROJECT_SRC_DIR}/${EXT_PROJECTS_DIR}/catch/`, you can use it in your project by adding the following to your root CMake file:
+
+```CMake
+# Includes Catch in the project:
+add_subdirectory(${EXT_PROJECTS_DIR}/catch)
+include_directories(${CATCH_INCLUDE_DIR} ${COMMON_INCLUDES})
+enable_testing(true)  # Enables unit-testing.
+```


### PR DESCRIPTION
- new file "docs/build-system.md" to document the integration of
  Catch with popular build systems.
- document how to configure Catch as a CMake external project.
