### PR TITLE
Support for parenthesizing types with commas.

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -6,6 +6,7 @@
 [Exceptions](#exceptions)<br>
 [Matcher expressions](#matcher-expressions)<br>
 [Thread Safety](#thread-safety)<br>
+[Expressions with commas](#expressions-with-commas)<br>
 
 Most test frameworks have a large collection of assertion macros to capture all possible conditional forms (```_EQUALS```, ```_NOTEQUALS```, ```_GREATER_THAN``` etc).
 
@@ -154,6 +155,34 @@ Matchers can be composed using `&&`, `||` and `!` operators.
 
 Currently assertions in Catch are not thread safe.
 For more details, along with workarounds, see the section on [the limitations page](limitations.md#thread-safe-assertions).
+
+## Expressions with commas
+
+Because the preprocessor parses code using different rules than the
+compiler, multiple-argument assertions (e.g. `REQUIRE_THROWS_AS`) have
+problems with commas inside the provided expressions. As an example
+`REQUIRE_THROWS_AS(std::pair<int, int>(1, 2), std::invalid_argument);`
+will fails to compile, because the preprocessor sees 3 arguments provided,
+but the macro accepts only 2. There are two possible workarounds.
+
+1) Use typedef:
+```cpp
+using int_pair = std::pair<int, int>;
+REQUIRE_THROWS_AS(int_pair(1, 2), std::invalid_argument);
+```
+
+This solution is always applicable, but makes the meaning of the code
+less clear.
+
+2) Parenthesize the expression:
+```cpp
+TEST_CASE_METHOD((Fixture<int, int>), "foo", "[bar]") {
+    SUCCEED();
+}
+```
+
+This solution is not always applicable, because it might require extra
+changes on the Catch's side to work.
 
 ---
 

--- a/include/internal/catch_test_registry.h
+++ b/include/internal/catch_test_registry.h
@@ -47,12 +47,17 @@ struct AutoReg : NonCopyable {
 
 } // end namespace Catch
 
+#define INTERNAL_CATCH_EXPAND1(param) INTERNAL_CATCH_EXPAND2(param)
+#define INTERNAL_CATCH_EXPAND2(...) INTERNAL_CATCH_NO## __VA_ARGS__
+#define INTERNAL_CATCH_DEF(...) INTERNAL_CATCH_DEF __VA_ARGS__
+#define INTERNAL_CATCH_NOINTERNAL_CATCH_DEF
+
 #if defined(CATCH_CONFIG_DISABLE)
     #define INTERNAL_CATCH_TESTCASE_NO_REGISTRATION( TestName, ... ) \
         static void TestName()
     #define INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION( TestName, ClassName, ... ) \
         namespace{                        \
-            struct TestName : ClassName { \
+            struct TestName : INTERNAL_CATCH_EXPAND1(INTERNAL_CATCH_DEF ClassName) { \
                 void test();              \
             };                            \
         }                                 \
@@ -80,7 +85,7 @@ struct AutoReg : NonCopyable {
     #define INTERNAL_CATCH_TEST_CASE_METHOD2( TestName, ClassName, ... )\
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
         namespace{ \
-            struct TestName : ClassName{ \
+            struct TestName : INTERNAL_CATCH_EXPAND1(INTERNAL_CATCH_DEF ClassName) { \
                 void test(); \
             }; \
             Catch::AutoReg INTERNAL_CATCH_UNIQUE_NAME( autoRegistrar ) ( Catch::makeTestInvoker( &TestName::test ), CATCH_INTERNAL_LINEINFO, #ClassName, Catch::NameAndTags{ __VA_ARGS__ } ); /* NOLINT */ \

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -12,6 +12,7 @@ Compilation.tests.cpp:<line number>: passed: t1 >= t2 for: {?} >= {?}
 Misc.tests.cpp:<line number>: passed:
 Compilation.tests.cpp:<line number>: passed: std::memcmp(uarr, "123", sizeof(uarr)) == 0 for: 0 == 0 with 2 messages: 'uarr := "123"' and 'sarr := "456"'
 Compilation.tests.cpp:<line number>: passed: std::memcmp(sarr, "456", sizeof(sarr)) == 0 for: 0 == 0 with 2 messages: 'uarr := "123"' and 'sarr := "456"'
+Compilation.tests.cpp:<line number>: passed:
 Exception.tests.cpp:<line number>: failed: unexpected exception with message: 'answer := 42' with 1 message: 'expected exception'
 Exception.tests.cpp:<line number>: failed: unexpected exception with message: 'answer := 42'; expression was: thisThrows() with 1 message: 'expected exception'
 Exception.tests.cpp:<line number>: passed: thisThrows() with 1 message: 'answer := 42'

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -1084,6 +1084,6 @@ due to unexpected exception with message:
   Why would you throw a std::string?
 
 ===============================================================================
-test cases:  205 | 152 passed |  49 failed |  4 failed as expected
-assertions: 1060 | 932 passed | 107 failed | 21 failed as expected
+test cases:  206 | 153 passed |  49 failed |  4 failed as expected
+assertions: 1061 | 933 passed | 107 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -127,6 +127,15 @@ with messages:
   sarr := "456"
 
 -------------------------------------------------------------------------------
+#1245
+-------------------------------------------------------------------------------
+Compilation.tests.cpp:<line number>
+...............................................................................
+
+Compilation.tests.cpp:<line number>:
+PASSED:
+
+-------------------------------------------------------------------------------
 #748 - captures with unexpected exceptions
   outside assertions
 -------------------------------------------------------------------------------
@@ -8941,6 +8950,6 @@ Misc.tests.cpp:<line number>:
 PASSED:
 
 ===============================================================================
-test cases:  205 | 139 passed |  62 failed |  4 failed as expected
-assertions: 1074 | 932 passed | 121 failed | 21 failed as expected
+test cases:  206 | 140 passed |  62 failed |  4 failed as expected
+assertions: 1075 | 933 passed | 121 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.swa4.approved.txt
+++ b/projects/SelfTest/Baselines/console.swa4.approved.txt
@@ -127,6 +127,15 @@ with messages:
   sarr := "456"
 
 -------------------------------------------------------------------------------
+#1245
+-------------------------------------------------------------------------------
+Compilation.tests.cpp:<line number>
+...............................................................................
+
+Compilation.tests.cpp:<line number>:
+PASSED:
+
+-------------------------------------------------------------------------------
 #748 - captures with unexpected exceptions
   outside assertions
 -------------------------------------------------------------------------------
@@ -332,6 +341,6 @@ with expansion:
   !true
 
 ===============================================================================
-test cases: 13 | 10 passed | 1 failed | 2 failed as expected
-assertions: 37 | 30 passed | 4 failed | 3 failed as expected
+test cases: 14 | 11 passed | 1 failed | 2 failed as expected
+assertions: 38 | 31 passed | 4 failed | 3 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="105" tests="1075" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="105" tests="1076" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <testcase classname="<exe-name>.global" name="# A test name that starts with a #" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1005: Comparing pointer to int and long (NULL can be either on various systems)" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1027" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1147" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1175 - Hidden Test" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1238" time="{duration}"/>
+    <testcase classname="<exe-name>.(Fixture_1245&lt;int, int>)" name="#1245" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#748 - captures with unexpected exceptions/outside assertions" time="{duration}">
       <error type="TEST_CASE">
 expected exception

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -127,6 +127,9 @@
       </Expression>
       <OverallResult success="true"/>
     </TestCase>
+    <TestCase name="#1245" tags="[compilation]" filename="projects/<exe-name>/UsageTests/Compilation.tests.cpp" >
+      <OverallResult success="true"/>
+    </TestCase>
     <TestCase name="#748 - captures with unexpected exceptions" tags="[!shouldfail][!throws][.][failing]" filename="projects/<exe-name>/UsageTests/Exception.tests.cpp" >
       <Section name="outside assertions" filename="projects/<exe-name>/UsageTests/Exception.tests.cpp" >
         <Info>
@@ -9889,7 +9892,7 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="932" failures="122" expectedFailures="21"/>
+    <OverallResults successes="933" failures="122" expectedFailures="21"/>
   </Group>
-  <OverallResults successes="932" failures="121" expectedFailures="21"/>
+  <OverallResults successes="933" failures="121" expectedFailures="21"/>
 </Catch>

--- a/projects/SelfTest/UsageTests/Compilation.tests.cpp
+++ b/projects/SelfTest/UsageTests/Compilation.tests.cpp
@@ -88,6 +88,9 @@ namespace { namespace CompilationTests {
 #pragma clang diagnostic pop
 #endif
 
+    template <typename, typename>
+    struct Fixture_1245 {};
+
 #endif
 
     TEST_CASE("#809") {
@@ -145,6 +148,10 @@ namespace { namespace CompilationTests {
 
         REQUIRE(std::memcmp(uarr, "123", sizeof(uarr)) == 0);
         REQUIRE(std::memcmp(sarr, "456", sizeof(sarr)) == 0);
+    }
+
+    TEST_CASE_METHOD((Fixture_1245<int, int>), "#1245", "[compilation]") {
+        SUCCEED();
     }
 
 }} // namespace CompilationTests


### PR DESCRIPTION
Currently, you cannot use template specializations with commas in them as fixtures. This because you need to parenthesize them in order for the macro to treat it as a single argument, and that single argument is used as a base class type specifier... and you can't have parentheses there.

In other words, this doesn't work today:

    template <typename, typename>
    struct Fixture { };

    TEST_CASE_METHOD((Fixture<int, int>), "a", "[b]") {
        CHECK(1 == 1);
    }

With less than helpful compile errors like:

```
foo.cxx:7:18: error: expected class-name before ‘(’ token
 TEST_CASE_METHOD((Fixture<int, int>), "a", "[b]") {
                  ^
foo.cxx:7:18: error: expected ‘{’ before ‘(’ token
foo.cxx:7:36: error: invalid declarator before ‘)’ token
 TEST_CASE_METHOD((Fixture<int, int>), "a", "[b]") {
                                    ^
foo.cxx:7:1: error: incomplete type ‘{anonymous}::____C_A_T_C_H____T_E_S_T____0’ used in nested name specifier
 TEST_CASE_METHOD((Fixture<int, int>), "a", "[b]") {
 ^
foo.cxx:7:1: error: invalid use of incomplete type ‘struct {anonymous}::____C_A_T_C_H____T_E_S_T____0’
 TEST_CASE_METHOD((Fixture<int, int>), "a", "[b]") {
 ^
foo.cxx:7:1: note: forward declaration of ‘struct {anonymous}::____C_A_T_C_H____T_E_S_T____0’
 TEST_CASE_METHOD((Fixture<int, int>), "a", "[b]") {
 ^
```

This PR makes this work by introducing a new type trait which is a spot that _does_ allow for extra parenthesis. Both `void(T)` and `void((T))` are valid types, so we can take advantage of that to pull out the `T` properly. All previously functional code should remain functional.