### PR TITLE
Print out full section stacks on failure.

### DIFF
--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -43,10 +43,14 @@ namespace Catch {
         }
         virtual void sectionStarting( SectionInfo const& _sectionInfo ) CATCH_OVERRIDE {
             m_sectionStack.push_back( _sectionInfo );
+            m_deepestSectionStack.push_back( _sectionInfo );
         }
 
         virtual void sectionEnded( SectionStats const& /* _sectionStats */ ) CATCH_OVERRIDE {
             m_sectionStack.pop_back();
+            if (m_sectionStack.empty()) {
+                m_deepestSectionStack.clear();
+            }
         }
         virtual void testCaseEnded( TestCaseStats const& /* _testCaseStats */ ) CATCH_OVERRIDE {
             currentTestCaseInfo.reset();
@@ -73,6 +77,7 @@ namespace Catch {
         LazyStat<TestCaseInfo> currentTestCaseInfo;
 
         std::vector<SectionInfo> m_sectionStack;
+        std::vector<SectionInfo> m_deepestSectionStack;
         ReporterPreferences m_reporterPrefs;
     };
 
@@ -168,7 +173,7 @@ namespace Catch {
 
         virtual bool assertionEnded( AssertionStats const& assertionStats ) CATCH_OVERRIDE {
             assert( !m_sectionStack.empty() );
-            SectionNode& sectionNode = *m_sectionStack.back();
+            SectionNode& sectionNode = *m_deepestSection;
             sectionNode.assertions.push_back( assertionStats );
             return true;
         }

--- a/include/reporters/catch_reporter_console.hpp
+++ b/include/reporters/catch_reporter_console.hpp
@@ -271,20 +271,20 @@ namespace Catch {
             }
         }
         void printTestCaseAndSectionHeader() {
-            assert( !m_sectionStack.empty() );
+            assert( !m_deepestSectionStack.empty() );
             printOpenHeader( currentTestCaseInfo->name );
 
-            if( m_sectionStack.size() > 1 ) {
+            if( m_deepestSectionStack.size() > 1 ) {
                 Colour colourGuard( Colour::Headers );
 
                 std::vector<SectionInfo>::const_iterator
-                    it = m_sectionStack.begin()+1, // Skip first section (test case)
-                    itEnd = m_sectionStack.end();
+                    it = m_deepestSectionStack.begin()+1, // Skip first section (test case)
+                    itEnd = m_deepestSectionStack.end();
                 for( ; it != itEnd; ++it )
                     printHeaderString( it->name, 2 );
             }
 
-            SourceLineInfo lineInfo = m_sectionStack.front().lineInfo;
+            SourceLineInfo lineInfo = m_deepestSectionStack.front().lineInfo;
 
             if( !lineInfo.empty() ){
                 stream << getLineOfChars<'-'>() << "\n";

--- a/include/reporters/catch_reporter_teamcity.hpp
+++ b/include/reporters/catch_reporter_teamcity.hpp
@@ -169,20 +169,20 @@ namespace Catch {
 
     private:
         void printSectionHeader( std::ostream& os ) {
-            assert( !m_sectionStack.empty() );
+            assert( !m_deepestSectionStack.empty() );
 
-            if( m_sectionStack.size() > 1 ) {
+            if( m_deepestSectionStack.size() > 1 ) {
                 os << getLineOfChars<'-'>() << "\n";
 
                 std::vector<SectionInfo>::const_iterator
-                it = m_sectionStack.begin()+1, // Skip first section (test case)
-                itEnd = m_sectionStack.end();
+                it = m_deepestSectionStack.begin()+1, // Skip first section (test case)
+                itEnd = m_deepestSectionStack.end();
                 for( ; it != itEnd; ++it )
                     printHeaderString( os, it->name );
                 os << getLineOfChars<'-'>() << "\n";
             }
 
-            SourceLineInfo lineInfo = m_sectionStack.front().lineInfo;
+            SourceLineInfo lineInfo = m_deepestSectionStack.front().lineInfo;
 
             if( !lineInfo.empty() )
                 os << lineInfo << "\n";


### PR DESCRIPTION
The Console reporter now "traces" the full section stack of its
current test execution and prints it out instead of the section
stack of the failing assertion itself. Likewise, the JUnit reporter
now groups assertions together into the testcase element of the test
execution where they happened.

This fixes #734 and allows post-condition tests after the deepest
SECTION in a test execution.
