### PR TITLE
the file Catch2ConfigVersion.cmake is contained in ${CMAKE_CURRENT_BI…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,9 +434,10 @@ install(EXPORT Catch2Config
 # install Catch2ConfigVersion.cmake file to handle versions in find_package
 include(CMakePackageConfigHelpers)
 
-write_basic_package_version_file(Catch2ConfigVersion.cmake
+write_basic_package_version_file(
+	"${CMAKE_CURRENT_BINARY_DIR}/Catch2ConfigVersion.cmake"
 	COMPATIBILITY SameMajorVersion)
 
 install(FILES
-	"${CMAKE_BINARY_DIR}/Catch2ConfigVersion.cmake"
+	"${CMAKE_CURRENT_BINARY_DIR}/Catch2ConfigVersion.cmake"
 	DESTINATION ${CATCH_CMAKE_CONFIG_DESTINATION})


### PR DESCRIPTION

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
The file Catch2ConfigVersion.cmake is contained in ${CMAKE_CURRENT_BINARY_DIR} and not always in ${CMAKE_CURRENT_DIR}.
Changed the install location to ${CMAKE_CURRENT_BINARY_DIR}
