### PR TITLE
Add example code linked to from documentation, part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
           packages: ['valgrind', 'clang-3.6']
       env: COMPILER='clang++-3.6' VALGRIND=1
 
-# Travis's containers do not seem to have Clang 3.7 in apt, no matter what sources I add. 
+# Travis's containers do not seem to have Clang 3.7 in apt, no matter what sources I add.
 #    - os: linux
 #      compiler: clang
 #      addons:
@@ -110,6 +110,10 @@ matrix:
           packages: ['valgrind', 'g++-7']
       env: COMPILER='g++-7' VALGRIND=1
 
+    - os: linux
+      compiler: gcc
+      addons: *gcc7
+      env: COMPILER='g++-7' ENV_NO_SELFTEST=1 ENV_BUILD_EXAMPLES=1
 
     # 3b/ Linux C++14 Clang builds
     - os: linux
@@ -200,8 +204,8 @@ before_script:
   - export CXX=${COMPILER}
   - cd ${TRAVIS_BUILD_DIR}
   # Only run valgrind in debug build
-  - cmake -H. -BBuild-Debug -DCMAKE_BUILD_TYPE=Debug -Wdev -DUSE_CPP14=${CPP14} -DUSE_VALGRIND=${VALGRIND}
-  - cmake -H. -BBuild-Release -DCMAKE_BUILD_TYPE=Release -Wdev -DUSE_CPP14=${CPP14}
+  - cmake -H. -BBuild-Debug -DCMAKE_BUILD_TYPE=Debug -Wdev -DUSE_CPP14=${CPP14} -DUSE_VALGRIND=${VALGRIND} -DNO_SELFTEST=${ENV_NO_SELFTEST} -DBUILD_EXAMPLES=${ENV_BUILD_EXAMPLES}
+  - cmake -H. -BBuild-Release -DCMAKE_BUILD_TYPE=Release -Wdev -DUSE_CPP14=${CPP14} -DNO_SELFTEST=${ENV_NO_SELFTEST} -DBUILD_EXAMPLES=${ENV_BUILD_EXAMPLES}
 
 script:
   - cd Build-Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,11 @@ if (NOT NO_SELFTEST)
 endif() # !NO_SELFTEST
 
 
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+
 install(DIRECTORY "single_include/" DESTINATION "include/catch")
 
 ## Provide some pkg-config integration

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,14 +20,23 @@ environment:
         - additional_flags: "/D_UNICODE /DUNICODE"
           wmain: 1
 
+        - additional_flags: ""
+          wmain: 0
+          env_build_examples: 1
+          env_no_selftest: 1
+
 matrix:
     exclude:
-        -
-            additional_flags: "/permissive- /std:c++latest"
-            os: Visual Studio 2015
-        -
-            additional_flags: "/permissive- /std:c++latest"
-            os: Visual Studio 2013
+        - os: Visual Studio 2015
+          additional_flags: "/permissive- /std:c++latest"
+
+        - os: Visual Studio 2015
+          env_build_examples: 1
+          env_no_selftest: 1
+
+        - configuration: Debug
+          env_build_examples: 1
+          env_no_selftest: 1
 
 init:
   - git config --global core.autocrlf input
@@ -51,7 +60,7 @@ configuration:
 #Cmake will autodetect the compiler, but we set the arch
 before_build:
   - set CXXFLAGS=%additional_flags%
-  - cmake -H. -BBuild -A%PLATFORM% -DUSE_WMAIN=%wmain%
+  - cmake -H. -BBuild -A%PLATFORM% -DUSE_WMAIN=%wmain% -DNO_SELFTEST=%env_no_selftest% -DBUILD_EXAMPLES=%env_build_examples%
 
 # build with MSBuild
 build:

--- a/docs/event-listeners.md
+++ b/docs/event-listeners.md
@@ -19,7 +19,7 @@ file that defines `CATCH_CONFIG_EXTERNAL_INTERFACES`.
 
 Then register it using `CATCH_REGISTER_LISTENER`.
 
-For example:
+For example ([complete source code](../examples/210-Evt-EventListeners.cpp)):
 
 ```c++
 #define CATCH_CONFIG_MAIN

--- a/docs/list-of-examples.md
+++ b/docs/list-of-examples.md
@@ -1,0 +1,31 @@
+<a id="top"></a>
+# List of examples
+
+- Test Case: [Single-file](../examples/010-TestCase.cpp)
+- Test Case: [Multiple-file 1](../examples/020-TestCase-1.cpp), [2](../examples/020-TestCase-1.cpp)
+- Assertion: [REQUIRE, CHECK](../examples/030-Asn-Require-Check.cpp)
+- Assertion: [REQUIRE_THAT and Matchers](../examples/040-Asn-RequireThat.cpp)
+- Assertion: [REQUIRE_NO_THROW](../examples/050-Asn-RequireNoThrow.cpp)
+- Assertion: [REQUIRE_THROWS](../examples/050-Asn-RequireThrows.cpp)
+- Assertion: [REQUIRE_THROWS_AS](../examples/070-Asn-RequireThrowsAs.cpp)
+- Assertion: [REQUIRE_THROWS_WITH](../examples/080-Asn-RequireThrowsWith.cpp)
+- Assertion: [REQUIRE_THROWS_MATCHES](../examples/090-Asn-RequireThrowsMatches.cpp)
+- Fixture: [Sections](../examples/100-Fix-Section.cpp)
+- Fixture: [Class-based fixtures](../examples/110-Fix-ClassFixture.cpp)
+- BDD: [SCENARIO, GIVEN, WHEN, THEN](../examples/120-Bdd-ScenarioGivenWhenThen.cpp)
+- Floating point: [Approx - Comparisons](../examples/130-Fpt-Approx.cpp)
+- Logging: [CAPTURE - Capture expression](../examples/140-Log-Capture.cpp)
+- Logging: [INFO - Provide information with failure](../examples/150-Log-Info.cpp)
+- Logging: [WARN - Issue warning](../examples/160-Log-Warn.cpp)
+- Logging: [FAIL, FAIL_CHECK - Issue message and force failure/continue](../examples/170-Log-Fail.cpp)
+- Logging: [SUCCEED - Issue message and continue](../examples/180-Log-Succeed.cpp)
+- Report: [User-defined type](../examples/190-Rpt-ReportUserDefinedType.cpp)
+- Report: [Reporter](../examples/200-Rpt-UserDefinedReporter.cpp)
+- Listener: [Listeners](../examples/210-Evt-EventListeners.cpp)
+- Configuration: [Provide your own main()](../examples/220-Cfg-OwnMain.cpp)
+- Configuration: [Compile-time configuration](../examples/230-Cfg-CompileTimeConfiguration.cpp)
+- Configuration: [Run-time configuration](../examples/240-Cfg-RunTimeConfiguration.cpp)
+
+---
+
+[Home](Readme.md#top)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -25,7 +25,7 @@ The rest of this tutorial will assume that the Catch2 single-include header (or 
 
 ## Writing tests
 
-Let's start with a really simple example. Say you have written a function to calculate factorials and now you want to test it (let's leave aside TDD for now). 
+Let's start with a really simple example ([code](../examples/010-TestCase.cpp)). Say you have written a function to calculate factorials and now you want to test it (let's leave aside TDD for now). 
 
 ```c++
 unsigned int Factorial( unsigned int number ) {
@@ -33,7 +33,7 @@ unsigned int Factorial( unsigned int number ) {
 }
 ```
 
-To keep things simple we'll put everything in a single file (<a href="#scaling-up">see later for more on how to structure your test files</a>)
+To keep things simple we'll put everything in a single file (<a href="#scaling-up">see later for more on how to structure your test files</a>).
 
 ```c++
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
@@ -110,7 +110,7 @@ Most test frameworks have a class-based fixture mechanism. That is, test cases m
 
 While Catch fully supports this way of working there are a few problems with the approach. In particular the way your code must be split up, and the blunt granularity of it, may cause problems. You can only have one setup/ teardown pair across a set of methods, but sometimes you want slightly different setup in each method, or you may even want several levels of setup (a concept which we will clarify later on in this tutorial). It was <a href="http://jamesnewkirk.typepad.com/posts/2007/09/why-you-should-.html">problems like these</a> that led James Newkirk, who led the team that built NUnit, to start again from scratch and <a href="http://jamesnewkirk.typepad.com/posts/2007/09/announcing-xuni.html">build xUnit</a>).
 
-Catch takes a different approach (to both NUnit and xUnit) that is a more natural fit for C++ and the C family of languages. This is best explained through an example:
+Catch takes a different approach (to both NUnit and xUnit) that is a more natural fit for C++ and the C family of languages. This is best explained through an example ([code](../examples/100-Fix-Section.cpp)):
 
 ```c++
 TEST_CASE( "vectors can be sized and resized", "[vector]" ) {
@@ -175,7 +175,7 @@ Sections can be nested to an arbitrary depth (limited only by your stack size). 
 
 If you name your test cases and sections appropriately you can achieve a BDD-style specification structure. This became such a useful way of working that first class support has been added to Catch. Scenarios can be specified using ```SCENARIO```, ```GIVEN```, ```WHEN``` and ```THEN``` macros, which map on to ```TEST_CASE```s and ```SECTION```s, respectively. For more details see [Test cases and sections](test-cases-and-sections.md#top).
 
-The vector example can be adjusted to use these macros like so:
+The vector example can be adjusted to use these macros like so ([example code](../examples/120-Bdd-ScenarioGivenWhenThen.cpp)):
 
 ```c++
 SCENARIO( "vectors can be sized and resized", "[vector]" ) {
@@ -245,7 +245,7 @@ The requirement is that the following block of code ([or equivalent](own-main.md
 
 appears in _exactly one_ source file. Use as many additional cpp files (or whatever you call your implementation files) as you need for your tests, partitioned however makes most sense for your way of working. Each additional file need only ```#include "catch.hpp"``` - do not repeat the ```#define```!
 
-In fact it is usually a good idea to put the block with the ```#define``` [in its own source file](slow-compiles.md#top).
+In fact it is usually a good idea to put the block with the ```#define``` [in its own source file](slow-compiles.md#top) (code example [main](../examples/020-TestCase-1.cpp), [tests](../examples/020-TestCase-2.cpp)).
 
 Do not write your tests in header files!
 

--- a/examples/000-CatchMain.cpp
+++ b/examples/000-CatchMain.cpp
@@ -1,0 +1,15 @@
+// 000-CatchMain.cpp
+
+// In a Catch project with multiple files, dedicate one file to compile the
+// source code of Catch itself and reuse the resulting object file for linking.
+
+// Let Catch provide main():
+#define CATCH_CONFIG_MAIN
+
+#include "catch.hpp"
+
+// That's it
+
+// Compile implementation of Catch for use with files that do contain tests:
+// - g++ -std=c++11 -Wall -I$(CATCH_SINGLE_INCLUDE) -c 000-CatchMain.cpp
+// - cl -EHsc -I%CATCH_SINGLE_INCLUDE% -c 000-CatchMain.cpp

--- a/examples/010-TestCase.cpp
+++ b/examples/010-TestCase.cpp
@@ -1,0 +1,36 @@
+// 010-TestCase.cpp
+
+// Let Catch provide main():
+#define CATCH_CONFIG_MAIN
+
+#include "catch.hpp"
+
+int Factorial( int number ) {
+   return number <= 1 ? number : Factorial( number - 1 ) * number;  // fail
+// return number <= 1 ? 1      : Factorial( number - 1 ) * number;  // pass
+}
+
+TEST_CASE( "Factorial of 0 is 1 (fail)", "[single-file]" ) {
+    REQUIRE( Factorial(0) == 1 );
+}
+
+TEST_CASE( "Factorials of 1 and higher are computed (pass)", "[single-file]" ) {
+    REQUIRE( Factorial(1) == 1 );
+    REQUIRE( Factorial(2) == 2 );
+    REQUIRE( Factorial(3) == 6 );
+    REQUIRE( Factorial(10) == 3628800 );
+}
+
+// Compile & run:
+// - g++ -std=c++11 -Wall -I$(CATCH_SINGLE_INCLUDE) -o 010-TestCase 010-TestCase.cpp && 010-TestCase --success
+// - cl -EHsc -I%CATCH_SINGLE_INCLUDE% 010-TestCase.cpp && 010-TestCase --success
+
+// Expected compact output (all assertions):
+//
+// prompt> 010-TestCase --reporter compact --success
+// 010-TestCase.cpp:14: failed: Factorial(0) == 1 for: 0 == 1
+// 010-TestCase.cpp:18: passed: Factorial(1) == 1 for: 1 == 1
+// 010-TestCase.cpp:19: passed: Factorial(2) == 2 for: 2 == 2
+// 010-TestCase.cpp:20: passed: Factorial(3) == 6 for: 6 == 6
+// 010-TestCase.cpp:21: passed: Factorial(10) == 3628800 for: 3628800 (0x375f00) == 3628800 (0x375f00)
+// Failed 1 test case, failed 1 assertion.

--- a/examples/020-TestCase-1.cpp
+++ b/examples/020-TestCase-1.cpp
@@ -1,0 +1,35 @@
+// 020-TestCase-1.cpp
+
+// In a Catch project with multiple files, dedicate one file to compile the
+// source code of Catch itself and reuse the resulting object file for linking.
+
+// Let Catch provide main():
+#define CATCH_CONFIG_MAIN
+
+#include "catch.hpp"
+
+TEST_CASE( "1: All test cases reside in other .cpp files (empty)", "[multi-file:1]" ) {
+}
+
+// ^^^
+// Normally no TEST_CASEs in this file.
+// Here just to show there are two source files via option --list-tests.
+
+// Compile & run:
+// - g++ -std=c++11 -Wall -I$(CATCH_SINGLE_INCLUDE) -c 020-TestCase-1.cpp
+// - g++ -std=c++11 -Wall -I$(CATCH_SINGLE_INCLUDE) -o 020-TestCase TestCase-1.o 020-TestCase-2.cpp && 020-TestCase --success
+//
+// - cl -EHsc -I%CATCH_SINGLE_INCLUDE% -c 020-TestCase-1.cpp
+// - cl -EHsc -I%CATCH_SINGLE_INCLUDE% -Fe020-TestCase.exe 020-TestCase-1.obj 020-TestCase-2.cpp && 020-TestCase --success
+
+// Expected test case listing:
+//
+// prompt> 020-TestCase --list-tests *
+// Matching test cases:
+//   1: All test cases reside in other .cpp files (empty)
+//       [multi-file:1]
+//   2: Factorial of 0 is computed (fail)
+//       [multi-file:2]
+//   2: Factorials of 1 and higher are computed (pass)
+//       [multi-file:2]
+// 3 matching test cases

--- a/examples/020-TestCase-2.cpp
+++ b/examples/020-TestCase-2.cpp
@@ -1,0 +1,33 @@
+// 020-TestCase-2.cpp
+
+// main() provided by Catch in file 020-TestCase-1.cpp.
+
+#include "catch.hpp"
+
+int Factorial( int number ) {
+   return number <= 1 ? number : Factorial( number - 1 ) * number;  // fail
+// return number <= 1 ? 1      : Factorial( number - 1 ) * number;  // pass
+}
+
+TEST_CASE( "2: Factorial of 0 is 1 (fail)", "[multi-file:2]" ) {
+    REQUIRE( Factorial(0) == 1 );
+}
+
+TEST_CASE( "2: Factorials of 1 and higher are computed (pass)", "[multi-file:2]" ) {
+    REQUIRE( Factorial(1) == 1 );
+    REQUIRE( Factorial(2) == 2 );
+    REQUIRE( Factorial(3) == 6 );
+    REQUIRE( Factorial(10) == 3628800 );
+}
+
+// Compile: see 020-TestCase-1.cpp
+
+// Expected compact output (all assertions):
+//
+// prompt> 020-TestCase --reporter compact --success
+// 020-TestCase-2.cpp:13: failed: Factorial(0) == 1 for: 0 == 1
+// 020-TestCase-2.cpp:17: passed: Factorial(1) == 1 for: 1 == 1
+// 020-TestCase-2.cpp:18: passed: Factorial(2) == 2 for: 2 == 2
+// 020-TestCase-2.cpp:19: passed: Factorial(3) == 6 for: 6 == 6
+// 020-TestCase-2.cpp:20: passed: Factorial(10) == 3628800 for: 3628800 (0x375f00) == 3628800 (0x375f00)
+// Failed 1 test case, failed 1 assertion.

--- a/examples/030-Asn-Require-Check.cpp
+++ b/examples/030-Asn-Require-Check.cpp
@@ -1,0 +1,74 @@
+// 030-Asn-Require-Check.cpp
+
+// Catch has two natural expression assertion macro's:
+// - REQUIRE() stops at first failure.
+// - CHECK() continues after failure.
+
+// There are two variants to support decomposing negated expressions:
+// - REQUIRE_FALSE() stops at first failure.
+// - CHECK_FALSE() continues after failure.
+
+// main() provided in 000-CatchMain.cpp
+
+#include "catch.hpp"
+
+std::string one() {
+    return "1";
+}
+
+TEST_CASE( "Assert that something is true (pass)", "[require]" ) {
+    REQUIRE( one() == "1" );
+}
+
+TEST_CASE( "Assert that something is true (fail)", "[require]" ) {
+    REQUIRE( one() == "x" );
+}
+
+TEST_CASE( "Assert that something is true (stop at first failure)", "[require]" ) {
+    WARN( "REQUIRE stops at first failure:" );
+
+    REQUIRE( one() == "x" );
+    REQUIRE( one() == "1" );
+}
+
+TEST_CASE( "Assert that something is true (continue after failure)", "[check]" ) {
+    WARN( "CHECK continues after failure:" );
+
+    CHECK(   one() == "x" );
+    REQUIRE( one() == "1" );
+}
+
+TEST_CASE( "Assert that something is false (stops at first failure)", "[require-false]" ) {
+    WARN( "REQUIRE_FALSE stops at first failure:" );
+
+    REQUIRE_FALSE( one() == "1" );
+    REQUIRE_FALSE( one() != "1" );
+}
+
+TEST_CASE( "Assert that something is false (continue after failure)", "[check-false]" ) {
+    WARN( "CHECK_FALSE continues after failure:" );
+
+    CHECK_FALSE(   one() == "1" );
+    REQUIRE_FALSE( one() != "1" );
+}
+
+// Compile & run:
+// - g++ -std=c++11 -Wall -I$(CATCH_SINGLE_INCLUDE) -o 030-Asn-Require-Check 030-Asn-Require-Check.cpp 000-CatchMain.o && 030-Asn-Require-Check --success
+// - cl -EHsc -I%CATCH_SINGLE_INCLUDE% 030-Asn-Require-Check.cpp 000-CatchMain.obj && 030-Asn-Require-Check --success
+
+// Expected compact output (all assertions):
+//
+// prompt> 030-Asn-Require-Check.exe --reporter compact --success
+// 030-Asn-Require-Check.cpp:20: passed: one() == "1" for: "1" == "1"
+// 030-Asn-Require-Check.cpp:24: failed: one() == "x" for: "1" == "x"
+// 030-Asn-Require-Check.cpp:28: warning: 'REQUIRE stops at first failure:'
+// 030-Asn-Require-Check.cpp:30: failed: one() == "x" for: "1" == "x"
+// 030-Asn-Require-Check.cpp:35: warning: 'CHECK continues after failure:'
+// 030-Asn-Require-Check.cpp:37: failed: one() == "x" for: "1" == "x"
+// 030-Asn-Require-Check.cpp:38: passed: one() == "1" for: "1" == "1"
+// 030-Asn-Require-Check.cpp:42: warning: 'REQUIRE_FALSE stops at first failure:'
+// 030-Asn-Require-Check.cpp:44: failed: !(one() == "1") for: !("1" == "1")
+// 030-Asn-Require-Check.cpp:49: warning: 'CHECK_FALSE continues after failure:'
+// 030-Asn-Require-Check.cpp:51: failed: !(one() == "1") for: !("1" == "1")
+// 030-Asn-Require-Check.cpp:52: passed: !(one() != "1") for: !("1" != "1")
+// Failed 5 test cases, failed 5 assertions.

--- a/examples/100-Fix-Section.cpp
+++ b/examples/100-Fix-Section.cpp
@@ -1,0 +1,69 @@
+// 100-Fix-Section.cpp
+
+// Catch has two ways to express fixtures:
+// - Sections (this file)
+// - Traditional class-based fixtures
+
+// main() provided in 000-CatchMain.cpp
+
+#include "catch.hpp"
+
+TEST_CASE( "vectors can be sized and resized", "[vector]" ) {
+
+    // For each section, vector v is anew:
+
+    std::vector<int> v( 5 );
+
+    REQUIRE( v.size() == 5 );
+    REQUIRE( v.capacity() >= 5 );
+
+    SECTION( "resizing bigger changes size and capacity" ) {
+        v.resize( 10 );
+
+        REQUIRE( v.size() == 10 );
+        REQUIRE( v.capacity() >= 10 );
+    }
+    SECTION( "resizing smaller changes size but not capacity" ) {
+        v.resize( 0 );
+
+        REQUIRE( v.size() == 0 );
+        REQUIRE( v.capacity() >= 5 );
+    }
+    SECTION( "reserving bigger changes capacity but not size" ) {
+        v.reserve( 10 );
+
+        REQUIRE( v.size() == 5 );
+        REQUIRE( v.capacity() >= 10 );
+    }
+    SECTION( "reserving smaller does not change size or capacity" ) {
+        v.reserve( 0 );
+
+        REQUIRE( v.size() == 5 );
+        REQUIRE( v.capacity() >= 5 );
+    }
+}
+
+// Compile & run:
+// - g++ -std=c++11 -Wall -I$(CATCH_SINGLE_INCLUDE) -o 100-Fix-Section 100-Fix-Section.cpp 000-CatchMain.o && 100-Fix-Section --success
+// - cl -EHsc -I%CATCH_SINGLE_INCLUDE% 100-Fix-Section.cpp 000-CatchMain.obj && 100-Fix-Section --success
+
+// Expected compact output (all assertions):
+//
+// prompt> 100-Fix-Section.exe --reporter compact --success
+// 100-Fix-Section.cpp:17: passed: v.size() == 5 for: 5 == 5
+// 100-Fix-Section.cpp:18: passed: v.capacity() >= 5 for: 5 >= 5
+// 100-Fix-Section.cpp:23: passed: v.size() == 10 for: 10 == 10
+// 100-Fix-Section.cpp:24: passed: v.capacity() >= 10 for: 10 >= 10
+// 100-Fix-Section.cpp:17: passed: v.size() == 5 for: 5 == 5
+// 100-Fix-Section.cpp:18: passed: v.capacity() >= 5 for: 5 >= 5
+// 100-Fix-Section.cpp:29: passed: v.size() == 0 for: 0 == 0
+// 100-Fix-Section.cpp:30: passed: v.capacity() >= 5 for: 5 >= 5
+// 100-Fix-Section.cpp:17: passed: v.size() == 5 for: 5 == 5
+// 100-Fix-Section.cpp:18: passed: v.capacity() >= 5 for: 5 >= 5
+// 100-Fix-Section.cpp:35: passed: v.size() == 5 for: 5 == 5
+// 100-Fix-Section.cpp:36: passed: v.capacity() >= 10 for: 10 >= 10
+// 100-Fix-Section.cpp:17: passed: v.size() == 5 for: 5 == 5
+// 100-Fix-Section.cpp:18: passed: v.capacity() >= 5 for: 5 >= 5
+// 100-Fix-Section.cpp:41: passed: v.size() == 5 for: 5 == 5
+// 100-Fix-Section.cpp:42: passed: v.capacity() >= 5 for: 5 >= 5
+// Passed 1 test case with 16 assertions.

--- a/examples/110-Fix-ClassFixture.cpp
+++ b/examples/110-Fix-ClassFixture.cpp
@@ -1,0 +1,63 @@
+// 110-Fix-ClassFixture.cpp
+
+// Catch has two ways to express fixtures:
+// - Sections
+// - Traditional class-based fixtures (this file)
+
+// main() provided in 000-CatchMain.cpp
+
+#include "catch.hpp"
+
+class DBConnection
+{
+public:
+    static DBConnection createConnection( std::string const & /*dbName*/ ) {
+        return DBConnection();
+    }
+
+    bool executeSQL( std::string const & /*query*/, int const /*id*/, std::string const & arg ) {
+        if ( arg.length() == 0 ) {
+            throw std::logic_error("empty SQL query argument");
+        }
+        return true; // ok
+    }
+};
+
+class UniqueTestsFixture
+{
+protected:
+    UniqueTestsFixture()
+    : conn( DBConnection::createConnection( "myDB" ) )
+    {}
+
+    int getID() {
+        return ++uniqueID;
+    }
+
+protected:
+    DBConnection conn;
+
+private:
+    static int uniqueID;
+};
+
+int UniqueTestsFixture::uniqueID = 0;
+
+TEST_CASE_METHOD( UniqueTestsFixture, "Create Employee/No Name", "[create]" ) {
+    REQUIRE_THROWS( conn.executeSQL( "INSERT INTO employee (id, name) VALUES (?, ?)", getID(), "") );
+}
+
+TEST_CASE_METHOD( UniqueTestsFixture, "Create Employee/Normal", "[create]" ) {
+    REQUIRE( conn.executeSQL( "INSERT INTO employee (id, name) VALUES (?, ?)", getID(), "Joe Bloggs" ) );
+}
+
+// Compile & run:
+// - g++ -std=c++11 -Wall -I$(CATCH_SINGLE_INCLUDE) -o 110-Fix-ClassFixture 110-Fix-ClassFixture.cpp 000-CatchMain.o && 110-Fix-ClassFixture --success
+// - cl -EHsc -I%CATCH_SINGLE_INCLUDE% 110-Fix-ClassFixture.cpp 000-CatchMain.obj && 110-Fix-ClassFixture --success
+
+// Expected compact output (all assertions):
+//
+// prompt> 110-Fix-ClassFixture.exe --reporter compact --success
+// 110-Fix-ClassFixture.cpp:47: passed: conn.executeSQL( "INSERT INTO employee (id, name) VALUES (?, ?)", getID(), "")
+// 110-Fix-ClassFixture.cpp:51: passed: conn.executeSQL( "INSERT INTO employee (id, name) VALUES (?, ?)", getID(), "Joe Bloggs" ) for: true
+// Passed both 2 test cases with 2 assertions.

--- a/examples/120-Bdd-ScenarioGivenWhenThen.cpp
+++ b/examples/120-Bdd-ScenarioGivenWhenThen.cpp
@@ -1,0 +1,73 @@
+// 120-Bdd-ScenarioGivenWhenThen.cpp
+
+// main() provided in 000-CatchMain.cpp
+
+#include "catch.hpp"
+
+SCENARIO( "vectors can be sized and resized", "[vector]" ) {
+
+    GIVEN( "A vector with some items" ) {
+        std::vector<int> v( 5 );
+
+        REQUIRE( v.size() == 5 );
+        REQUIRE( v.capacity() >= 5 );
+
+        WHEN( "the size is increased" ) {
+            v.resize( 10 );
+
+            THEN( "the size and capacity change" ) {
+                REQUIRE( v.size() == 10 );
+                REQUIRE( v.capacity() >= 10 );
+            }
+        }
+        WHEN( "the size is reduced" ) {
+            v.resize( 0 );
+
+            THEN( "the size changes but not capacity" ) {
+                REQUIRE( v.size() == 0 );
+                REQUIRE( v.capacity() >= 5 );
+            }
+        }
+        WHEN( "more capacity is reserved" ) {
+            v.reserve( 10 );
+
+            THEN( "the capacity changes but not the size" ) {
+                REQUIRE( v.size() == 5 );
+                REQUIRE( v.capacity() >= 10 );
+            }
+        }
+        WHEN( "less capacity is reserved" ) {
+            v.reserve( 0 );
+
+            THEN( "neither size nor capacity are changed" ) {
+                REQUIRE( v.size() == 5 );
+                REQUIRE( v.capacity() >= 5 );
+            }
+        }
+    }
+}
+
+// Compile & run:
+// - g++ -std=c++11 -Wall -I$(CATCH_SINGLE_INCLUDE) -o 120-Bdd-ScenarioGivenWhenThen 120-Bdd-ScenarioGivenWhenThen.cpp 000-CatchMain.o && 120-Bdd-ScenarioGivenWhenThen --success
+// - cl -EHsc -I%CATCH_SINGLE_INCLUDE% 120-Bdd-ScenarioGivenWhenThen.cpp 000-CatchMain.obj && 120-Bdd-ScenarioGivenWhenThen --success
+
+// Expected compact output (all assertions):
+//
+// prompt> 120-Bdd-ScenarioGivenWhenThen.exe --reporter compact --success
+// 120-Bdd-ScenarioGivenWhenThen.cpp:12: passed: v.size() == 5 for: 5 == 5
+// 120-Bdd-ScenarioGivenWhenThen.cpp:13: passed: v.capacity() >= 5 for: 5 >= 5
+// 120-Bdd-ScenarioGivenWhenThen.cpp:19: passed: v.size() == 10 for: 10 == 10
+// 120-Bdd-ScenarioGivenWhenThen.cpp:20: passed: v.capacity() >= 10 for: 10 >= 10
+// 120-Bdd-ScenarioGivenWhenThen.cpp:12: passed: v.size() == 5 for: 5 == 5
+// 120-Bdd-ScenarioGivenWhenThen.cpp:13: passed: v.capacity() >= 5 for: 5 >= 5
+// 120-Bdd-ScenarioGivenWhenThen.cpp:27: passed: v.size() == 0 for: 0 == 0
+// 120-Bdd-ScenarioGivenWhenThen.cpp:28: passed: v.capacity() >= 5 for: 5 >= 5
+// 120-Bdd-ScenarioGivenWhenThen.cpp:12: passed: v.size() == 5 for: 5 == 5
+// 120-Bdd-ScenarioGivenWhenThen.cpp:13: passed: v.capacity() >= 5 for: 5 >= 5
+// 120-Bdd-ScenarioGivenWhenThen.cpp:35: passed: v.size() == 5 for: 5 == 5
+// 120-Bdd-ScenarioGivenWhenThen.cpp:36: passed: v.capacity() >= 10 for: 10 >= 10
+// 120-Bdd-ScenarioGivenWhenThen.cpp:12: passed: v.size() == 5 for: 5 == 5
+// 120-Bdd-ScenarioGivenWhenThen.cpp:13: passed: v.capacity() >= 5 for: 5 >= 5
+// 120-Bdd-ScenarioGivenWhenThen.cpp:43: passed: v.size() == 5 for: 5 == 5
+// 120-Bdd-ScenarioGivenWhenThen.cpp:44: passed: v.capacity() >= 5 for: 5 >= 5
+// Passed 1 test case with 16 assertions.

--- a/examples/210-Evt-EventListeners.cpp
+++ b/examples/210-Evt-EventListeners.cpp
@@ -1,0 +1,416 @@
+// 210-Evt-EventListeners.cpp
+
+// Contents:
+// 1. Printing of listener data
+// 2. My listener and registration
+// 3. Test cases
+
+// main() provided in 000-CatchMain.cpp
+
+// Let Catch provide the required interfaces:
+#define CATCH_CONFIG_EXTERNAL_INTERFACES
+
+#include "catch.hpp"
+#include <iostream>
+
+// -----------------------------------------------------------------------
+// 1. Printing of listener data:
+//
+
+std::string ws(int const level) {
+    return std::string( 2 * level, ' ' );
+}
+
+template< typename T >
+std::ostream& operator<<( std::ostream& os, std::vector<T> const& v ) {
+    os << "{ ";
+    for ( auto x : v )
+        os << x << ", ";
+    return os << "}";
+}
+
+// struct SourceLineInfo {
+//     char const* file;
+//     std::size_t line;
+// };
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::SourceLineInfo const& info ) {
+    os << ws(level  ) << title << ":\n"
+       << ws(level+1) << "- file: " << info.file << "\n"
+       << ws(level+1) << "- line: " << info.line << "\n";
+}
+
+//struct MessageInfo {
+//    std::string macroName;
+//    std::string message;
+//    SourceLineInfo lineInfo;
+//    ResultWas::OfType type;
+//    unsigned int sequence;
+//};
+
+void print( std::ostream& os, int const level, Catch::MessageInfo const& info ) {
+    os << ws(level+1) << "- macroName: '" << info.macroName << "'\n"
+       << ws(level+1) << "- message '"    << info.message   << "'\n";
+    print( os,level+1  , "- lineInfo", info.lineInfo );
+    os << ws(level+1) << "- sequence "    << info.sequence  << "\n";
+}
+
+void print( std::ostream& os, int const level, std::string const& title, std::vector<Catch::MessageInfo> const& v ) {
+    os << ws(level  ) << title << ":\n";
+    for ( auto x : v )
+    {
+        os << ws(level+1) << "{\n";
+        print( os, level+2, x );
+        os << ws(level+1) << "}\n";
+    }
+//    os << ws(level+1) << "\n";
+}
+
+// struct TestRunInfo {
+//     std::string name;
+// };
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::TestRunInfo const& info ) {
+    os << ws(level  ) << title << ":\n"
+       << ws(level+1) << "- name: " << info.name << "\n";
+}
+
+// struct Counts {
+//     std::size_t total() const;
+//     bool allPassed() const;
+//     bool allOk() const;
+//
+//     std::size_t passed = 0;
+//     std::size_t failed = 0;
+//     std::size_t failedButOk = 0;
+// };
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::Counts const& info ) {
+    os << ws(level  ) << title << ":\n"
+       << ws(level+1) << "- total(): "     << info.total()     << "\n"
+       << ws(level+1) << "- allPassed(): " << info.allPassed() << "\n"
+       << ws(level+1) << "- allOk(): "     << info.allOk()     << "\n"
+       << ws(level+1) << "- passed: "      << info.passed      << "\n"
+       << ws(level+1) << "- failed: "      << info.failed      << "\n"
+       << ws(level+1) << "- failedButOk: " << info.failedButOk << "\n";
+}
+
+// struct Totals {
+//     Counts assertions;
+//     Counts testCases;
+// };
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::Totals const& info ) {
+    os << ws(level) << title << ":\n";
+    print( os, level+1, "- assertions", info.assertions );
+    print( os, level+1, "- testCases" , info.testCases  );
+}
+
+// struct TestRunStats {
+//     TestRunInfo runInfo;
+//     Totals totals;
+//     bool aborting;
+// };
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::TestRunStats const& info ) {
+    os << ws(level) << title << ":\n";
+    print( os, level+1 , "- runInfo", info.runInfo );
+    print( os, level+1 , "- totals" , info.totals  );
+    os << ws(level+1) << "- aborting: " << info.aborting << "\n";
+}
+
+// struct TestCaseInfo {
+//     enum SpecialProperties{
+//         None = 0,
+//         IsHidden = 1 << 1,
+//         ShouldFail = 1 << 2,
+//         MayFail = 1 << 3,
+//         Throws = 1 << 4,
+//         NonPortable = 1 << 5,
+//         Benchmark = 1 << 6
+//     };
+//
+//     bool isHidden() const;
+//     bool throws() const;
+//     bool okToFail() const;
+//     bool expectedToFail() const;
+//
+//     std::string tagsAsString() const;
+//
+//     std::string name;
+//     std::string className;
+//     std::string description;
+//     std::vector<std::string> tags;
+//     std::vector<std::string> lcaseTags;
+//     SourceLineInfo lineInfo;
+//     SpecialProperties properties;
+// };
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::TestCaseInfo const& info ) {
+    os << ws(level  ) << title << ":\n"
+       << ws(level+1) << "- isHidden(): "       << info.isHidden() << "\n"
+       << ws(level+1) << "- throws(): "         << info.throws() << "\n"
+       << ws(level+1) << "- okToFail(): "       << info.okToFail() << "\n"
+       << ws(level+1) << "- expectedToFail(): " << info.expectedToFail() << "\n"
+       << ws(level+1) << "- tagsAsString(): '"  << info.tagsAsString() << "'\n"
+       << ws(level+1) << "- name: '"            << info.name << "'\n"
+       << ws(level+1) << "- className: '"       << info.className << "'\n"
+       << ws(level+1) << "- description: '"     << info.description << "'\n"
+       << ws(level+1) << "- tags: "             << info.tags << "\n"
+       << ws(level+1) << "- lcaseTags: "        << info.lcaseTags << "\n";
+    print( os, level+1 , "- lineInfo", info.lineInfo );
+    os << ws(level+1) << "- properties (flags): 0x" << std::hex << info.properties << std::dec << "\n";
+}
+
+// struct TestCaseStats {
+//     TestCaseInfo testInfo;
+//     Totals totals;
+//     std::string stdOut;
+//     std::string stdErr;
+//     bool aborting;
+// };
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::TestCaseStats const& info ) {
+    os << ws(level  ) << title << ":\n";
+    print( os, level+1 , "- testInfo", info.testInfo );
+    print( os, level+1 , "- totals"  , info.totals   );
+    os << ws(level+1) << "- stdOut: "   << info.stdOut << "\n"
+       << ws(level+1) << "- stdErr: "   << info.stdErr << "\n"
+       << ws(level+1) << "- aborting: " << info.aborting << "\n";
+}
+
+// struct SectionInfo {
+//     std::string name;
+//     std::string description;
+//     SourceLineInfo lineInfo;
+// };
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::SectionInfo const& info ) {
+    os << ws(level  ) << title << ":\n"
+       << ws(level+1) << "- name: "         << info.name << "\n"
+       << ws(level+1) << "- description: '" << info.description << "'\n";
+    print( os, level+1 , "- lineInfo", info.lineInfo );
+}
+
+// struct SectionStats {
+//     SectionInfo sectionInfo;
+//     Counts assertions;
+//     double durationInSeconds;
+//     bool missingAssertions;
+// };
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::SectionStats const& info ) {
+    os << ws(level  ) << title << ":\n";
+    print( os, level+1 , "- sectionInfo", info.sectionInfo );
+    print( os, level+1 , "- assertions" , info.assertions );
+    os << ws(level+1) << "- durationInSeconds: " << info.durationInSeconds << "\n"
+       << ws(level+1) << "- missingAssertions: " << info.missingAssertions << "\n";
+}
+
+// struct AssertionInfo
+// {
+//     StringRef macroName;
+//     SourceLineInfo lineInfo;
+//     StringRef capturedExpression;
+//     ResultDisposition::Flags resultDisposition;
+// };
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::AssertionInfo const& info ) {
+    os << ws(level  ) << title << ":\n"
+       << ws(level+1) << "- macroName: '"  << info.macroName << "'\n";
+    print( os, level+1 , "- lineInfo" , info.lineInfo );
+    os << ws(level+1) << "- capturedExpression: '" << info.capturedExpression << "'\n"
+       << ws(level+1) << "- resultDisposition (flags): 0x" << std::hex << info.resultDisposition  << std::dec << "\n";
+}
+
+//struct AssertionResultData
+//{
+//    std::string reconstructExpression() const;
+//
+//    std::string message;
+//    mutable std::string reconstructedExpression;
+//    LazyExpression lazyExpression;
+//    ResultWas::OfType resultType;
+//};
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::AssertionResultData const& info ) {
+    os << ws(level  ) << title << ":\n"
+       << ws(level+1) << "- reconstructExpression(): '" <<   info.reconstructExpression() << "'\n"
+       << ws(level+1) << "- message: '"                 <<   info.message << "'\n"
+       << ws(level+1) << "- lazyExpression: '"          << "(info.lazyExpression)" << "'\n"
+       << ws(level+1) << "- resultType: '"              <<   info.resultType << "'\n";
+}
+
+//class AssertionResult {
+//    bool isOk() const;
+//    bool succeeded() const;
+//    ResultWas::OfType getResultType() const;
+//    bool hasExpression() const;
+//    bool hasMessage() const;
+//    std::string getExpression() const;
+//    std::string getExpressionInMacro() const;
+//    bool hasExpandedExpression() const;
+//    std::string getExpandedExpression() const;
+//    std::string getMessage() const;
+//    SourceLineInfo getSourceInfo() const;
+//    std::string getTestMacroName() const;
+//
+//    AssertionInfo m_info;
+//    AssertionResultData m_resultData;
+//};
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::AssertionResult const& info ) {
+    os << ws(level  ) << title << ":\n"
+       << ws(level+1) << "- isOk(): "  << info.isOk() << "\n"
+       << ws(level+1) << "- succeeded(): "  << info.succeeded() << "\n"
+       << ws(level+1) << "- getResultType(): "  << info.getResultType() << "\n"
+       << ws(level+1) << "- hasExpression(): "  << info.hasExpression() << "\n"
+       << ws(level+1) << "- hasMessage(): "  << info.hasMessage() << "\n"
+       << ws(level+1) << "- getExpression(): '"  << info.getExpression() << "'\n"
+       << ws(level+1) << "- getExpressionInMacro(): '"  << info.getExpressionInMacro()  << "'\n"
+       << ws(level+1) << "- hasExpandedExpression(): "  << info.hasExpandedExpression() << "\n"
+       << ws(level+1) << "- getExpandedExpression(): "  << info.getExpandedExpression() << "'\n"
+       << ws(level+1) << "- getMessage(): '"  << info.getMessage() << "'\n";
+    print( os, level+1 , "- getSourceInfo(): ", info.getSourceInfo() );
+    os << ws(level+1) << "- getTestMacroName(): '"  << info.getTestMacroName() << "'\n";
+
+//    print( os, level+1 , "- *** m_info (AssertionInfo)", info.m_info );
+//    print( os, level+1 , "- *** m_resultData (AssertionResultData)", info.m_resultData );
+}
+
+// struct AssertionStats {
+//     AssertionResult assertionResult;
+//     std::vector<MessageInfo> infoMessages;
+//     Totals totals;
+// };
+
+void print( std::ostream& os, int const level, std::string const& title, Catch::AssertionStats const& info ) {
+    os << ws(level  ) << title << ":\n";
+    print( os, level+1 , "- assertionResult", info.assertionResult );
+    print( os, level+1 , "- infoMessages", info.infoMessages );
+    print( os, level+1 , "- totals", info.totals );
+}
+
+// -----------------------------------------------------------------------
+// 2. My listener and registration:
+//
+
+const std::string dashed_line =
+    "--------------------------------------------------------------------------";
+
+struct MyListener : Catch::TestEventListenerBase {
+
+    using TestEventListenerBase::TestEventListenerBase; // inherit constructor
+
+    // The whole test run starting
+    virtual void testRunStarting( Catch::TestRunInfo const& testRunInfo ) override {
+        std::cout
+            << std::boolalpha
+            << "\nEvent: testRunStarting:\n";
+        print( std::cout, 1, "- testRunInfo", testRunInfo );
+    }
+
+    // The whole test run ending
+    virtual void testRunEnded( Catch::TestRunStats const& testRunStats ) override {
+        std::cout
+            << dashed_line
+            << "\nEvent: testRunEnded:\n";
+        print( std::cout, 1, "- testRunStats", testRunStats );
+    }
+
+    // A test is being skipped (because it is "hidden")
+    virtual void skipTest( Catch::TestCaseInfo const& testInfo ) override {
+        std::cout
+            << dashed_line
+            << "\nEvent: skipTest:\n";
+        print( std::cout, 1, "- testInfo", testInfo );
+    }
+
+    // Test cases starting
+    virtual void testCaseStarting( Catch::TestCaseInfo const& testInfo ) override {
+        std::cout
+            << dashed_line
+            << "\nEvent: testCaseStarting:\n";
+        print( std::cout, 1, "- testInfo", testInfo );
+    }
+
+    // Test cases ending
+    virtual void testCaseEnded( Catch::TestCaseStats const& testCaseStats ) override {
+        std::cout << "\nEvent: testCaseEnded:\n";
+        print( std::cout, 1, "testCaseStats", testCaseStats );
+    }
+
+    // Sections starting
+    virtual void sectionStarting( Catch::SectionInfo const& sectionInfo ) override {
+        std::cout << "\nEvent: sectionStarting:\n";
+        print( std::cout, 1, "- sectionInfo", sectionInfo );
+    }
+
+    // Sections ending
+    virtual void sectionEnded( Catch::SectionStats const& sectionStats ) override {
+        std::cout << "\nEvent: sectionEnded:\n";
+        print( std::cout, 1, "- sectionStats", sectionStats );
+    }
+
+    // Assertions before/ after
+    virtual void assertionStarting( Catch::AssertionInfo const& assertionInfo ) override {
+        std::cout << "\nEvent: assertionStarting:\n";
+        print( std::cout, 1, "- assertionInfo", assertionInfo );
+    }
+
+    virtual bool assertionEnded( Catch::AssertionStats const& assertionStats ) override {
+        std::cout << "\nEvent: assertionEnded:\n";
+        print( std::cout, 1, "- assertionStats", assertionStats );
+        return true;
+    }
+};
+
+CATCH_REGISTER_LISTENER( MyListener )
+
+// -----------------------------------------------------------------------
+// 3. Test cases:
+//
+
+TEST_CASE( "1: Hidden testcase", "[.hidden]" ) {
+}
+
+TEST_CASE( "2: Testcase with sections", "[tag-A][tag-B]" ) {
+
+    int i = 42;
+
+    REQUIRE( i == 42 );
+
+    SECTION("Section 1") {
+        INFO("Section 1")
+        i = 7;
+        SECTION("Section 1.1") {
+            INFO("Section 1.1")
+            REQUIRE( i == 42 );
+        }
+    }
+
+    SECTION("Section 2") {
+        INFO("Section 2")
+        REQUIRE( i == 42 );
+    }
+    WARN("At end of test case");
+}
+
+struct Fixture {
+    int fortytwo() const {
+        return 42;
+    }
+};
+
+TEST_CASE_METHOD( Fixture, "3: Testcase with class-based fixture", "[tag-C][tag-D]" ) {
+    REQUIRE( fortytwo() == 42 );
+}
+
+// Compile & run:
+// - g++ -std=c++11 -Wall -I$(CATCH_SINGLE_INCLUDE) -o 210-Evt-EventListeners 210-Evt-EventListeners.cpp 000-CatchMain.o && 210-Evt-EventListeners --success
+// - cl -EHsc -I%CATCH_SINGLE_INCLUDE% 210-Evt-EventListeners.cpp 000-CatchMain.obj && 210-Evt-EventListeners --success
+
+// Expected compact output (all assertions):
+//
+// prompt> 210-Evt-EventListeners --reporter compact --success
+// result omitted for brevity.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,100 @@
+#
+# Build examples.
+#
+# Requires BUILD_EXAMPLES to be defined 'true', see ../CMakeLists.txt.
+#
+
+cmake_minimum_required( VERSION 3.0 )
+
+project( CatchExamples CXX )
+
+# define folders used:
+
+set( EXAMPLES_DIR ${CATCH_DIR}/examples )
+set( HEADER_DIR   ${CATCH_DIR}/single_include )
+
+# single-file sources:
+
+set( SOURCES_SINGLE_FILE
+    010-TestCase.cpp
+)
+
+# multiple-file modules:
+
+set( SOURCES_020
+    020-TestCase-1.cpp
+    020-TestCase-2.cpp
+)
+
+# main for idiomatic test sources:
+
+set( SOURCES_IDIOMATIC_MAIN
+    000-CatchMain.cpp
+)
+
+# sources to combine with 000-CatchMain.cpp:
+
+set( SOURCES_IDIOMATIC_TESTS
+    030-Asn-Require-Check.cpp
+    100-Fix-Section.cpp
+    110-Fix-ClassFixture.cpp
+    120-Bdd-ScenarioGivenWhenThen.cpp
+    210-Evt-EventListeners.cpp
+)
+
+# check if all sources are listed, warn if not:
+
+set( SOURCES_ALL
+    ${SOURCES_020}
+    ${SOURCES_SINGLE_FILE}
+    ${SOURCES_IDIOMATIC_MAIN}
+    ${SOURCES_IDIOMATIC_TESTS}
+)
+
+foreach( name ${SOURCES_ALL} )
+    list( APPEND SOURCES_ALL_PATH ${EXAMPLES_DIR}/${name} )
+endforeach()
+
+CheckFileList( SOURCES_ALL_PATH ${EXAMPLES_DIR} )
+
+# create target names:
+
+string( REPLACE ".cpp" "" BASENAMES_SINGLE_FILE     "${SOURCES_SINGLE_FILE}" )
+string( REPLACE ".cpp" "" BASENAMES_IDIOMATIC_TESTS "${SOURCES_IDIOMATIC_TESTS}" )
+
+set( TARGETS_SINGLE_FILE     ${BASENAMES_SINGLE_FILE} )
+set( TARGETS_IDIOMATIC_TESTS ${BASENAMES_IDIOMATIC_TESTS} )
+set( TARGETS_ALL             ${TARGETS_SINGLE_FILE} ${TARGETS_IDIOMATIC_TESTS} 020-TestCase CatchMain )
+
+# define program targets:
+
+add_library( CatchMain OBJECT ${EXAMPLES_DIR}/${SOURCES_IDIOMATIC_MAIN} ${HEADER_DIR}/catch.hpp )
+
+add_executable( 020-TestCase ${EXAMPLES_DIR}/020-TestCase-1.cpp ${EXAMPLES_DIR}/020-TestCase-2.cpp ${HEADER_DIR}/catch.hpp )
+
+foreach( name ${TARGETS_SINGLE_FILE} )
+    add_executable( ${name} ${EXAMPLES_DIR}/${name}.cpp ${HEADER_DIR}/catch.hpp )
+endforeach()
+
+foreach( name ${TARGETS_IDIOMATIC_TESTS} )
+    add_executable( ${name} ${EXAMPLES_DIR}/${name}.cpp $<TARGET_OBJECTS:CatchMain> ${HEADER_DIR}/catch.hpp )
+endforeach()
+
+foreach( name ${TARGETS_ALL} )
+    target_include_directories( ${name} PRIVATE ${HEADER_DIR} )
+
+    set_property(TARGET ${name} PROPERTY CXX_STANDARD 11)
+
+    # Add desired warnings
+    if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU" )
+        target_compile_options( ${name}  PRIVATE -Wall -Wextra -Wunreachable-code )
+    endif()
+    # Clang specific warning go here
+    if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
+        # Actually keep these
+        target_compile_options( ${name}  PRIVATE -Wweak-vtables -Wexit-time-destructors -Wglobal-constructors -Wmissing-noreturn )
+    endif()
+    if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
+        target_compile_options( ${name}  PRIVATE /W4 /w44265 /WX )
+    endif()
+endforeach()


### PR DESCRIPTION
PR linked to issue #1037.

I've integrated building of the examples into CMake.

**`USE_EXAMPLES`**&emsp;The examples are built if `USE_EXAMPLES` is `true`. This name follows the existing pattern, but may not properly reflect the choice. `NO_EXAMPLES` is the wrong way round. Plain `EXAMPLES` is weird.
Do you have suggestions?

**Travis, AppVeyor**&emsp; I've not touched CI yet. Do you have suggestions here; I wouldn't mind to leave this to experts.

Other remarks?