### PR TITLE
performance improvement - isTrue, isFalseTest, SourceLineInfo ctor

### DIFF
--- a/include/internal/catch_assertionhandler.cpp
+++ b/include/internal/catch_assertionhandler.cpp
@@ -8,10 +8,8 @@
 
 #include "catch_assertionhandler.h"
 #include "catch_assertionresult.h"
-#include "catch_interfaces_capture.h"
 #include "catch_interfaces_runner.h"
 #include "catch_interfaces_config.h"
-#include "catch_context.h"
 #include "catch_debugger.h"
 #include "catch_interfaces_registry_hub.h"
 #include "catch_capture_matchers.h"
@@ -59,12 +57,6 @@ namespace Catch {
     :   m_assertionInfo{ macroName, lineInfo, capturedExpression, resultDisposition }
     {
         getCurrentContext().getResultCapture()->assertionStarting( m_assertionInfo );
-    }
-    AssertionHandler::~AssertionHandler() {
-        if ( m_inExceptionGuard ) {
-            handle( ResultWas::ThrewException, "Exception translation was disabled by CATCH_CONFIG_FAST_COMPILE" );
-            getCurrentContext().getResultCapture()->exceptionEarlyReported();
-        }
     }
 
     void AssertionHandler::handle( ITransientExpression const& expr ) {

--- a/include/internal/catch_assertionhandler.h
+++ b/include/internal/catch_assertionhandler.h
@@ -10,6 +10,8 @@
 
 #include "catch_decomposer.h"
 #include "catch_assertioninfo.h"
+#include "catch_context.h"
+#include "catch_interfaces_capture.h"
 
 namespace Catch {
 
@@ -44,7 +46,13 @@ namespace Catch {
                 SourceLineInfo const& lineInfo,
                 StringRef capturedExpression,
                 ResultDisposition::Flags resultDisposition );
-        ~AssertionHandler();
+        ~AssertionHandler()
+        {
+            if ( m_inExceptionGuard ) {
+                handle( ResultWas::ThrewException, "Exception translation was disabled by CATCH_CONFIG_FAST_COMPILE" );
+                getCurrentContext().getResultCapture()->exceptionEarlyReported();
+            }
+        }
 
         void handle( ITransientExpression const& expr );
 

--- a/include/internal/catch_common.cpp
+++ b/include/internal/catch_common.cpp
@@ -15,10 +15,6 @@
 
 namespace Catch {
 
-    SourceLineInfo::SourceLineInfo( char const* _file, std::size_t _line ) noexcept
-    :   file( _file ),
-        line( _line )
-    {}
     bool SourceLineInfo::empty() const noexcept {
         return file[0] == '\0';
     }
@@ -38,7 +34,6 @@ namespace Catch {
         return os;
     }
 
-    bool isTrue( bool value ){ return value; }
     bool alwaysTrue() { return true; }
     bool alwaysFalse() { return false; }
 

--- a/include/internal/catch_common.h
+++ b/include/internal/catch_common.h
@@ -43,7 +43,8 @@ namespace Catch {
     struct SourceLineInfo {
 
         SourceLineInfo() = delete;
-        SourceLineInfo( char const* _file, std::size_t _line ) noexcept;
+        SourceLineInfo( char const* _file, std::size_t _line ) noexcept
+        : file( _file ), line( _line ) {}
 
         SourceLineInfo( SourceLineInfo const& other )        = default;
         SourceLineInfo( SourceLineInfo && )                  = default;
@@ -61,7 +62,7 @@ namespace Catch {
     std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info );
 
     // This is just here to avoid compiler warnings with macro constants and boolean literals
-    bool isTrue( bool value );
+    inline bool isTrue( bool value ) { return value; }
     bool alwaysTrue();
     bool alwaysFalse();
 
@@ -82,4 +83,3 @@ namespace Catch {
     ::Catch::SourceLineInfo( __FILE__, static_cast<std::size_t>( __LINE__ ) )
 
 #endif // TWOBLUECUBES_CATCH_COMMON_H_INCLUDED
-

--- a/include/internal/catch_context.cpp
+++ b/include/internal/catch_context.cpp
@@ -20,7 +20,7 @@ namespace Catch {
             return m_runner;
         }
 
-        virtual IConfigPtr getConfig() const override {
+        virtual IConfigPtr const & getConfig() const override {
             return m_config;
         }
 

--- a/include/internal/catch_context.h
+++ b/include/internal/catch_context.h
@@ -25,7 +25,7 @@ namespace Catch {
 
         virtual IResultCapture* getResultCapture() = 0;
         virtual IRunner* getRunner() = 0;
-        virtual IConfigPtr getConfig() const = 0;
+        virtual IConfigPtr const & getConfig() const = 0;
     };
 
     struct IMutableContext : IContext

--- a/include/internal/catch_result_type.cpp
+++ b/include/internal/catch_result_type.cpp
@@ -22,7 +22,6 @@ namespace Catch {
     }
 
     bool shouldContinueOnFailure( int flags )    { return ( flags & ResultDisposition::ContinueOnFailure ) != 0; }
-    bool isFalseTest( int flags )                { return ( flags & ResultDisposition::FalseTest ) != 0; }
     bool shouldSuppressFailure( int flags )      { return ( flags & ResultDisposition::SuppressFail ) != 0; }
 
 } // end namespace Catch

--- a/include/internal/catch_result_type.h
+++ b/include/internal/catch_result_type.h
@@ -47,7 +47,7 @@ namespace Catch {
     ResultDisposition::Flags operator | ( ResultDisposition::Flags lhs, ResultDisposition::Flags rhs );
 
     bool shouldContinueOnFailure( int flags );
-    bool isFalseTest( int flags );
+    inline bool isFalseTest( int flags ) { return ( flags & ResultDisposition::FalseTest ) != 0; }
     bool shouldSuppressFailure( int flags );
 
 } // end namespace Catch


### PR DESCRIPTION
inlined isTrue, isFalseTest and SourceLineInfo ctor.

Brings test from 0m25.584s to 0m20.635s

inlined ~AssertionHandler(), and changed getConfig to return
shared_ptr const reference instead of by value (very expensive for
shared_ptr's).

Brings test from 0m20.635s to 0m17.186s

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
