### PR TITLE
Add static library target for efficient recompilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,7 +424,8 @@ endif()
 add_library(Catch INTERFACE)
 
 # depend on some obvious c++11 features so the dependency is transitively added dependants
-target_compile_features(Catch INTERFACE cxx_auto_type cxx_constexpr cxx_noexcept)
+set(COMPILE_FEATURES cxx_auto_type cxx_constexpr cxx_noexcept)
+target_compile_features(Catch INTERFACE ${COMPILE_FEATURES})
 
 target_include_directories(Catch
 	INTERFACE
@@ -454,3 +455,17 @@ write_basic_package_version_file(
 install(FILES
 	"${CMAKE_CURRENT_BINARY_DIR}/Catch2ConfigVersion.cmake"
 	DESTINATION ${CATCH_CMAKE_CONFIG_DESTINATION})
+
+# add an object library as intermediate for 'static' catch
+add_library(Catch-static-objects OBJECT EXCLUDE_FROM_ALL
+	${IMPL_SOURCES}
+	${REPORTER_SOURCES})
+target_compile_features(Catch-static-objects PRIVATE ${COMPILE_FEATURES})
+target_include_directories(Catch-static-objects PRIVATE ${HEADER_DIR})
+
+# add catch as a 'static' library target
+add_library(Catch-static INTERFACE)
+target_compile_features(Catch-static INTERFACE ${COMPILE_FEATURES})
+target_include_directories(Catch-static INTERFACE ${HEADER_DIR})
+target_sources(Catch-static INTERFACE $<TARGET_OBJECTS:Catch-static-objects>)
+add_library(Catch2::Catch-static ALIAS Catch-static)


### PR DESCRIPTION
I add a static library target for catch, as an alternative to the single header solution.
I created this change to save build time and memory on computers and VMs which have limited CPU and RAM resource. This compiles the internal classes separately a single time, rather than with each test program.

I took one of the example programs and compared header-only catch vs static library.
As you can judge by results, a recompilation of the test took 7% of time and 24% of the memory.
The productivity gain is quite considerable.

```
#/usr/bin/time -f "real:%es user:%Us sys:%Ss max-rss:%MkB" make 010-TestCase
real:39.92s user:37.12s sys:1.24s max-rss:693944kB
#/usr/bin/time -f "real:%es user:%Us sys:%Ss max-rss:%MkB" make 010-TestCase-static
real:2.92s user:2.43s sys:0.37s max-rss:163224kB
```

This was the project used for a benchmark.

```
cmake_minimum_required(VERSION 3.1)

add_subdirectory("../Catch2" Catch2.dir)

add_executable(010-TestCase-static 010-TestCase.cpp)
target_link_libraries(010-TestCase-static PRIVATE Catch2::Catch-static)

add_executable(010-TestCase 010-TestCase.cpp)
target_link_libraries(010-TestCase PRIVATE Catch2::Catch)
```

Edit: I make this an object/interface library target. A static library is not going to work, because the linker will discard some required symbols which initialize the framework.