### PR TITLE
Fix catch exception by reference

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -136,7 +136,7 @@
                 static_cast<void>(expr); \
                 __catchResult.captureResult( Catch::ResultWas::DidntThrowException ); \
             } \
-            catch( exceptionType ) { \
+            catch( exceptionType& ) { \
                 __catchResult.captureResult( Catch::ResultWas::Ok ); \
             } \
             catch( ... ) { \

--- a/projects/SelfTest/CompilationTests.cpp
+++ b/projects/SelfTest/CompilationTests.cpp
@@ -41,7 +41,7 @@ bool templated_tests(T t) {
     REQUIRE(a == t);
     CHECK(a == t);
     REQUIRE_THROWS(throws_int(true));
-    CHECK_THROWS_AS(throws_int(true), const int&);
+    CHECK_THROWS_AS(throws_int(true), const int);
     REQUIRE_NOTHROW(throws_int(false));
     REQUIRE_THAT("aaa", Catch::EndsWith("aaa"));
     return true;


### PR DESCRIPTION
When compiling our codebase with clang we were getting the following
error:

GSL/tests/algorithm_tests.cpp:198:58: warning: catch handler catches by
value; should catch by reference instead
[misc-throw-by-value-catch-by-reference]
    CHECK_THROWS_AS(copy(src_span_dyn, dst_span_static), fail_fast);
                                                             ^
Looking at the catch source code exceptions were being caught by value.
One could have it designed so that users might say:

CHECK_THROWS_AS(copy(src_span_dyn, dst_span_static), fail_fast&);

But I don't think this is the intent and looking at the Catch tests
itself looks like this macro does not expect the reference:

    REQUIRE_THROWS_AS( thisThrows(), std::domain_error );
    CHECK_THROWS_AS( thisDoesntThrow(), std::domain_error );

This commit makes Catch catch exceptions by reference instead of by
value.

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
