### PR TITLE
Xcode/XCTest Runner Integration

### DIFF
--- a/projects/runners/XCTestRunner/XCTestRunner.mm
+++ b/projects/runners/XCTestRunner/XCTestRunner.mm
@@ -226,7 +226,7 @@ private:
                 case ResultWas::FatalErrorCondition:
                     cause = "an unexpected error occured";
                     expected = false;
-                    
+                    break;
                     
                 case ResultWas::Info:
                     cause = "info";

--- a/projects/runners/XCTestRunner/XCTestRunner.mm
+++ b/projects/runners/XCTestRunner/XCTestRunner.mm
@@ -1,0 +1,237 @@
+
+/*
+ * Copyright (c) 2014 - 2015 Landon Fuller <landon@landonf.org>
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+#include <XCTest/XCTest.h>
+#include <inttypes.h>
+#include <objc/message.h>
+
+namespace Catch {
+
+static void *TestInfoKey = NULL;
+static void *TestSelectorKey = NULL;
+static void *TestSessionKey = NULL;
+
+class XCTestRegistryHub : public RegistryHub {
+public:
+    XCTestRegistryHub (Session &session) : _session(session) {}
+    
+    /* Generates an XCTest instance that allows Xcode to find and invoke all test cases. */
+    virtual void registerTest( TestCase const& testInfo ) {
+        /* Create a standard registration via our superclass */
+        RegistryHub::registerTest(testInfo);
+        
+        /* Generate a valid class name from the description */
+        const char *description = testInfo.name.c_str();
+        NSString *clsName = normalize_identifier([NSString stringWithUTF8String: description]);
+        
+        /* If the class name is already in use, loop until we've got a unique name */
+        if (NSClassFromString(clsName) != nil) {
+            /* First, try appending 'Tests'; this handles the case where the tests have the same name as the class being tested. */
+            if (![clsName hasSuffix: @"Test"] && ![clsName hasSuffix: @"Tests"]) {
+                NSString *testClassName = [clsName stringByAppendingString: @"Tests"];
+                
+                if (NSClassFromString(testClassName) == nil) {
+                    clsName = testClassName;
+                }
+            }
+            
+            /* Otherwise, try appending a unique number to the name */
+            for (NSUInteger i = 0; i < NSUIntegerMax && NSClassFromString(clsName) != nil; i++) {
+                if (i == NSUIntegerMax) {
+                    [NSException raise: NSInternalInconsistencyException format: @"Couldn't find a unique test name for %@. You must have an impressive number of tests.", clsName];
+                    __builtin_trap();
+                }
+                
+                NSMutableString *proposedName = [NSMutableString stringWithFormat:@"%@%" PRIu64, clsName, (uint64_t) i];
+                if (NSClassFromString(proposedName) == nil) {
+                    clsName = proposedName;
+                    break;
+                }
+            }
+        }
+        
+        /* Allocate the new class */
+        Class cls = objc_allocateClassPair([XCTestCase class], [clsName UTF8String], 0);
+        if (cls == nil) {
+            [NSException raise: NSInternalInconsistencyException format: @"Could not allocate test class: %@", clsName];
+            __builtin_trap();
+        }
+        
+        /* Add XCTestCase methods */
+        { // +defaultTestSuite
+            Method m = class_getInstanceMethod([[XCTestCase class] class], @selector(defaultTestSuite));
+            class_addMethod(object_getClass(cls), @selector(defaultTestSuite), (IMP) _methodImpl_defaultTestSuite, method_getTypeEncoding(m));
+        }
+        
+        /* Add XCTest methods */
+        { // -name
+            Method m = class_getInstanceMethod([XCTestCase class], @selector(name));
+            class_addMethod(cls, @selector(name), (IMP) _methodImpl_name, method_getTypeEncoding(m));
+        }
+        
+        /* Add a test invocation method */
+        SEL testSel = register_test_selector(cls, description, _methodImpl_runTest);
+        objc_setAssociatedObject(cls, &TestSelectorKey, (__bridge id) (void *) testSel, OBJC_ASSOCIATION_ASSIGN);
+
+        /* Register the new class */
+        objc_registerClassPair(cls);
+
+        /* Attach the test info to the class */
+        TestCase *tc = new TestCase(testInfo); // Leaks if the class is deregistered (which is unlikely)
+        objc_setAssociatedObject(cls, &TestInfoKey, (__bridge id) tc, OBJC_ASSOCIATION_ASSIGN);
+        
+        objc_setAssociatedObject(cls, &TestSessionKey, (__bridge id) &_session, OBJC_ASSOCIATION_ASSIGN);
+    }
+    
+private:
+    /** Our singleton test session */
+    Session &_session;
+    
+    static XCTestSuite *_methodImpl_defaultTestSuite (Class self, SEL _cmd) {
+        TestCase const& testInfo = *(__bridge TestCase const *) objc_getAssociatedObject(self, &TestInfoKey);
+        SEL testSel = (SEL) (__bridge void *) objc_getAssociatedObject(self, &TestSelectorKey);
+        
+        XCTestCase *tc = [(XCTestCase *)[self alloc] initWithSelector: testSel];
+#if !__has_feature(objc_arc)
+        [tc autorelease];
+#endif
+
+        XCTestSuite *suite = [XCTestSuite testSuiteWithName: tc.name];
+        [suite addTest: tc];
+        return suite;
+    }
+    
+    static NSString *_methodImpl_name (Class self, SEL _cmd) {
+        TestCase const& testInfo = *(__bridge TestCase const *) objc_getAssociatedObject([self class], &TestInfoKey);
+        return [NSString stringWithUTF8String: testInfo.name.c_str()];
+    }
+    
+    static void _methodImpl_runTest (XCTestCase *self, SEL _cmd) {
+        TestCase const& testInfo = *(__bridge TestCase const *) objc_getAssociatedObject([self class], &TestInfoKey);
+        Session *session = (__bridge Session *) objc_getAssociatedObject([self class], &TestSessionKey);
+        
+        /* Reset the session's configuration */
+        session->useConfigData(ConfigData());
+        
+        /* Pass our testcase spec to the session */
+        auto testSpec = testInfo.name;
+        const char *argv0 = [[[[NSProcessInfo processInfo] arguments] objectAtIndex: 0] UTF8String];
+        const char * const args[] = { argv0, "--break" /* break on errors */, testSpec.c_str() };
+        session->applyCommandLine(sizeof(args) / sizeof(args[0]), (char * const *) args);
+        
+        /* Run */
+        if (session->run() != 0) {
+            /* TODO: Do we need our own reporter to provide more useful errors? */
+            XCTFail(@"%@ failed", self.name);
+        }
+    }
+    
+    
+    /* Given a test case description and a target class, derive a unique selector selector from the camel cased description, and register it with the target class and imp. */
+    SEL register_test_selector (Class cls, const char *description, void (*imp)(XCTestCase *self, SEL _cmd)) {
+        /* Generate a valid selector for the description */
+        NSString *selectorName = normalize_identifier([NSString stringWithUTF8String: description]);
+        
+        /* If the selector is already in use, loop until we have a unique name */
+        while (class_getInstanceMethod(cls, NSSelectorFromString(selectorName)) != NULL) {
+            for (NSUInteger i = 0; i < NSUIntegerMax; i++) {
+                if (i == NSUIntegerMax) {
+                    [NSException raise: NSInternalInconsistencyException format: @"Couldn't find a unique selector name for %s. You must have an impressive number of tests.", description];
+                    __builtin_trap();
+                }
+                
+                selectorName = [NSString stringWithFormat:@"%@%" PRIu64, selectorName, (uint64_t) i];
+                if (class_getInstanceMethod(cls, NSSelectorFromString(selectorName)) == NULL)
+                break;
+            }
+        }
+        
+        /* Register and return the SEL */
+        SEL newSel = NSSelectorFromString(selectorName);
+        
+        { // -xsmTestSection
+            NSString *typeEnc = [NSString stringWithFormat: @"%s%s%s", @encode(void), @encode(id), @encode(SEL)];
+            class_addMethod(cls, newSel, (IMP) imp, [typeEnc UTF8String]);
+        }
+        
+        return newSel;
+    }
+
+    /* Given a test case description, generate a valid Objective-C identifier. */
+    NSString *normalize_identifier (NSString *description) {
+        /* Split the description into individual components */
+        NSArray *components = [description componentsSeparatedByCharactersInSet: [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        
+        /* Camel case any elements that contain only lowercase letters (otherwise, we assume the case is already correct), and remove
+         * any invalid characters that may not occur in an Objective-C identifier. */
+        NSMutableArray *cleanedComponents = [NSMutableArray arrayWithCapacity: [components count]];
+        NSCharacterSet *allowedChars = [NSCharacterSet characterSetWithCharactersInString: @"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"];
+        for (NSUInteger i = 0; i < [components count]; i++) {
+            NSString *component = components[i];
+            NSString *newComponent = [[component componentsSeparatedByCharactersInSet: [allowedChars invertedSet]] componentsJoinedByString: @""];
+            
+            /* If the string is entirely lowercase, apply camel casing */
+            if ([[newComponent lowercaseString] isEqualToString: newComponent]) {
+                newComponent = [newComponent capitalizedString];
+            }
+            
+            /* Add to the result array. */
+            [cleanedComponents addObject: newComponent];
+        }
+        
+        /* Generate the identifier, stripping any leading numbers */
+        NSString *identifier = [cleanedComponents componentsJoinedByString: @""];
+        {
+            NSRange range = [identifier rangeOfCharacterFromSet: [NSCharacterSet decimalDigitCharacterSet]];
+            if (range.location == 0)
+            identifier = [identifier substringFromIndex: range.length];
+        }
+        
+        return identifier;
+    }
+};
+    
+}
+
+@interface XCTestCaseCatchRegistry : NSObject @end
+@implementation XCTestCaseCatchRegistry
+
+/* Runs before all C++ initializers; we can insert our custom registry hub here. */
++ (void) load {
+    using namespace Catch;
+    static Session session;
+    
+    RegistryHub **hub = &getTheRegistryHub();
+    RegistryHub *previous = *hub;
+    *hub = new XCTestRegistryHub(session);
+    delete previous;
+}
+
+@end

--- a/projects/runners/XCTestRunner/XCTestRunner.xcodeproj/project.pbxproj
+++ b/projects/runners/XCTestRunner/XCTestRunner.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0576DBA71B448C30000BCA73 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0576DBA61B448C30000BCA73 /* main.cpp */; };
 		0576DBB61B448C57000BCA73 /* XCTestRunnerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0576DBB51B448C57000BCA73 /* XCTestRunnerTests.mm */; };
 		0576DBBB1B448C87000BCA73 /* XCTestRunner.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0576DBBA1B448C87000BCA73 /* XCTestRunner.mm */; };
+		05D0AE281B45C22700296632 /* XCTestRunnerSecondTUTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 05D0AE271B45C22700296632 /* XCTestRunnerSecondTUTests.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -31,6 +32,7 @@
 		0576DBB41B448C57000BCA73 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0576DBB51B448C57000BCA73 /* XCTestRunnerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = XCTestRunnerTests.mm; sourceTree = "<group>"; };
 		0576DBBA1B448C87000BCA73 /* XCTestRunner.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = XCTestRunner.mm; sourceTree = "<group>"; };
+		05D0AE271B45C22700296632 /* XCTestRunnerSecondTUTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = XCTestRunnerSecondTUTests.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +84,7 @@
 			isa = PBXGroup;
 			children = (
 				0576DBB51B448C57000BCA73 /* XCTestRunnerTests.mm */,
+				05D0AE271B45C22700296632 /* XCTestRunnerSecondTUTests.mm */,
 				0576DBB31B448C57000BCA73 /* Supporting Files */,
 			);
 			path = XCTestRunnerTests;
@@ -192,6 +195,7 @@
 			files = (
 				0576DBBB1B448C87000BCA73 /* XCTestRunner.mm in Sources */,
 				0576DBB61B448C57000BCA73 /* XCTestRunnerTests.mm in Sources */,
+				05D0AE281B45C22700296632 /* XCTestRunnerSecondTUTests.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -345,6 +349,7 @@
 				0576DBAC1B448C30000BCA73 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		0576DBB71B448C57000BCA73 /* Build configuration list for PBXNativeTarget "XCTestRunnerTests" */ = {
 			isa = XCConfigurationList;
@@ -353,6 +358,7 @@
 				0576DBB91B448C57000BCA73 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/projects/runners/XCTestRunner/XCTestRunner.xcodeproj/project.pbxproj
+++ b/projects/runners/XCTestRunner/XCTestRunner.xcodeproj/project.pbxproj
@@ -1,0 +1,360 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0576DBA71B448C30000BCA73 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0576DBA61B448C30000BCA73 /* main.cpp */; };
+		0576DBB61B448C57000BCA73 /* XCTestRunnerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0576DBB51B448C57000BCA73 /* XCTestRunnerTests.mm */; };
+		0576DBBB1B448C87000BCA73 /* XCTestRunner.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0576DBBA1B448C87000BCA73 /* XCTestRunner.mm */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		0576DBA11B448C30000BCA73 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		0576DBA31B448C30000BCA73 /* XCTestRunner */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = XCTestRunner; sourceTree = BUILT_PRODUCTS_DIR; };
+		0576DBA61B448C30000BCA73 /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
+		0576DBB11B448C57000BCA73 /* XCTestRunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XCTestRunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0576DBB41B448C57000BCA73 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0576DBB51B448C57000BCA73 /* XCTestRunnerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = XCTestRunnerTests.mm; sourceTree = "<group>"; };
+		0576DBBA1B448C87000BCA73 /* XCTestRunner.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = XCTestRunner.mm; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0576DBA01B448C30000BCA73 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0576DBAE1B448C57000BCA73 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0576DB9A1B448C30000BCA73 = {
+			isa = PBXGroup;
+			children = (
+				0576DBBA1B448C87000BCA73 /* XCTestRunner.mm */,
+				0576DBA51B448C30000BCA73 /* XCTestRunner */,
+				0576DBB21B448C57000BCA73 /* XCTestRunnerTests */,
+				0576DBA41B448C30000BCA73 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		0576DBA41B448C30000BCA73 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0576DBA31B448C30000BCA73 /* XCTestRunner */,
+				0576DBB11B448C57000BCA73 /* XCTestRunnerTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0576DBA51B448C30000BCA73 /* XCTestRunner */ = {
+			isa = PBXGroup;
+			children = (
+				0576DBA61B448C30000BCA73 /* main.cpp */,
+			);
+			path = XCTestRunner;
+			sourceTree = "<group>";
+		};
+		0576DBB21B448C57000BCA73 /* XCTestRunnerTests */ = {
+			isa = PBXGroup;
+			children = (
+				0576DBB51B448C57000BCA73 /* XCTestRunnerTests.mm */,
+				0576DBB31B448C57000BCA73 /* Supporting Files */,
+			);
+			path = XCTestRunnerTests;
+			sourceTree = "<group>";
+		};
+		0576DBB31B448C57000BCA73 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				0576DBB41B448C57000BCA73 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0576DBA21B448C30000BCA73 /* XCTestRunner */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0576DBAA1B448C30000BCA73 /* Build configuration list for PBXNativeTarget "XCTestRunner" */;
+			buildPhases = (
+				0576DB9F1B448C30000BCA73 /* Sources */,
+				0576DBA01B448C30000BCA73 /* Frameworks */,
+				0576DBA11B448C30000BCA73 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = XCTestRunner;
+			productName = XCTestRunner;
+			productReference = 0576DBA31B448C30000BCA73 /* XCTestRunner */;
+			productType = "com.apple.product-type.tool";
+		};
+		0576DBB01B448C57000BCA73 /* XCTestRunnerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0576DBB71B448C57000BCA73 /* Build configuration list for PBXNativeTarget "XCTestRunnerTests" */;
+			buildPhases = (
+				0576DBAD1B448C57000BCA73 /* Sources */,
+				0576DBAE1B448C57000BCA73 /* Frameworks */,
+				0576DBAF1B448C57000BCA73 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = XCTestRunnerTests;
+			productName = XCTestRunnerTests;
+			productReference = 0576DBB11B448C57000BCA73 /* XCTestRunnerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0576DB9B1B448C30000BCA73 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0620;
+				ORGANIZATIONNAME = "Plausible Labs Cooperative, Inc.";
+				TargetAttributes = {
+					0576DBA21B448C30000BCA73 = {
+						CreatedOnToolsVersion = 6.2;
+					};
+					0576DBB01B448C57000BCA73 = {
+						CreatedOnToolsVersion = 6.2;
+					};
+				};
+			};
+			buildConfigurationList = 0576DB9E1B448C30000BCA73 /* Build configuration list for PBXProject "XCTestRunner" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 0576DB9A1B448C30000BCA73;
+			productRefGroup = 0576DBA41B448C30000BCA73 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0576DBA21B448C30000BCA73 /* XCTestRunner */,
+				0576DBB01B448C57000BCA73 /* XCTestRunnerTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0576DBAF1B448C57000BCA73 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0576DB9F1B448C30000BCA73 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0576DBA71B448C30000BCA73 /* main.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0576DBAD1B448C57000BCA73 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0576DBBB1B448C87000BCA73 /* XCTestRunner.mm in Sources */,
+				0576DBB61B448C57000BCA73 /* XCTestRunnerTests.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		0576DBA81B448C30000BCA73 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					../../../include,
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		0576DBA91B448C30000BCA73 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					../../../include,
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		0576DBAB1B448C30000BCA73 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		0576DBAC1B448C30000BCA73 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		0576DBB81B448C57000BCA73 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = XCTestRunnerTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		0576DBB91B448C57000BCA73 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = XCTestRunnerTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0576DB9E1B448C30000BCA73 /* Build configuration list for PBXProject "XCTestRunner" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0576DBA81B448C30000BCA73 /* Debug */,
+				0576DBA91B448C30000BCA73 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0576DBAA1B448C30000BCA73 /* Build configuration list for PBXNativeTarget "XCTestRunner" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0576DBAB1B448C30000BCA73 /* Debug */,
+				0576DBAC1B448C30000BCA73 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		0576DBB71B448C57000BCA73 /* Build configuration list for PBXNativeTarget "XCTestRunnerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0576DBB81B448C57000BCA73 /* Debug */,
+				0576DBB91B448C57000BCA73 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0576DB9B1B448C30000BCA73 /* Project object */;
+}

--- a/projects/runners/XCTestRunner/XCTestRunner/main.cpp
+++ b/projects/runners/XCTestRunner/XCTestRunner/main.cpp
@@ -1,0 +1,15 @@
+//
+//  main.cpp
+//  XCTestRunner
+//
+//  Created by Landon Fuller on 7/1/15.
+//  Copyright (c) 2015 Plausible Labs Cooperative, Inc. All rights reserved.
+//
+
+#include <iostream>
+
+int main(int argc, const char * argv[]) {
+    // insert code here...
+    std::cout << "Hello, World!\n";
+    return 0;
+}

--- a/projects/runners/XCTestRunner/XCTestRunnerTests/Info.plist
+++ b/projects/runners/XCTestRunner/XCTestRunnerTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>twobluecubes.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/projects/runners/XCTestRunner/XCTestRunnerTests/XCTestRunnerSecondTUTests.mm
+++ b/projects/runners/XCTestRunner/XCTestRunnerTests/XCTestRunnerSecondTUTests.mm
@@ -27,10 +27,10 @@
 
 #include "catch.hpp"
 
-TEST_CASE("Objective-C Matchers") {
-    WHEN("comparing two equal strings") {
-        THEN("matching should succeed") {
-            REQUIRE_THAT(@"string1", Equals(@"intentionally fail"));
+TEST_CASE("A Second Test Case") {
+    WHEN("running in a second translation unit") {
+        THEN("the tests should be executed") {
+            REQUIRE(1 == 47);
         }
     }
 }

--- a/projects/runners/XCTestRunner/XCTestRunnerTests/XCTestRunnerTests.mm
+++ b/projects/runners/XCTestRunner/XCTestRunnerTests/XCTestRunnerTests.mm
@@ -1,0 +1,41 @@
+
+/*
+ * Copyright (c) 2014 - 2015 Landon Fuller <landon@landonf.org>
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "catch.hpp"
+
+TEST_CASE("TEST_CASE Registration") {
+    REQUIRE(true != false);
+}
+
+
+TEST_CASE("Another Test") {
+    REQUIRE(true != true);
+}
+
+TEST_CASE("A Third Test") {
+    REQUIRE(true == true);
+}


### PR DESCRIPTION
This patch adds support for XCTest integration by inverting the usual Catch behavior; rather than using Catch as the test runner, we dynamically register XCTestCase classes with the Objective-C runtime to allow Xcode's test runner to execute (and report on) Catch-defined test cases.

To use this implementation, a project need only include "XCTestRunner.mm" in their unit test build -- the `+[XCTestCaseCatchRegistry load]` method will insert an XCTestRegistryHub instance that automatically registers XCTestCase classes for any Catch test cases defined within the image.

`+load` methods by definition will run prior to C++ static initializers in the same image, ensuring that we insert our registry prior to any TestCase instances registering themselves.

Currently, our granularity is limited to test cases -- we can't report on section execution without first registering the section as a test instance in the XCTestCase, and this would require static access to the list of sections/subsections defined within a TestCase or Section.

This approach is based on the XCTest registration code I wrote for XSmallTest: https://github.com/landonf/XSmallTest
