### PR TITLE
Make INFO() use the same output customization as CHECK()

### DIFF
--- a/include/internal/catch_message.h
+++ b/include/internal/catch_message.h
@@ -11,6 +11,7 @@
 #include <string>
 #include "catch_result_type.h"
 #include "catch_common.h"
+#include "catch_tostring.h"
 
 namespace Catch {
 
@@ -44,7 +45,7 @@ namespace Catch {
 
         template<typename T>
         MessageBuilder& operator << ( T const& value ) {
-            m_stream << value;
+            m_stream << toString(value);
             return *this;
         }
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.
-->


## Description

This changes MessageBuilder so that `INFO(x << y)` has output similar to `CHECK(x == y)`. I'm not sure if this was an intentional omission, but since I make heavy use of `StringMaker`, I'm really happy with this change :)