### PR TITLE
Fix 'defined but not used' warning

### DIFF
--- a/include/internal/catch_fatal_condition.cpp
+++ b/include/internal/catch_fatal_condition.cpp
@@ -17,12 +17,16 @@
 #    pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#if defined( CATCH_CONFIG_WINDOWS_SEH ) || defined( CATCH_CONFIG_POSIX_SIGNALS )
+
 namespace {
     // Report the error condition
     void reportFatal( char const * const message ) {
         Catch::getCurrentContext().getResultCapture()->handleFatalErrorCondition( message );
     }
 }
+
+#endif // signals/SEH handling
 
 #if defined( CATCH_CONFIG_WINDOWS_SEH )
 


### PR DESCRIPTION
The warning occurred when !CATCH_CONFIG_WINDOWS_SEH && !CATCH_CONFIG_POSIX_SIGNALS which is the case in my setup.