### PR TITLE
MSVC Static Analysis

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,3 +96,20 @@ build:
 test_script:
   - set CTEST_OUTPUT_ON_FAILURE=1
   - cmd: .\misc\appveyorTestRunScript.bat
+
+for:
+# Specific settings for msvc-analysis branch, overriding the common configuration
+-
+  branches:
+    only:
+      - msvc-analysis
+  environment:
+    matrix:
+      - additional_flags: "/analyze"
+        wmain: 0
+  matrix:
+    exclude:
+      - os: Visual Studio 2015
+      - additional_flags: "/permissive- /std:c++latest"
+      - additional_flags: "/D_UNICODE /DUNICODE"
+      - additional_flags: ""

--- a/include/internal/catch_output_redirect.cpp
+++ b/include/internal/catch_output_redirect.cpp
@@ -59,7 +59,16 @@ namespace Catch {
             if (strerror_s(buffer, errno)) {
                 throw std::runtime_error("Could not translate errno to string");
             }
+// strerror_s always null terminates the buffer when successful
+// m_buffer is zero initialized
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:6054) // String 'buffer' might not be zero-terminated
+#endif
             throw std::runtime_error("Could not open the temp file: " + std::string(m_buffer) + buffer);
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
         }
     }
 #else
@@ -102,8 +111,15 @@ namespace Catch {
         m_originalStderr(dup(2)),
         m_stdoutDest(stdout_dest),
         m_stderrDest(stderr_dest) {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:6031) // Return value ignored: '_dup2'
+#endif
         dup2(fileno(m_stdoutFile.getFile()), 1);
         dup2(fileno(m_stderrFile.getFile()), 2);
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
     }
 
     OutputRedirect::~OutputRedirect() {
@@ -115,8 +131,15 @@ namespace Catch {
         Catch::clog() << std::flush;
         fflush(stderr);
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:6031) // Return value ignored: '_dup2'
+#endif
         dup2(m_originalStdout, 1);
         dup2(m_originalStderr, 2);
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
         m_stdoutDest += m_stdoutFile.getContents();
         m_stderrDest += m_stderrFile.getContents();

--- a/projects/SelfTest/UsageTests/Benchmark.tests.cpp
+++ b/projects/SelfTest/UsageTests/Benchmark.tests.cpp
@@ -36,8 +36,15 @@ TEST_CASE( "benchmarked", "[!benchmark]" ) {
         for(int i =0; i < size; ++i )
             array[i] = i;
     }
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:6001) // Using uninitialized memory 'array'
+#endif
     int sum = 0;
     for(int i =0; i < size; ++i )
         sum += array[i];
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
     REQUIRE( sum > size );
 }

--- a/projects/SelfTest/UsageTests/Class.tests.cpp
+++ b/projects/SelfTest/UsageTests/Class.tests.cpp
@@ -22,6 +22,10 @@ public:
     : s( "hello" )
     {}
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:6237) // (<zero> && <expression>) is always zero
+#endif
     void succeedingCase()
     {
         REQUIRE( s == "hello" );
@@ -30,6 +34,9 @@ public:
     {
         REQUIRE( s == "world" );
     }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 };
 
 struct Fixture

--- a/projects/SelfTest/UsageTests/Tricky.tests.cpp
+++ b/projects/SelfTest/UsageTests/Tricky.tests.cpp
@@ -412,7 +412,14 @@ TEST_CASE("Commas in various macros are allowed") {
 TEST_CASE( "null deref", "[.][failing][!nonportable]" ) {
     CHECK( false );
     int *x = NULL;
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:6011) // Dereferencing NULL pointer 'x'
+#endif
     *x = 1;
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 }
 
 TEST_CASE( "non-copyable objects", "[.][failing]" ) {


### PR DESCRIPTION
## Description
Enable MSVC /analyze on branch msvc-analysis

When pushing updates to the msvc-analysis branch, appveyor will perform
static analysis when building. Matrix used is a combination of Debug/Release and Win32/x64 with additional_flags=/analyze on VS2017 (4 jobs total).

I ignored all existing warnings to get the static analysis portion to pass, they look like either false positives or intentional mistakes for testing however you might want to scan through them quickly anyway.

https://ci.appveyor.com/project/IanHattendorf/catch2/build/13 (I'll delete this project a few days after this PR is closed).

## GitHub Issues
#1266