### PR TITLE
Return non-const ref from Catch::Session::cli()

### DIFF
--- a/include/catch_runner.hpp
+++ b/include/catch_runner.hpp
@@ -184,7 +184,7 @@ namespace Catch {
             }
         }
 
-        Clara::CommandLine<ConfigData> const& cli() const {
+        Clara::CommandLine<ConfigData> & cli() {
             return m_cli;
         }
         std::vector<Clara::Parser::Token> const& unusedTokens() const {


### PR DESCRIPTION
A non-const reference to the `CommandLine` object returned from `Catch::Session::cli()` allows a custom `main` implementation to add additional options to the command line, which cannot be done with a const reference.
