### PR TITLE
Fix platform detection for iOS

### DIFF
--- a/include/internal/catch_platform.h
+++ b/include/internal/catch_platform.h
@@ -11,7 +11,7 @@
 
 #ifdef __APPLE__
 # include <TargetConditionals.h>
-# if TARGET_OS_MAC == 1
+# if TARGET_OS_OSX == 1
 #  define CATCH_PLATFORM_MAC
 # elif TARGET_OS_IPHONE == 1
 #  define CATCH_PLATFORM_IPHONE


### PR DESCRIPTION
Platform detection fails for iOS resulting in compile error.

The `TARGET_OS_MAC` is a super category of `TARGET_OS_OSX` and `TARGET_OS_IPHONE` thus `CATCH_PLATFORM_IPHONE` is never selected. 

From apple docs:

```
    TARGET_OS_* 
    These conditionals specify in which Operating System the generated code will
    run.  Indention is used to show which conditionals are evolutionary subclasses.  
    
    The MAC/WIN32/UNIX conditionals are mutually exclusive.
    The IOS/TV/WATCH conditionals are mutually exclusive.
    
    
        TARGET_OS_WIN32           - Generated code will run under 32-bit Windows
        TARGET_OS_UNIX            - Generated code will run under some Unix (not OSX) 
        TARGET_OS_MAC             - Generated code will run under Mac OS X variant
           TARGET_OS_OSX          - Generated code will run under OS X devices
           TARGET_OS_IPHONE          - Generated code for firmware, devices, or simulator
              TARGET_OS_IOS             - Generated code will run under iOS 
              TARGET_OS_TV              - Generated code will run under Apple TV OS
              TARGET_OS_WATCH           - Generated code will run under Apple Watch OS
              TARGET_OS_BRIDGE          - Generated code will run under Bridge devices
           TARGET_OS_SIMULATOR      - Generated code will run under a simulator
           TARGET_OS_EMBEDDED       - Generated code for firmware
       
        TARGET_IPHONE_SIMULATOR   - DEPRECATED: Same as TARGET_OS_SIMULATOR
        TARGET_OS_NANO            - DEPRECATED: Same as TARGET_OS_WATCH

      +------------------------------------------------+
      |                TARGET_OS_MAC                   |
      | +---+  +-------------------------------------+ |
      | |   |  |          TARGET_OS_IPHONE           | |
      | |OSX|  | +-----+ +----+ +-------+ +--------+ | |
      | |   |  | | IOS | | TV | | WATCH | | BRIDGE | | |
      | |   |  | +-----+ +----+ +-------+ +--------+ | |
      | +---+  +-------------------------------------+ |
      +------------------------------------------------+
```
