### PR TITLE
Add gdbinit and lldbinit files to skip stepping into Catch code during debugging

### DIFF
--- a/contrib/gdbinit
+++ b/contrib/gdbinit
@@ -1,0 +1,16 @@
+#
+# This file provides a way to skip stepping into Catch code when debugging with gdb.
+#
+# With the gdb "skip" command you can tell gdb to skip files or functions during debugging.
+# see https://xaizek.github.io/2016-05-26/skipping-standard-library-in-gdb/ for an example
+#
+# Basically the following line tells gdb to skip all functions containing the
+# regexp "Catch", which matches the complete Catch namespace.
+# If you want to skip just some parts of the Catch code you can modify the
+# regexp accordingly.
+# 
+# If you want to permanently skip stepping into Catch code copy the following
+# line into your ~/.gdbinit file
+# 
+
+skip -rfu Catch

--- a/contrib/lldbinit
+++ b/contrib/lldbinit
@@ -1,0 +1,16 @@
+#
+# This file provides a way to skip stepping into Catch code when debugging with lldb.
+#
+# With the setting "target.process.thread.step-avoid-regexp" you can tell lldb
+# to skip functions matching the regexp
+#
+# Basically the following line tells lldb to skip all functions containing the
+# regexp "Catch", which matches the complete Catch namespace.
+# If you want to skip just some parts of the Catch code you can modify the
+# regexp accordingly.
+#
+# If you want to permanently skip stepping into Catch code copy the following
+# line into your ~/.lldbinit file
+#
+
+settings set target.process.thread.step-avoid-regexp Catch


### PR DESCRIPTION
## Description

The commands provided have to be executed in the current gdb/lldb session or copied
into the users ~/.gdbinit ~/.lldbinit files to permanently skip debugging Catch code.

## GitHub Issues
Fixes #904
