### PR TITLE
Fixing clara Opt namespace

### DIFF
--- a/docs/own-main.md
+++ b/docs/own-main.md
@@ -83,9 +83,9 @@ int main( int argc, char* argv[] )
   // Build a new parser on top of Catch's
   auto cli 
     = session.cli() // Get Catch's composite command line parser
-    | Opt( height, "height" ) // bind variable to a new option, with a hint string
-        ["-g"]["--height"]    // the option names it will respond to
-        ("how high?");        // description string for the help output
+    | Catch::clara::Opt( height, "height" ) // bind variable to a new option, with a hint string
+                      ["-g"]["--height"]      // the option names it will respond to
+                      ("how high?");          // description string for the help output
         
   // Now pass the new composite back to Catch so it uses that
   session.cli( cli ); 


### PR DESCRIPTION
Opt is under namespace Catch::clara

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
When following the guide of "Adding your own command line options", the compiler reports error of not declaring `Opt`. It is under namespace `Catch::clara`, however, this doc does not reflect that. To fix, either add a line of `using Catch::clara::Opt;` or add `Catch::clara::` directly before `Opt`. For the sake of simplicity, I added the namespace prefix inline before `Opt`.



## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
Not opened.