### PR TITLE
add user hooks to notify start and end of test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.0 build 33 (master branch)*
+*v1.0 build 34 (master branch)*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -157,8 +157,7 @@ namespace Catch {
             return m_userHooks;
         }
 
-        void addUserHook(ITestCaseHook* hook)
-        {
+        void addUserHook(ITestCaseHook* hook) {
             m_userHooks.push_back(hook);
         }
 

--- a/include/internal/catch_interfaces_config.h
+++ b/include/internal/catch_interfaces_config.h
@@ -35,8 +35,8 @@ namespace Catch {
         Never
     }; };
 
-    struct ITestCaseHook
-    {
+    struct ITestCaseHook {
+
         virtual ~ITestCaseHook() {}
 
         virtual void sectionStarting(TestCaseInfo const & testCaseInfo) = 0;

--- a/include/internal/catch_runner_impl.hpp
+++ b/include/internal/catch_runner_impl.hpp
@@ -256,8 +256,7 @@ namespace Catch {
             return action;
         }
 
-        void runTestCaseStartingHook(TestCaseInfo const& testCaseInfo)
-        {
+        void runTestCaseStartingHook(TestCaseInfo const& testCaseInfo) {
             std::vector<ITestCaseHook*> const & validations = m_config->userTestCaseHooks();
 
             for(std::vector<ITestCaseHook*>::const_iterator it = validations.begin(), end = validations.end(); it != end; ++it)
@@ -266,8 +265,7 @@ namespace Catch {
             }
         }
 
-        void runTestCaseEndingHook(TestCaseInfo const& testCaseInfo)
-        {
+        void runTestCaseEndingHook(TestCaseInfo const& testCaseInfo) {
             std::vector<ITestCaseHook*> const & validations = m_config->userTestCaseHooks();
 
             for(std::vector<ITestCaseHook*>::const_reverse_iterator it = validations.rbegin(), end = validations.rend(); it != end; ++it)

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -13,7 +13,7 @@
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 1, 0, 33, "master" );
+    Version libraryVersion( 1, 0, 34, "master" );
 }
 
 #endif // TWOBLUECUBES_CATCH_VERSION_HPP_INCLUDED

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
  *  CATCH v1.0 build 34 (master branch)
- *  Generated: 2014-03-25 14:43:34.962000
+ *  Generated: 2014-03-25 15:40:48.212000
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -1520,8 +1520,8 @@ namespace Catch {
         Never
     }; };
 
-    struct ITestCaseHook
-    {
+    struct ITestCaseHook {
+
         virtual ~ITestCaseHook() {}
 
         virtual void sectionStarting(TestCaseInfo const & testCaseInfo) = 0;
@@ -3010,8 +3010,7 @@ namespace Catch {
             return m_userHooks;
         }
 
-        void addUserHook(ITestCaseHook* hook)
-        {
+        void addUserHook(ITestCaseHook* hook) {
             m_userHooks.push_back(hook);
         }
 
@@ -5047,8 +5046,7 @@ namespace Catch {
             return action;
         }
 
-        void runTestCaseStartingHook(TestCaseInfo const& testCaseInfo)
-        {
+        void runTestCaseStartingHook(TestCaseInfo const& testCaseInfo) {
             std::vector<ITestCaseHook*> const & validations = m_config->userTestCaseHooks();
 
             for(std::vector<ITestCaseHook*>::const_iterator it = validations.begin(), end = validations.end(); it != end; ++it)
@@ -5057,8 +5055,7 @@ namespace Catch {
             }
         }
 
-        void runTestCaseEndingHook(TestCaseInfo const& testCaseInfo)
-        {
+        void runTestCaseEndingHook(TestCaseInfo const& testCaseInfo) {
             std::vector<ITestCaseHook*> const & validations = m_config->userTestCaseHooks();
 
             for(std::vector<ITestCaseHook*>::const_reverse_iterator it = validations.rbegin(), end = validations.rend(); it != end; ++it)


### PR DESCRIPTION
Hi,

We use your framework and needed to run code before starting and after ending a test case. Concretely, this allowed us to perform memory leak validation between each test. This is something we wanted globally, so fixtures would not have been suitable for us.

Hopefully, this is something you might like and accept to include in your framework.

Thank you
