### PR TITLE
Add inja to open source users

### DIFF
--- a/docs/opensource-users.md
+++ b/docs/opensource-users.md
@@ -39,7 +39,7 @@ A header-only template engine for modern C++.
 A, single-header, JSON parsing library that takes advantage of what C++ has to offer.
 
 ### [MNMLSTC Core](https://github.com/mnmlstc/core)
-a small and easy to use C++11 library that adds a functionality set that will be available in C++14 and later, as well as some useful additions
+A small and easy to use C++11 library that adds a functionality set that will be available in C++14 and later, as well as some useful additions.
 
 ### [nanodbc](https://github.com/lexicalunit/nanodbc/)
 A small C++ library wrapper for the native C ODBC API.

--- a/docs/opensource-users.md
+++ b/docs/opensource-users.md
@@ -32,6 +32,9 @@ A, single-header-only, type-safe, command line parser - which also prints format
 ### [Couchbase-lite-core](https://github.com/couchbase/couchbase-lite-core)
 The next-generation core storage and query engine for Couchbase Lite/
 
+### [Inja](ttps://github.com/pantor/inja)
+A header-only template engine for modern C++.
+
 ### [JSON for Modern C++](https://github.com/nlohmann/json)
 A, single-header, JSON parsing library that takes advantage of what C++ has to offer.
 

--- a/docs/opensource-users.md
+++ b/docs/opensource-users.md
@@ -32,7 +32,7 @@ A, single-header-only, type-safe, command line parser - which also prints format
 ### [Couchbase-lite-core](https://github.com/couchbase/couchbase-lite-core)
 The next-generation core storage and query engine for Couchbase Lite/
 
-### [Inja](ttps://github.com/pantor/inja)
+### [Inja](https://github.com/pantor/inja)
 A header-only template engine for modern C++.
 
 ### [JSON for Modern C++](https://github.com/nlohmann/json)


### PR DESCRIPTION
Add [Inja](https://github.com/pantor/inja) to the list of open source libraries using Catch2.
