### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.0)
 
 project(CatchSelfTest)
 
+include(GNUInstallDirs)
+
 option(USE_VALGRIND "Perform SelfTests with Valgrind" OFF)
 option(BUILD_EXAMPLES "Build documentation examples" OFF)
 option(ENABLE_COVERAGE "Generate coverage for codecov.io" OFF)
@@ -366,14 +368,14 @@ if(BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-install(DIRECTORY "single_include/" DESTINATION "include/catch")
+install(DIRECTORY "single_include/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/catch")
 
 ## Provide some pkg-config integration
 # Don't bother on Windows
 if(NOT WIN32 OR NOT CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
 
     set(PKGCONFIG_INSTALL_DIR
-        "${CMAKE_INSTALL_PREFIX}/share/pkgconfig"
+        "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig"
         CACHE PATH "Path where catch.pc is installed"
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,8 @@ endif()
 
 install(DIRECTORY "single_include/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/catch")
 
+install(DIRECTORY docs/ DESTINATION "${CMAKE_INSTALL_DOCDIR}")
+
 ## Provide some pkg-config integration
 # Don't bother on Windows
 if(NOT WIN32 OR NOT CMAKE_HOST_SYSTEM_NAME MATCHES Windows)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT DEFINED PROJECT_NAME)
   set(NOT_SUBPROJECT ON)
 endif()
 
-project(CatchSelfTest)
+project(Catch2)
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.0)
 
+# detect if Catch is being bundled,
+# disable testsuite in that case
+if(NOT DEFINED PROJECT_NAME)
+  set(NOT_SUBPROJECT ON)
+endif()
+
 project(CatchSelfTest)
 
 include(GNUInstallDirs)
@@ -287,7 +293,19 @@ SOURCE_GROUP("Surrogates" FILES ${SURROGATE_SOURCES})
 
 # Projects consuming Catch via ExternalProject_Add might want to use install step
 # without building all of our selftests.
-if (NOT NO_SELFTEST)
+
+if(DEFINED NO_SELFTEST)
+    message(DEPRECATION "*** CMake option NO_SELFTEST is deprecated; use BUILD_TESTING instead")
+    if (NO_SELFTEST)
+        set(BUILD_TESTING OFF CACHE BOOL "Disable Catch2 internal testsuite" FORCE)
+    else()
+        set(BUILD_TESTING ON CACHE BOOL "Disable Catch2 internal testsuite" FORCE)
+    endif()
+endif()
+
+include(CTest)
+
+if (BUILD_TESTING AND NOT_SUBPROJECT)
     add_executable(SelfTest ${TEST_SOURCES} ${IMPL_SOURCES} ${REPORTER_SOURCES} ${SURROGATE_SOURCES} ${HEADERS})
     target_include_directories(SelfTest PRIVATE ${HEADER_DIR})
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ before_build:
 
 # build with MSBuild
 build:
-  project: Build\CatchSelfTest.sln      # path to Visual Studio solution or project
+  project: Build\Catch2.sln             # path to Visual Studio solution or project
   parallel: true                        # enable MSBuild parallel builds
   verbosity: normal                     # MSBuild verbosity level {quiet|minimal|normal|detailed}
 

--- a/catch.pc.in
+++ b/catch.pc.in
@@ -1,9 +1,6 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: Catch
 Description: Testing library for C++
-Requires:
 Version: @CATCH_VERSION_NUMBER@
-Libs:
-Cflags: -I${prefix}/@INCLUDE_INSTALL_DIR@/include
+Cflags: -I${includedir}


### PR DESCRIPTION
1. Do not build tests with `-Werror` by default
  `-Werror` is good for CI testing but causes massive integrations issues, as compilers add warnings that developers cannot foresee. See also:
    - https://bugs.gentoo.org/644354
    - https://blog.flameeyes.eu/2009/02/future-proof-your-code-dont-use-werror/
2. Install documentation
3. Use CTest to control test suite via `BUILD_TESTING`. The `CTest` module, like `GNUInstallDirs`, provides an idiomatic way to enable and disable the testsuite.
4. Use `GNUInstallDirs` module
  `GNUInstallDirs` is a standardised way to change paths, which makes systems integration easier and allows for a more consistent user experience.