### PR TITLE
Improved support for Oracle Solaris Studio 12.1 toolchain

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -120,6 +120,16 @@
 #endif // _MSC_VER
 
 ////////////////////////////////////////////////////////////////////////////////
+// Oracle Solaris Studio
+#ifdef __SUNPRO_CC
+
+#   if __SUNPRO_CC == 0x5100  // Oracle Solaris Studio version 12.1
+#       define CATCH_INTERNAL_SUNPRO_CC_NON_COMPLIANT_STL
+#   endif
+
+#endif // __SUNPRO_CC
+
+////////////////////////////////////////////////////////////////////////////////
 
 // Use variadic macros if the compiler supports them
 #if ( defined _MSC_VER && _MSC_VER > 1400 && !defined __EDGE__) || \

--- a/include/internal/catch_run_context.hpp
+++ b/include/internal/catch_run_context.hpp
@@ -327,8 +327,9 @@ namespace Catch {
         void handleUnfinishedSections() {
             // If sections ended prematurely due to an exception we stored their
             // infos here so we can tear them down outside the unwind process.
-            for( std::vector<SectionEndInfo>::const_reverse_iterator it = m_unfinishedSections.rbegin(),
-                        itEnd = m_unfinishedSections.rend();
+            std::vector<SectionEndInfo> const& constUnfinishedSections = m_unfinishedSections;
+            for( std::vector<SectionEndInfo>::const_reverse_iterator it = constUnfinishedSections.rbegin(),
+                        itEnd = constUnfinishedSections.rend();
                     it != itEnd;
                     ++it )
                 sectionEnded( *it );

--- a/include/internal/catch_tag_alias_registry.hpp
+++ b/include/internal/catch_tag_alias_registry.hpp
@@ -48,7 +48,7 @@ namespace Catch {
             oss << "error: tag alias, \"" << alias << "\" is not of the form [@alias name].\n" << lineInfo;
             throw std::domain_error( oss.str().c_str() );
         }
-        if( !m_registry.insert( std::make_pair( alias, TagAlias( tag, lineInfo ) ) ).second ) {
+        if( !m_registry.insert( std::make_pair( std::string(alias), TagAlias( tag, lineInfo ) ) ).second ) {
             std::ostringstream oss;
             oss << "error: tag alias, \"" << alias << "\" already registered.\n"
                 << "\tFirst seen at " << find(alias)->lineInfo << "\n"

--- a/include/reporters/catch_reporter_compact.hpp
+++ b/include/reporters/catch_reporter_compact.hpp
@@ -218,7 +218,12 @@ namespace Catch {
 
                 // using messages.end() directly yields compilation error:
                 std::vector<MessageInfo>::const_iterator itEnd = messages.end();
+#               ifdef CATCH_INTERNAL_SUNPRO_CC_NON_COMPLIANT_STL
+                std::size_t N;
+                std::distance( itMessage, itEnd, N );
+#               else
                 const std::size_t N = static_cast<std::size_t>( std::distance( itMessage, itEnd ) );
+#               endif // CATCH_INTERNAL_SUNPRO_CC_NON_COMPLIANT_STL
 
                 {
                     Colour colourGuard( colour );


### PR DESCRIPTION
Catch doesn't currently build with Oracle Solaris Studio 12.1 but the changes required to make it build are minor.  Three changes in total, two are trivial, one, sadly, is a little ugly due to the platforms non-compliant STL implementation for std::distance.

These issues probably affect other versions of the toolchain but i'm unable to verify so have tried constrain the "non-compliant STL" change just to this compiler.
