### PR TITLE
performance improvements

### DIFF
--- a/include/internal/catch_context.cpp
+++ b/include/internal/catch_context.cpp
@@ -45,21 +45,16 @@ namespace Catch {
         IResultCapture* m_resultCapture = nullptr;
     };
 
-    namespace {
-        Context* currentContext = nullptr;
-    }
-    IMutableContext& getCurrentMutableContext() {
-        if( !currentContext )
-            currentContext = new Context();
-        return *currentContext;
-    }
-    IContext& getCurrentContext() {
-        return getCurrentMutableContext();
+    IMutableContext *IMutableContext::currentContext = nullptr;
+
+    void IMutableContext::createContext()
+    {
+        currentContext = new Context();
     }
 
     void cleanUpContext() {
-        delete currentContext;
-        currentContext = nullptr;
+        delete IMutableContext::currentContext;
+        IMutableContext::currentContext = nullptr;
     }
     IContext::~IContext() = default;
     IMutableContext::~IMutableContext() = default;

--- a/include/internal/catch_context.h
+++ b/include/internal/catch_context.h
@@ -15,6 +15,7 @@ namespace Catch {
     struct IResultCapture;
     struct IRunner;
     struct IConfig;
+    struct IMutableContext;
 
     using IConfigPtr = std::shared_ptr<IConfig const>;
 
@@ -33,10 +34,26 @@ namespace Catch {
         virtual void setResultCapture( IResultCapture* resultCapture ) = 0;
         virtual void setRunner( IRunner* runner ) = 0;
         virtual void setConfig( IConfigPtr const& config ) = 0;
+
+    private:
+        static IMutableContext *currentContext;
+        friend IMutableContext& getCurrentMutableContext();
+        friend void cleanUpContext();
+        static void createContext();
     };
 
-    IContext& getCurrentContext();
-    IMutableContext& getCurrentMutableContext();
+    inline IMutableContext& getCurrentMutableContext()
+    {
+        if( !IMutableContext::currentContext )
+            IMutableContext::createContext();
+        return *IMutableContext::currentContext;
+    }
+
+    inline IContext& getCurrentContext()
+    {
+        return getCurrentMutableContext();
+    }
+
     void cleanUpContext();
 }
 

--- a/include/internal/catch_stringref.cpp
+++ b/include/internal/catch_stringref.cpp
@@ -17,10 +17,6 @@
 
 namespace Catch {
 
-    auto StringRef::operator = ( StringRef other ) noexcept -> StringRef& {
-        swap( other );
-        return *this;
-    }
     StringRef::operator std::string() const {
         return std::string( m_start, m_size );
     }

--- a/include/internal/catch_stringref.h
+++ b/include/internal/catch_stringref.h
@@ -77,7 +77,14 @@ namespace Catch {
             delete[] m_data;
         }
 
-        auto operator = ( StringRef other ) noexcept -> StringRef&;
+        auto operator = ( StringRef const &other ) noexcept -> StringRef& {
+            delete[] m_data;
+            m_data = nullptr;
+            m_start = other.m_start;
+            m_size = other.m_size;
+            return *this;
+        }
+
         operator std::string() const;
 
         void swap( StringRef& other ) noexcept;


### PR DESCRIPTION
inlined StringRef::operator= and reduced data copy in half.
Brings test from 0m44.942s to 0m37.913.

inlined getCurrentContext and getMutableContext
Brings test from 0m37.913 to 0m25.584s
Catch2 is now faster than Catch 1.x!!
