### PR TITLE
Fix: CATCH_NOEXCEPT redefined warning

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -114,7 +114,7 @@
 #    define CATCH_NOEXCEPT_IS(x) noexcept(x)
 #  endif
 #endif
-#ifndef CATCH_NO_EXCEPT
+#ifndef CATCH_NOEXCEPT
 #  define CATCH_NOEXCEPT throw()
 #  define CATCH_NOEXCEPT_IS(x)
 #endif


### PR DESCRIPTION
We should check whether CATCH_NOEXCEPT was defined not CATCH_NO_EXCEPT.

This is quite severe bug, since all Clang/Mac users will see the warning.
