### PR TITLE
Fix clang-tidy 6 diagnostic about virtual call in destructor

### DIFF
--- a/include/internal/catch_run_context.h
+++ b/include/internal/catch_run_context.h
@@ -99,7 +99,7 @@ namespace Catch {
 
     public:
         // !TBD We need to do this another way!
-        bool aborting() const override;
+        bool aborting() const final;
 
     private:
 


### PR DESCRIPTION
## Description
The newest clang-tidy reports an issue within catch: the issue is in the main function (`Canch::Session().run(argc,argv)`), but it can only be suppressed in the catch source.

The warning is that the `RunContext` class calls `aborting()` in its destructor, which is virtual.

As nothing derives from `RunContext`, I changed the `override` specifier to `final`.