### PR TITLE
Fix gcc warning empty-body

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -67,7 +67,7 @@ struct TestFailureException{};
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_ACCEPT_EXPR( evaluatedExpr, resultDisposition, originalExpr ) \
     if( Catch::ResultAction::Value internal_catch_action = Catch::getResultCapture().acceptExpression( evaluatedExpr, INTERNAL_CATCH_ASSERTIONINFO_NAME )  ) { \
-        if( internal_catch_action & Catch::ResultAction::Debug ) CATCH_BREAK_INTO_DEBUGGER(); \
+        if( internal_catch_action & Catch::ResultAction::Debug ) { CATCH_BREAK_INTO_DEBUGGER(); } \
         if( internal_catch_action & Catch::ResultAction::Abort ) throw Catch::TestFailureException(); \
         if( !Catch::shouldContinueOnFailure( resultDisposition ) ) throw Catch::TestFailureException(); \
         Catch::isTrue( false && originalExpr ); \


### PR DESCRIPTION
CATCH_BREAK_INTO_DEBUGGER() seems to eval to nothing on some systems,
causing a warning like this:

```
warning: suggest braces around empty body in an ‘if’ statement
```

(along a stack of explanations where the expansion is done)
