### PR TITLE
Replace include_directories() with target_include_directories()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,12 +281,12 @@ SOURCE_GROUP("Tests" FILES ${TEST_SOURCES})
 SOURCE_GROUP("Surrogates" FILES ${SURROGATE_SOURCES})
 
 # configure the executable
-include_directories(${HEADER_DIR})
 
 # Projects consuming Catch via ExternalProject_Add might want to use install step
 # without building all of our selftests.
 if (NOT NO_SELFTEST)
     add_executable(SelfTest ${TEST_SOURCES} ${IMPL_SOURCES} ${REPORTER_SOURCES} ${SURROGATE_SOURCES} ${HEADERS})
+    target_include_directories(SelfTest PRIVATE ${HEADER_DIR})
 
     # Add desired warnings
     if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU" )


### PR DESCRIPTION
to prevent inheritance of include directories that possibly lead to a clash.

A clash occurs when a folder is included, e.g. examples, that wants to use the single-include directory instead of the normal include directory as used by the SelfTest in the next higher level.

CMake: [include_directories()](https://cmake.org/cmake/help/v3.0/command/include_directories.html)
CMake: [target_include_directories()](https://cmake.org/cmake/help/v3.0/command/target_include_directories.html)

Aside: I am a little surprised that the CMake description for SelfTest is in the toplevel `CMakeFiles.txt` and not in e.g. `projects/SelfTest/CMakeFiles.txt`.