### PR TITLE
Node.js support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This documentation comprises these three parts:
 * [Why do we need yet another C++ Test Framework?](docs/why-catch.md)
 * [Tutorial](docs/tutorial.md) - getting started
 * [Reference section](docs/Readme.md) - all the details
+* [Node.js/npm support](docs/nodejs-npm.md) - how to use with Node.js, node-gyp, and npm
 
 ## More
 * Issues and bugs can be raised on the [Issue tracker on GitHub](https://github.com/philsquared/Catch/issues)

--- a/docs/nodejs-npm.md
+++ b/docs/nodejs-npm.md
@@ -1,0 +1,60 @@
+# Catch on npm
+
+This document describes how use to Catch with [node-gyp](https://github.com/nodejs/node-gyp) for [Node.js](https://github.com/nodejs/node) applications. Thanks to @philsquared and Catch contributors for the library, and @smikes for the foundation of the npm/node-gyp stuff!
+
+# Using catch via npm
+
+A `package.json` is provided for installation with [npm](https://github.com/npm/npm). NB: as of this writing (2016-09-21) the `catch` npm package refers to @smikes's original work which uses an older version of Catch. You can use `@bchociej/catch` for this version.
+
+
+# Settings in binding.gyp
+
+`include_dirs` should reference the Catch include directory:
+
+    "include_dirs": [
+    	"<!(node -e \"require('catch')\")"
+    ]
+
+Catch requires exceptions, so add these two lines to your target (for Unixy systems):
+
+    "cflags!":    ["-fno-exceptions"],
+    "cflags_cc!": ["-fno-exceptions"]
+
+Caveat developer: I'm not 100% sure how to do the same on Windows or Mac. These are my estimations based on node's `common.gypi` file. You may need to alter them to fit your needs.
+
+    # Windows
+    "defines!": ["_HAS_EXCEPTIONS=0"]
+
+    # Mac
+	"xcode_settings": {"GCC_ENABLE_CPP_EXCEPTIONS": "YES"}
+
+# Build the test executable on its own
+
+You can build a standalone test executable with a separate node-gyp target, e.g.:
+
+    {
+    	"target_name": "test_executable_name",
+    	"type":        "executable",
+    	"cflags!":     ["-fno-exceptions"], # for Unixes; others see above
+    	"cflags_cc!":  ["-fno-exceptions"], # for Unixes; others see above
+    	"sources": [
+    		"test/testfile.cc",
+    		"test/testfile2.cc",
+    		"src/source.cc",
+    		"src/source2.cc",
+    		(etc),
+    	],
+    	"include_dirs": [
+    		"<!(node -e \"require('catch')\")"
+    	]
+    }
+
+The test executable will end up at `build/Release/test_executable_name` or `build/Debug/test_executable_name` or so.
+
+# Using Catch
+
+     #define CATCH_CONFIG_MAIN
+     #include "catch/single_include/catch.hpp"
+
+Follow the [tutorial](https://github.com/philsquared/Catch/blob/master/docs/tutorial.md) for more
+details.

--- a/include_dirs.js
+++ b/include_dirs.js
@@ -1,0 +1,2 @@
+var path = require('path');
+console.log(path.join(path.relative('.', __dirname),'include'));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@bchociej/catch",
+  "version": "1.5.6-npm.4",
+  "description": "catch C++ unit test framework",
+  "main": "include_dirs.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bchociej/Catch.git"
+  },
+  "author": "philsquared",
+  "contributors": [
+     "sam mikes",
+     "Ben Chociej <ben@chociej.io>"
+  ],
+  "license": "Boost",
+  "bugs": {
+    "url": "https://github.com/bchociej/Catch/issues"
+  },
+  "homepage": "https://github.com/bchociej/Catch"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bchociej/catch",
-  "version": "1.5.6-npm.4",
+  "version": "1.5.6-npm.5",
   "description": "catch C++ unit test framework",
   "main": "include_dirs.js",
   "directories": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/bchociej/Catch.git"
+    "url": "https://github.com/philsquared/Catch.git"
   },
   "author": "philsquared",
   "contributors": [
@@ -17,7 +17,7 @@
   ],
   "license": "Boost",
   "bugs": {
-    "url": "https://github.com/bchociej/Catch/issues"
+    "url": "https://github.com/philsquared/Catch/issues"
   },
-  "homepage": "https://github.com/bchociej/Catch"
+  "homepage": "https://github.com/philsquared/Catch"
 }


### PR DESCRIPTION
I propose to add (very lightweight) support for Node.js applications. This work is based on [smikes/Catch](https://github.com/smikes/Catch), where much of the legwork was already done, but some updates were required for newer versions of Catch.

This patch accomplishes Node.js support via:
- `package.json`, a configuration file for [npm](https://github.com/npm/npm), the package manager for Node.js applications
- `include_dirs.js`, a tiny script to help the Node.js build system, [node-gyp](https://github.com/nodejs/node-gyp), locate the necessary C++ include directory
- relevant documentation

I would be happy to maintain these bits going forward, along with @smikes or anyone else who is interested.

This PR is for master; a develop-v2 patch has also been prepared and differs only in npm metadata. I'll happily throw that PR up if these changes are deemed acceptable.

A note about publishing packages to the central npm repository. @smikes has already done great work publishing his older version of Catch to the npm repository and therefore owns the npm package name `catch`. My version is currently published as a "namespaced" package, `@bchociej/catch`. Should this PR land, I hope to be able to work with @smikes to update the main npm package.

Many thanks to all the Catch contributors and especially @smikes for the inspiration and existing work!
