### PR TITLE
Fix fileno not always present. fileno(stdout) = 1.

### DIFF
--- a/include/internal/catch_console_colour_impl.hpp
+++ b/include/internal/catch_console_colour_impl.hpp
@@ -117,7 +117,7 @@ namespace {
     };
 
     inline bool shouldUseColourForPlatform() {
-        return isatty( fileno(stdout) );
+        return isatty(STDOUT_FILENO);
     }
 
     PosixColourImpl platformColourImpl;


### PR DESCRIPTION
This was a problem when compiling on Cygwin with gcc 4.8.
