### PR TITLE
Export catch as cmake package and as a 'linkable' target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 # detect if Catch is being bundled,
 # disable testsuite in that case
@@ -403,3 +403,37 @@ if(NOT WIN32 OR NOT CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/catch.pc DESTINATION ${PKGCONFIG_INSTALL_DIR})
 
 endif()
+
+# add catch as a 'linkable' target
+add_library(Catch INTERFACE)
+
+# depend on some obvious c++11 features so the dependency is transitively added dependants
+target_compile_features(Catch INTERFACE cxx_auto_type cxx_constexpr cxx_noexcept)
+
+target_include_directories(Catch
+	INTERFACE
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/single_include>
+		$<INSTALL_INTERFACE:include/catch>
+		$<INSTALL_INTERFACE:include>)
+
+# provide a namespaced alias for clients to 'link' against if catch is included as a sub-project
+add_library(Catch2::Catch ALIAS Catch)
+
+set(CATCH_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Catch2")
+
+# create and install an export set for catch target as Catch2::Catch
+install(TARGETS Catch EXPORT Catch2Config DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(EXPORT Catch2Config
+	NAMESPACE Catch2::
+	DESTINATION ${CATCH_CMAKE_CONFIG_DESTINATION})
+
+# install Catch2ConfigVersion.cmake file to handle versions in find_package
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(Catch2ConfigVersion.cmake
+	COMPATIBILITY SameMajorVersion)
+
+install(FILES
+	"${CMAKE_BINARY_DIR}/Catch2ConfigVersion.cmake"
+	DESTINATION ${CATCH_CMAKE_CONFIG_DESTINATION})


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
Create a namespaced catch::catch target that is 'linkable' through
`target_link_libraries()` and export it so it is findable through
`find_package()`.

This makes catch a lot easier to use in CMake-based projects. Whether it
is found using `find_package` or included in the client project as a
subdirectory, the client can include the catch headers per-target with
`target_include_directories(target PRIVATE catch::catch).

Also exported is a catch-config-version.cmake file that handles
versions if specified through `find_package(catch 2.1.1 REQUIRED)`.
It will find versions with the exact same major number and with a minor
number >= specified minor number.

LIMITATIONS: As catch.hpp is stored inside the single_include directory,
but installed to include/catch, the `#include` directive changes based
on whether catch is a subdirectory or installed package.

    subdirectory: `#include <catch.hpp>` or `#include "catch.hpp"`
    packaged:     `#include <catch/catch.hpp>`

This could be resolved if catch.hpp was moved into single_include/catch,
but I'll leave that decision to someone else.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
