### PR TITLE
Small fix to generate pc with all include path

### DIFF
--- a/catch.pc.in
+++ b/catch.pc.in
@@ -3,4 +3,4 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: Catch
 Description: Testing library for C++
 Version: @Catch2_VERSION@
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/catch


### PR DESCRIPTION
In CMake module both include and include/catch are added to includes
lookup path. Examples are built with #include "catch.hpp" not #include "catch/catch.hpp". 
This should be the same with pkg-config.
Fixing pc file would ease Catch2 use from build systems like [Meson](http://mesonbuild.com/index.html).
