### PR TITLE
Disable copy constructor of Session

### DIFF
--- a/include/catch_runner.hpp
+++ b/include/catch_runner.hpp
@@ -100,6 +100,10 @@ namespace Catch {
     class Session {
         static bool alreadyInstantiated;
 
+    private:
+      // Prevent copy constructor
+      Session(const Session& other);
+
     public:
 
         struct OnUnusedOptions { enum DoWhat { Ignore, Fail }; };


### PR DESCRIPTION
Since only one instance of Catch::Session can ever be used.

While trying to call session in my own function, I made a mistake of
passing session object by value. It called copy constructor and
destructor later, which called Catch::clean(). Disabling copy
constructor of session can prevent similar mistakes.
