### PR TITLE
Fixed Catch2 for GCC 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,14 @@ matrix:
           packages: ['g++-7']
       env: COMPILER='g++-7'
 
+    - os: linux
+      compiler: gcc
+      addons: &gcc8
+        apt:
+          sources: *all_sources
+          packages: ['g++-8']
+      env: COMPILER='g++-8'
+
     # 3b/ Linux C++14 Clang builds
     # Note that we need newer libstdc++ for C++14 support
     - os: linux
@@ -155,6 +163,11 @@ matrix:
       compiler: gcc
       addons: *gcc7
       env: COMPILER='g++-7' CPP14=1
+
+    - os: linux
+      compiler: gcc
+      addons: *gcc8
+      env: COMPILER='g++-8' CPP14=1
 
     # 5/ OSX Clang Builds
     - os: osx

--- a/projects/SelfTest/UsageTests/Misc.tests.cpp
+++ b/projects/SelfTest/UsageTests/Misc.tests.cpp
@@ -304,7 +304,7 @@ TEST_CASE( "toString on const wchar_t pointer returns the string contents", "[to
 }
 
 TEST_CASE( "toString on wchar_t const pointer returns the string contents", "[toString]" ) {
-        auto const s = const_cast<wchar_t* const>( L"wide load" );
+        auto const s = const_cast<wchar_t*>( L"wide load" );
         std::string result = ::Catch::Detail::stringify( s );
         CHECK( result == "\"wide load\"" );
 }


### PR DESCRIPTION
## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

While trying to install Catch2 on a Docker system with GCC 8, I encountered this warning:

```
[32/100] Building CXX object CMakeFiles/SelfTest.dir/projects/SelfTest/UsageTests/Misc.tests.cpp.o
FAILED: CMakeFiles/SelfTest.dir/projects/SelfTest/UsageTests/Misc.tests.cpp.o
/usr/local/bin/c++   -I/usr/src/catch/Catch2/include -O3 -DNDEBUG   -Wall -Wextra -Wunreachable-code -Wpedantic -Werror -std=c++11 -MD -MT CMakeFiles/SelfTest.dir/projects/SelfTest/UsageTests/Misc.tests.cpp.o -MF CMakeFiles/SelfTest.dir/projects/SelfTest/UsageTests/Misc.tests.cpp.o.d -o CMakeFiles/SelfTest.dir/projects/SelfTest/UsageTests/Misc.tests.cpp.o -c /usr/src/catch/Catch2/projects/SelfTest/UsageTests/Misc.tests.cpp
/usr/src/catch/Catch2/projects/SelfTest/UsageTests/Misc.tests.cpp: In function 'void {anonymous}::MiscTests::____C_A_T_C_H____T_E_S_T____77()':
/usr/src/catch/Catch2/projects/SelfTest/UsageTests/Misc.tests.cpp:307:65: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
         auto const s = const_cast<wchar_t* const>( L"wide load" );
                                                                 ^
```

Essentially, GCC 8 is warning that the `const` in the `const_cast` is ignored. This appears to be the only break for GCC 8, but it wasn't testable outside of my machine, so I added GCC 8 to Travis too.

## GitHub Issues

No GitHub issue right now, but I can add one.

## Other

I am running a clang-6.0 branch through Travis, and will make a PR for that too, if it passes.