### PR TITLE
More CMake fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -204,7 +204,7 @@ before_script:
 
   - |
     # Use Debug builds for running Valgrind and building examples
-    cmake -H. -BBuild-Debug -DCMAKE_BUILD_TYPE=Debug -Wdev -DUSE_CPP14=${CPP14} -DUSE_VALGRIND=${VALGRIND} -DBUILD_EXAMPLES=ON -DENABLE_COVERAGE=ON
+    cmake -H. -BBuild-Debug -DCMAKE_BUILD_TYPE=Debug -Wdev -DUSE_CPP14=${CPP14} -DCATCH_USE_VALGRIND=${VALGRIND} -DCATCH_BUILD_EXAMPLES=ON -DCATCH_ENABLE_COVERAGE=ON
     # Don't bother with release build for coverage build
     cmake -H. -BBuild-Release -DCMAKE_BUILD_TYPE=Release -Wdev -DUSE_CPP14=${CPP14}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,10 @@ project(Catch2 LANGUAGES CXX VERSION 2.1.0)
 
 include(GNUInstallDirs)
 
-option(USE_VALGRIND "Perform SelfTests with Valgrind" OFF)
-option(BUILD_EXAMPLES "Build documentation examples" OFF)
-option(ENABLE_COVERAGE "Generate coverage for codecov.io" OFF)
-option(DISABLE_WERROR "Do not enable warnings as errors" OFF)
+option(CATCH_USE_VALGRIND "Perform SelfTests with Valgrind" OFF)
+option(CATCH_BUILD_EXAMPLES "Build documentation examples" OFF)
+option(CATCH_ENABLE_COVERAGE "Generate coverage for codecov.io" OFF)
+option(CATCH_ENABLE_WERROR "Enable all warnings as errors" ON)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -319,7 +319,8 @@ if (BUILD_TESTING AND NOT_SUBPROJECT)
     set_property(TARGET SelfTest PROPERTY CXX_STANDARD_REQUIRED ON)
     set_property(TARGET SelfTest PROPERTY CXX_EXTENSIONS OFF)
 
-    if (ENABLE_COVERAGE)
+    if (CATCH_ENABLE_COVERAGE)
+        set(ENABLE_COVERAGE ON CACHE BOOL "Enable coverage build." FORCE)
         list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")
         find_package(codecov)
         add_coverage(SelfTest)
@@ -330,7 +331,7 @@ if (BUILD_TESTING AND NOT_SUBPROJECT)
     # Add desired warnings
     if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU" )
         target_compile_options( SelfTest PRIVATE -Wall -Wextra -Wunreachable-code )
-        if (NOT DISABLE_WERROR)
+        if (CATCH_ENABLE_WERROR)
             target_compile_options( SelfTest PRIVATE -Werror)
         endif()
     endif()
@@ -342,7 +343,7 @@ if (BUILD_TESTING AND NOT_SUBPROJECT)
     if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
 		STRING(REGEX REPLACE "/W[0-9]" "/W4" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}) # override default warning level
         target_compile_options( SelfTest PRIVATE /w44265 /w44061 /w44062 )
-        if (NOT DISABLE_WERROR)
+        if (CATCH_ENABLE_WERROR)
             target_compile_options( SelfTest PRIVATE /WX)
         endif()
     endif()
@@ -370,7 +371,7 @@ if (BUILD_TESTING AND NOT_SUBPROJECT)
     add_test(NAME ApprovalTests COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/scripts/approvalTests.py $<TARGET_FILE:SelfTest>)
     set_tests_properties(ApprovalTests PROPERTIES FAIL_REGULAR_EXPRESSION "Results differed")
 
-    if (USE_VALGRIND)
+    if (CATCH_USE_VALGRIND)
         add_test(NAME ValgrindRunTests COMMAND valgrind --leak-check=full --error-exitcode=1 $<TARGET_FILE:SelfTest>)
         add_test(NAME ValgrindListTests COMMAND valgrind --leak-check=full --error-exitcode=1 $<TARGET_FILE:SelfTest> --list-tests --verbosity high)
         set_tests_properties(ValgrindListTests PROPERTIES PASS_REGULAR_EXPRESSION "definitely lost: 0 bytes in 0 blocks")
@@ -381,7 +382,7 @@ if (BUILD_TESTING AND NOT_SUBPROJECT)
 endif() # !NO_SELFTEST
 
 
-if(BUILD_EXAMPLES)
+if(CATCH_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT DEFINED PROJECT_NAME)
   set(NOT_SUBPROJECT ON)
 endif()
 
-project(Catch2)
+project(Catch2 LANGUAGES CXX VERSION 2.1.0)
 
 include(GNUInstallDirs)
 
@@ -22,7 +22,6 @@ set(CATCH_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(SELF_TEST_DIR ${CATCH_DIR}/projects/SelfTest)
 set(BENCHMARK_DIR ${CATCH_DIR}/projects/Benchmark)
 set(HEADER_DIR ${CATCH_DIR}/include)
-set(CATCH_VERSION_NUMBER 2.1.0)
 
 if(USE_WMAIN)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ENTRY:wmainCRTStartup")

--- a/catch.pc.in
+++ b/catch.pc.in
@@ -2,5 +2,5 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: Catch
 Description: Testing library for C++
-Version: @CATCH_VERSION_NUMBER@
+Version: @Catch2_VERSION@
 Cflags: -I${includedir}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Build examples.
 #
-# Requires BUILD_EXAMPLES to be defined 'true', see ../CMakeLists.txt.
+# Requires CATCH_BUILD_EXAMPLES to be defined 'true', see ../CMakeLists.txt.
 #
 
 cmake_minimum_required( VERSION 3.0 )

--- a/misc/appveyorBuildConfigurationScript.bat
+++ b/misc/appveyorBuildConfigurationScript.bat
@@ -6,7 +6,7 @@ if "%CONFIGURATION%"=="Debug" (
   python scripts\generateSingleHeader.py
   cmake -Hmisc -Bbuild-misc -A%PLATFORM%
   cmake --build build-misc
-  cmake -H. -BBuild -A%PLATFORM% -DUSE_WMAIN=%wmain% -DBUILD_EXAMPLES=ON -DMEMORYCHECK_COMMAND=build-misc\Debug\CoverageHelper.exe -DMEMORYCHECK_COMMAND_OPTIONS=--sep-- -DMEMORYCHECK_TYPE=Valgrind
+  cmake -H. -BBuild -A%PLATFORM% -DUSE_WMAIN=%wmain% -DCATCH_BUILD_EXAMPLES=ON -DMEMORYCHECK_COMMAND=build-misc\Debug\CoverageHelper.exe -DMEMORYCHECK_COMMAND_OPTIONS=--sep-- -DMEMORYCHECK_TYPE=Valgrind
 )
 if "%CONFIGURATION%"=="Release" (
   cmake -H. -BBuild -A%PLATFORM% -DUSE_WMAIN=%wmain%

--- a/scripts/releaseCommon.py
+++ b/scripts/releaseCommon.py
@@ -128,13 +128,12 @@ def updateConanTestFile(version):
         f.write( line + "\n" )
 
 def updateCmakeFile(version):
-    cmakeParser = re.compile(r'set(CATCH_VERSION_NUMBER \d+\.\d+\.\d+)')
     with open(cmakePath, 'r') as file:
         lines = file.readlines()
     with open(cmakePath, 'w') as file:
         for line in lines:
-            if 'set(CATCH_VERSION_NUMBER ' in line:
-                file.write('set(CATCH_VERSION_NUMBER {0})\n'.format(version.getVersionString()))
+            if 'project(Catch2 LANGUAGES CXX VERSION ' in line:
+                file.write('project(Catch2 LANGUAGES CXX VERSION {0})\n'.format(version.getVersionString()))
             else:
                 file.write(line)
 


### PR DESCRIPTION
1. Use `VERSION` specifier in `project()`. This is the modern idiomatic CMake way of specifying the version, for instance see https://rix0r.nl/blog/2015/08/13/cmake-guide/. All regexes for the build scripts have been updated.
2. Namespace all Catch options as suggested by @martinmoene 