### PR TITLE
Use non-variadic SUCCEED() and support more compilers

### DIFF
--- a/projects/SelfTest/MiscTests.cpp
+++ b/projects/SelfTest/MiscTests.cpp
@@ -341,7 +341,7 @@ TEST_CASE("A couple of nested sections followed by a failure", "[failing][.]")
 TEST_CASE("not allowed", "[!throws]")
 {
     // This test case should not be included if you run with -e on the command line
-    SUCCEED();
+    SUCCEED("");
 }
 
 //TEST_CASE( "Is big endian" ) {


### PR DESCRIPTION
Hi Phil,

In merging Catch to Catch-VC6 I encountered usage of the variadic variant of the SUCCEED() macro.

Using the non-variadic variant would enlarge the set of compilers that can be used to test Catch(-VC6;)

For Catch-VC6 I did: MiscTests.cpp(344): s/SUCCEED()/SUCCEED("")/

cheers,
Martin
