### PR TITLE
ApproxContainer for approximate comparison of stl containers.

### DIFF
--- a/include/catch.hpp
+++ b/include/catch.hpp
@@ -36,6 +36,7 @@
 #include "internal/catch_generators.hpp"
 #include "internal/catch_interfaces_exception.h"
 #include "internal/catch_approx.hpp"
+#include "internal/catch_approx_container.hpp"
 #include "internal/catch_matchers.hpp"
 #include "internal/catch_compiler_capabilities.h"
 #include "internal/catch_interfaces_tag_alias_registry.h"
@@ -207,6 +208,7 @@
 #define AND_THEN( desc ) SECTION( std::string("     And: ") + desc, "" )
 
 using Catch::Detail::Approx;
+using Catch::Detail::ApproxContainer;
 
 #include "internal/catch_reenable_warnings.h"
 

--- a/include/internal/catch_approx.hpp
+++ b/include/internal/catch_approx.hpp
@@ -43,7 +43,7 @@ namespace Detail {
 
         friend bool operator == ( double lhs, Approx const& rhs ) {
             // Thanks to Richard Harris for his help refining this formula
-            return fabs( lhs - rhs.m_value ) < rhs.m_epsilon * (rhs.m_scale + (std::max)( fabs(lhs), fabs(rhs.m_value) ) );
+            return rhs.compare(rhs.m_value, lhs);
         }
 
         friend bool operator == ( Approx const& lhs, double rhs ) {
@@ -74,9 +74,15 @@ namespace Detail {
             return oss.str();
         }
 
-    private:
+    protected:
+        bool compare ( double lhs, double rhs ) const {
+            return fabs( rhs - lhs ) < m_epsilon * (m_scale + (std::max)( fabs(rhs), fabs(lhs) ) );
+        }
+
         double m_epsilon;
         double m_scale;
+
+    private:
         double m_value;
     };
 }

--- a/include/internal/catch_approx.hpp
+++ b/include/internal/catch_approx.hpp
@@ -42,7 +42,6 @@ namespace Detail {
         }
 
         friend bool operator == ( double lhs, Approx const& rhs ) {
-            // Thanks to Richard Harris for his help refining this formula
             return rhs.compare(rhs.m_value, lhs);
         }
 
@@ -76,6 +75,7 @@ namespace Detail {
 
     protected:
         bool compare ( double lhs, double rhs ) const {
+            // Thanks to Richard Harris for his help refining this formula
             return fabs( rhs - lhs ) < m_epsilon * (m_scale + (std::max)( fabs(rhs), fabs(lhs) ) );
         }
 

--- a/include/internal/catch_approx_container.hpp
+++ b/include/internal/catch_approx_container.hpp
@@ -1,0 +1,98 @@
+/*
+ *  Created by Phil on 28/04/2011.
+ *  Copyright 2010 Two Blue Cubes Ltd. All rights reserved.
+ *
+ *  Distributed under the Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+#ifndef TWOBLUECUBES_CATCH_APPROX_CONTAINER_HPP_INCLUDED
+#define TWOBLUECUBES_CATCH_APPROX_CONTAINER_HPP_INCLUDED
+
+#include "catch_approx.hpp"
+
+namespace Catch {
+namespace Detail {
+
+    template<template <typename T, typename Alloc = std::allocator<T> > class Container = std::vector>
+    class ApproxContainer : public Approx {
+        typedef ApproxContainer<Container> my_t;
+    public:
+
+        template<typename T>
+        ApproxContainer (const Container<T> & c)
+        :   Approx( 0. ),
+            m_values( c.begin(), c.end() )
+        {}
+
+        ApproxContainer( ApproxContainer const& other )
+        :   Approx(other),
+            m_values( other.m_values )
+        {}
+
+        static ApproxContainer custom() {
+            return ApproxContainer( Container<double>() );
+        }
+
+        template<typename T>
+        ApproxContainer operator()(const Container<T> & c) {
+            ApproxContainer approx( c );
+            approx.epsilon( m_epsilon );
+            approx.scale( m_scale );
+            return approx;
+        }
+
+        template<typename T>
+        friend bool operator == ( const Container<T> & lhs, my_t const& rhs ) {
+            bool success = rhs.m_values.size() == lhs.size();
+            typename Container<T>::const_iterator lhs_it = lhs.begin();
+            typename Container<double>::const_iterator values_it = rhs.m_values.begin();
+            for (; lhs_it != lhs.end() && success; ++lhs_it, ++values_it) {
+                success &= rhs.compare(*lhs_it, *values_it);
+            }
+            return success;
+        }
+
+        template<typename T>
+        friend bool operator == ( my_t const& lhs, Container<T> rhs ) {
+            return operator==( rhs, lhs );
+        }
+
+        template<typename T>
+        friend bool operator != ( Container<T> lhs, my_t const& rhs ) {
+            return !operator==( lhs, rhs );
+        }
+
+        template<typename T>
+        friend bool operator != ( my_t const& lhs, std::vector<T> rhs ) {
+            return !operator==( rhs, lhs );
+        }
+
+        std::string toString() const {
+            std::ostringstream oss;
+            oss << "Approx( " << Catch::toString( m_values) << " )";
+            return oss.str();
+        }
+
+        my_t& epsilon( double newEpsilon ) {
+            m_epsilon = newEpsilon;
+            return *this;
+        }
+
+        my_t& scale( double newScale ) {
+            m_scale = newScale;
+            return *this;
+        }
+
+    protected:
+        Container<double> m_values;
+    };
+
+    template<template <typename T, typename Alloc> class Container>
+    std::ostream& operator<<(std::ostream& os, const ApproxContainer<Container>& rhs) {
+        return os << rhs.toString();
+    }
+}
+
+} // end namespace Catch
+
+#endif // TWOBLUECUBES_CATCH_APPROX_CONTAINER_HPP_INCLUDED


### PR DESCRIPTION
This pull request adds the `ApproxContainer<ContainerType>` class for approximate comparison of values in stl containers. The default container is `std::vector`, but it should work for most stl containers (uses iterators).

I couldn't partially specialize the global `toString` function (since this is templated on container type), so I overloaded the `std::ostream` operator instead.

I haven't updated the single include or added to the documentation yet. If you like the look of it, I can do both before it's merged. I know I'm pull requesting into master, but it is a quick patch to `v1.*` and it seems more appropriate there than `v2.*`. I can move the pull request if you disagree.

E.g.,

```
std::vector<double> a {1., 2., 3.};
std::vector<double> b {1.01, 2.05, 2.99};
CHECK(a == ApproxContainer<>(b).epsilon(0.01));
REQUIRE(a == ApproxContainer<>(b).epsilon(0.1));
```

Output for the failed `CHECK`:

```
  CHECK( a == ApproxContainer<>(b).epsilon(0.01) )
with expansion:
  { 1.0, 2.0, 3.0 }
  ==
  Approx( { 1.01, 2.05, 2.99 } )
```
