### PR TITLE
Enable console colour in the approval tests on windows.

### DIFF
--- a/scripts/approvalTests.py
+++ b/scripts/approvalTests.py
@@ -12,6 +12,10 @@ import difflib
 import scriptCommon
 from scriptCommon import catchPath
 
+if os.name == 'nt':
+	# Enable console colours on windows
+	os.system('')
+
 rootPath = os.path.join(catchPath, 'projects/SelfTest/Baselines')
 
 


### PR DESCRIPTION
This method to enable colours only works on windows 10. 