### PR TITLE
fix typo in WithinAbs::match() and add selftests that would have failed previously

### DIFF
--- a/include/internal/catch_matchers_floating.cpp
+++ b/include/internal/catch_matchers_floating.cpp
@@ -88,7 +88,7 @@ namespace Floating {
     // Performs equivalent check of std::fabs(lhs - rhs) <= margin
     // But without the subtraction to allow for INFINITY in comparison
     bool WithinAbsMatcher::match(double const& matchee) const {
-        return (matchee + m_margin >= m_target) && (m_target + m_margin >= m_margin);
+        return (matchee + m_margin >= m_target) && (m_target + m_margin >= matchee);
     }
 
     std::string WithinAbsMatcher::describe() const {

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -235,6 +235,10 @@ Matchers.tests.cpp:<line number>: passed: 0., WithinAbs(1., 1) for: 0.0 is withi
 Matchers.tests.cpp:<line number>: passed: 0., !WithinAbs(1., 0.99) for: 0.0 not is within 0.99 of 1.0
 Matchers.tests.cpp:<line number>: passed: 0., !WithinAbs(1., 0.99) for: 0.0 not is within 0.99 of 1.0
 Matchers.tests.cpp:<line number>: passed: NAN, !WithinAbs(NAN, 0) for: nanf not is within 0.0 of nan
+Matchers.tests.cpp:<line number>: passed: 11., !WithinAbs(10., 0.5) for: 11.0 not is within 0.5 of 10.0
+Matchers.tests.cpp:<line number>: passed: 10., !WithinAbs(11., 0.5) for: 10.0 not is within 0.5 of 11.0
+Matchers.tests.cpp:<line number>: passed: -10., WithinAbs(-10., 0.5) for: -10.0 is within 0.5 of -10.0
+Matchers.tests.cpp:<line number>: passed: -10., WithinAbs(-9.6, 0.5) for: -10.0 is within 0.5 of -9.6
 Matchers.tests.cpp:<line number>: passed: 1., WithinULP(1., 0) for: 1.0 is within 0 ULPs of 1.0
 Matchers.tests.cpp:<line number>: passed: nextafter(1., 2.), WithinULP(1., 1) for: 1.0 is within 1 ULPs of 1.0
 Matchers.tests.cpp:<line number>: passed: nextafter(1., 0.), WithinULP(1., 1) for: 1.0 is within 1 ULPs of 1.0
@@ -255,6 +259,10 @@ Matchers.tests.cpp:<line number>: passed: 0.f, !WithinAbs(1.f, 0.99f) for: 0.0f 
 Matchers.tests.cpp:<line number>: passed: 0.f, !WithinAbs(1.f, 0.99f) for: 0.0f not is within 0.9900000095 of 1.0
 Matchers.tests.cpp:<line number>: passed: 0.f, WithinAbs(-0.f, 0) for: 0.0f is within 0.0 of -0.0
 Matchers.tests.cpp:<line number>: passed: NAN, !WithinAbs(NAN, 0) for: nanf not is within 0.0 of nan
+Matchers.tests.cpp:<line number>: passed: 11.f, !WithinAbs(10.f, 0.5f) for: 11.0f not is within 0.5 of 10.0
+Matchers.tests.cpp:<line number>: passed: 10.f, !WithinAbs(11.f, 0.5f) for: 10.0f not is within 0.5 of 11.0
+Matchers.tests.cpp:<line number>: passed: -10.f, WithinAbs(-10.f, 0.5f) for: -10.0f is within 0.5 of -10.0
+Matchers.tests.cpp:<line number>: passed: -10.f, WithinAbs(-9.6f, 0.5f) for: -10.0f is within 0.5 of -9.6000003815
 Matchers.tests.cpp:<line number>: passed: 1.f, WithinULP(1.f, 0) for: 1.0f is within 0 ULPs of 1.0f
 Matchers.tests.cpp:<line number>: passed: nextafter(1.f, 2.f), WithinULP(1.f, 1) for: 1.0f is within 1 ULPs of 1.0f
 Matchers.tests.cpp:<line number>: passed: nextafter(1.f, 0.f), WithinULP(1.f, 1) for: 1.0f is within 1 ULPs of 1.0f

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -1085,5 +1085,5 @@ due to unexpected exception with message:
 
 ===============================================================================
 test cases:  202 | 149 passed |  49 failed |  4 failed as expected
-assertions: 1007 | 879 passed | 107 failed | 21 failed as expected
+assertions: 1015 | 887 passed | 107 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -1858,6 +1858,30 @@ PASSED:
 with expansion:
   nanf not is within 0.0 of nan
 
+Matchers.tests.cpp:<line number>:
+PASSED:
+  REQUIRE_THAT( 11., !WithinAbs(10., 0.5) )
+with expansion:
+  11.0 not is within 0.5 of 10.0
+
+Matchers.tests.cpp:<line number>:
+PASSED:
+  REQUIRE_THAT( 10., !WithinAbs(11., 0.5) )
+with expansion:
+  10.0 not is within 0.5 of 11.0
+
+Matchers.tests.cpp:<line number>:
+PASSED:
+  REQUIRE_THAT( -10., WithinAbs(-10., 0.5) )
+with expansion:
+  -10.0 is within 0.5 of -10.0
+
+Matchers.tests.cpp:<line number>:
+PASSED:
+  REQUIRE_THAT( -10., WithinAbs(-9.6, 0.5) )
+with expansion:
+  -10.0 is within 0.5 of -9.6
+
 -------------------------------------------------------------------------------
 Floating point matchers: double
   ULPs
@@ -1997,6 +2021,30 @@ PASSED:
   REQUIRE_THAT( NAN, !WithinAbs(NAN, 0) )
 with expansion:
   nanf not is within 0.0 of nan
+
+Matchers.tests.cpp:<line number>:
+PASSED:
+  REQUIRE_THAT( 11.f, !WithinAbs(10.f, 0.5f) )
+with expansion:
+  11.0f not is within 0.5 of 10.0
+
+Matchers.tests.cpp:<line number>:
+PASSED:
+  REQUIRE_THAT( 10.f, !WithinAbs(11.f, 0.5f) )
+with expansion:
+  10.0f not is within 0.5 of 11.0
+
+Matchers.tests.cpp:<line number>:
+PASSED:
+  REQUIRE_THAT( -10.f, WithinAbs(-10.f, 0.5f) )
+with expansion:
+  -10.0f is within 0.5 of -10.0
+
+Matchers.tests.cpp:<line number>:
+PASSED:
+  REQUIRE_THAT( -10.f, WithinAbs(-9.6f, 0.5f) )
+with expansion:
+  -10.0f is within 0.5 of -9.6000003815
 
 -------------------------------------------------------------------------------
 Floating point matchers: float
@@ -8551,5 +8599,5 @@ PASSED:
 
 ===============================================================================
 test cases:  202 | 136 passed |  62 failed |  4 failed as expected
-assertions: 1021 | 879 passed | 121 failed | 21 failed as expected
+assertions: 1029 | 887 passed | 121 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="105" tests="1022" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="105" tests="1030" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <testcase classname="<exe-name>.global" name="# A test name that starts with a #" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1005: Comparing pointer to int and long (NULL can be either on various systems)" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1027" time="{duration}"/>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -2108,7 +2108,39 @@
             nanf not is within 0.0 of nan
           </Expanded>
         </Expression>
-        <OverallResults successes="5" failures="0" expectedFailures="0"/>
+        <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            11., !WithinAbs(10., 0.5)
+          </Original>
+          <Expanded>
+            11.0 not is within 0.5 of 10.0
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            10., !WithinAbs(11., 0.5)
+          </Original>
+          <Expanded>
+            10.0 not is within 0.5 of 11.0
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            -10., WithinAbs(-10., 0.5)
+          </Original>
+          <Expanded>
+            -10.0 is within 0.5 of -10.0
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            -10., WithinAbs(-9.6, 0.5)
+          </Original>
+          <Expanded>
+            -10.0 is within 0.5 of -9.6
+          </Expanded>
+        </Expression>
+        <OverallResults successes="9" failures="0" expectedFailures="0"/>
       </Section>
       <Section name="ULPs" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
         <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
@@ -2283,7 +2315,39 @@
             nanf not is within 0.0 of nan
           </Expanded>
         </Expression>
-        <OverallResults successes="6" failures="0" expectedFailures="0"/>
+        <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            11.f, !WithinAbs(10.f, 0.5f)
+          </Original>
+          <Expanded>
+            11.0f not is within 0.5 of 10.0
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            10.f, !WithinAbs(11.f, 0.5f)
+          </Original>
+          <Expanded>
+            10.0f not is within 0.5 of 11.0
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            -10.f, WithinAbs(-10.f, 0.5f)
+          </Original>
+          <Expanded>
+            -10.0f is within 0.5 of -10.0
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            -10.f, WithinAbs(-9.6f, 0.5f)
+          </Original>
+          <Expanded>
+            -10.0f is within 0.5 of -9.6000003815
+          </Expanded>
+        </Expression>
+        <OverallResults successes="10" failures="0" expectedFailures="0"/>
       </Section>
       <Section name="ULPs" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
         <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
@@ -9405,7 +9469,7 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="879" failures="122" expectedFailures="21"/>
+    <OverallResults successes="887" failures="122" expectedFailures="21"/>
   </Group>
-  <OverallResults successes="879" failures="121" expectedFailures="21"/>
+  <OverallResults successes="887" failures="121" expectedFailures="21"/>
 </Catch>

--- a/projects/SelfTest/UsageTests/Matchers.tests.cpp
+++ b/projects/SelfTest/UsageTests/Matchers.tests.cpp
@@ -321,6 +321,11 @@ namespace { namespace MatchersTests {
 
                 REQUIRE_THAT(0.f, WithinAbs(-0.f, 0));
                 REQUIRE_THAT(NAN, !WithinAbs(NAN, 0));
+
+                REQUIRE_THAT(11.f, !WithinAbs(10.f, 0.5f));
+                REQUIRE_THAT(10.f, !WithinAbs(11.f, 0.5f));
+                REQUIRE_THAT(-10.f, WithinAbs(-10.f, 0.5f));
+                REQUIRE_THAT(-10.f, WithinAbs(-9.6f, 0.5f));
             }
             SECTION("ULPs") {
                 REQUIRE_THAT(1.f, WithinULP(1.f, 0));
@@ -358,6 +363,11 @@ namespace { namespace MatchersTests {
                 REQUIRE_THAT(0., !WithinAbs(1., 0.99));
 
                 REQUIRE_THAT(NAN, !WithinAbs(NAN, 0));
+
+                REQUIRE_THAT(11., !WithinAbs(10., 0.5));
+                REQUIRE_THAT(10., !WithinAbs(11., 0.5));
+                REQUIRE_THAT(-10., WithinAbs(-10., 0.5));
+                REQUIRE_THAT(-10., WithinAbs(-9.6, 0.5));
             }
             SECTION("ULPs") {
                 REQUIRE_THAT(1., WithinULP(1., 0));


### PR DESCRIPTION
## Description
I encountered a condition in `WithinAbs()` that should not fail from my understanding of that feature.
Looking into the code, I believe I found the issue.

Added a few selftests that would have pointed out this problem before the fix.

Obviously `approvalTests.py` fails and reports theses new tests but guess I'm not supposed to approve these differences.
