### PR TITLE
N4152 C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,7 @@ set(INTERNAL_HEADERS
         ${HEADER_DIR}/internal/catch_timer.h
         ${HEADER_DIR}/internal/catch_tostring.h
         ${HEADER_DIR}/internal/catch_totals.h
+        ${HEADER_DIR}/internal/catch_uncaught_exceptions.h
         ${HEADER_DIR}/internal/catch_user_interfaces.h
         ${HEADER_DIR}/internal/catch_version.h
         ${HEADER_DIR}/internal/catch_wildcard_pattern.h
@@ -247,6 +248,7 @@ set(IMPL_SOURCES
         ${HEADER_DIR}/internal/catch_timer.cpp
         ${HEADER_DIR}/internal/catch_tostring.cpp
         ${HEADER_DIR}/internal/catch_totals.cpp
+        ${HEADER_DIR}/internal/catch_uncaught_exceptions.cpp
         ${HEADER_DIR}/internal/catch_version.cpp
         ${HEADER_DIR}/internal/catch_wildcard_pattern.cpp
         ${HEADER_DIR}/internal/catch_xmlwriter.cpp

--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -31,6 +31,14 @@
 #    define CATCH_CPP14_OR_GREATER
 #  endif
 
+#  if __cplusplus >= 201703L
+#    define CATCH_CPP17_OR_GREATER
+#  endif
+
+#endif
+
+#if defined(CATCH_CPP17_OR_GREATER)
+#  define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
 #endif
 
 #ifdef __clang__
@@ -80,6 +88,11 @@
 // Visual C++
 #ifdef _MSC_VER
 
+
+#  if _MSC_VER >= 1900 // Visual Studio 2015 or newer
+#    define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
+#  endif
+
 // Universal Windows platform does not support SEH
 // Or console colours (or console at all...)
 #  if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
@@ -111,6 +124,11 @@
 #if !defined(CATCH_INTERNAL_CONFIG_NO_POSIX_SIGNALS) && !defined(CATCH_CONFIG_NO_POSIX_SIGNALS) && !defined(CATCH_CONFIG_POSIX_SIGNALS)
 #   define CATCH_CONFIG_POSIX_SIGNALS
 #endif
+
+#if defined(CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS) && !defined(CATCH_INTERNAL_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS) && !defined(CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
+#  define CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
+#endif
+
 
 #if !defined(CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS)
 #   define CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS

--- a/include/internal/catch_message.cpp
+++ b/include/internal/catch_message.cpp
@@ -8,6 +8,7 @@
 
 #include "catch_message.h"
 #include "catch_interfaces_capture.h"
+#include "catch_uncaught_exceptions.h"
 
 namespace Catch {
 
@@ -49,18 +50,9 @@ namespace Catch {
         getResultCapture().pushScopedMessage( m_info );
     }
 
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable:4996) // std::uncaught_exception is deprecated in C++17
-#endif
     ScopedMessage::~ScopedMessage() {
-        if ( !std::uncaught_exception() ){
+        if ( !uncaught_exceptions() ){
             getResultCapture().popScopedMessage(m_info);
         }
     }
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
-
-
 } // end namespace Catch

--- a/include/internal/catch_section.cpp
+++ b/include/internal/catch_section.cpp
@@ -8,6 +8,7 @@
 
 #include "catch_section.h"
 #include "catch_capture.hpp"
+#include "catch_uncaught_exceptions.h"
 
 namespace Catch {
 
@@ -18,22 +19,15 @@ namespace Catch {
         m_timer.start();
     }
 
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable:4996) // std::uncaught_exception is deprecated in C++17
-#endif
     Section::~Section() {
         if( m_sectionIncluded ) {
             SectionEndInfo endInfo( m_info, m_assertions, m_timer.getElapsedSeconds() );
-            if( std::uncaught_exception() )
+            if( uncaught_exceptions() )
                 getResultCapture().sectionEndedEarly( endInfo );
             else
                 getResultCapture().sectionEnded( endInfo );
         }
     }
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 
     // This indicates whether the section should be executed or not
     Section::operator bool() const {

--- a/include/internal/catch_uncaught_exceptions.cpp
+++ b/include/internal/catch_uncaught_exceptions.cpp
@@ -1,0 +1,22 @@
+/*
+ *  Created by Josh on 1/2/2018.
+ *  Copyright 2018 Two Blue Cubes Ltd. All rights reserved.
+ *
+ *  Distributed under the Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#include "catch_compiler_capabilities.h"
+#include "catch_uncaught_exceptions.h"
+#include <exception>
+
+namespace Catch {
+    bool uncaught_exceptions() {
+// https://github.com/catchorg/Catch2/issues/1162
+#if defined(CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
+        return std::uncaught_exceptions() > 0;
+#else
+        return std::uncaught_exception();
+#endif
+  }
+} // end namespace Catch

--- a/include/internal/catch_uncaught_exceptions.h
+++ b/include/internal/catch_uncaught_exceptions.h
@@ -1,0 +1,15 @@
+/*
+ *  Created by Josh on 1/2/2018.
+ *  Copyright 2018 Two Blue Cubes Ltd. All rights reserved.
+ *
+ *  Distributed under the Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+#ifndef TWOBLUECUBES_CATCH_UNCAUGHT_EXCEPTIONS_H_INCLUDED
+#define TWOBLUECUBES_CATCH_UNCAUGHT_EXCEPTIONS_H_INCLUDED
+
+namespace Catch {
+    bool uncaught_exceptions();
+} // end namespace Catch
+
+#endif // TWOBLUECUBES_CATCH_UNCAUGHT_EXCEPTIONS_H_INCLUDED


### PR DESCRIPTION
## Description
[N4152](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4152.pdf) deprecates `std::uncaught_exception`.

## GitHub Issues
A minimal patch satisfying #1162 , although I am unclear whether or how to support older compilers here. (cf. #927 )
