### PR TITLE
Now using <random> features instead of rand/srand

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -244,7 +244,7 @@ Randomly sorted. Test names are sorted using ```std::random_shuffle()```. By def
 ## Specify a seed for the Random Number Generator
 <pre>--rng-seed &lt;'time'|number&gt;</pre>
 
-Sets a seed for the random number generator using ```std::srand()```. 
+Sets a seed for the random number generator. 
 If a number is provided this is used directly as the seed so the random pattern is repeatable.
 Alternatively if the keyword ```time``` is provided then the result of calling ```std::time(0)``` is used and so the pattern becomes unpredictable.
 

--- a/include/internal/catch_random_number_generator.cpp
+++ b/include/internal/catch_random_number_generator.cpp
@@ -13,19 +13,19 @@
 
 namespace Catch {
 
-    void seedRng( IConfig const& config ) {
-        if( config.rngSeed() != 0 )
-            std::srand( config.rngSeed() );
-    }
     unsigned int rngSeed() {
         return getCurrentContext().getConfig()->rngSeed();
     }
 
-    RandomNumberGenerator::result_type RandomNumberGenerator::operator()( result_type n ) const {
-        return std::rand() % n;
-    }
-    RandomNumberGenerator::result_type RandomNumberGenerator::operator()() const {
-        return std::rand() % (max)();
-    }
+    RandomNumberGenerator::RandomNumberGenerator( int seed )
+        : generator(seed)
+    {}
 
+    RandomNumberGenerator::result_type RandomNumberGenerator::operator()( RandomNumberGenerator::result_type n ) {
+        std::uniform_int_distribution<result_type> dis( 0, n );
+        return dis( generator );
+    }
+    RandomNumberGenerator::result_type RandomNumberGenerator::operator()() {
+        return (*this)((max)());
+    }
 }

--- a/include/internal/catch_random_number_generator.h
+++ b/include/internal/catch_random_number_generator.h
@@ -8,29 +8,34 @@
 #define TWOBLUECUBES_CATCH_RANDOM_NUMBER_GENERATOR_H_INCLUDED
 
 #include <algorithm>
+#include <random>
 
 namespace Catch {
 
     struct IConfig;
 
-    void seedRng( IConfig const& config );
-
     unsigned int rngSeed();
 
-    struct RandomNumberGenerator {
+    class RandomNumberGenerator {
+    public:
         using result_type = unsigned int;
+        
+        RandomNumberGenerator( int seed = rngSeed() );
 
         static constexpr result_type (min)() { return 0; }
         static constexpr result_type (max)() { return 1000000; }
 
-        result_type operator()( result_type n ) const;
-        result_type operator()() const;
+        result_type operator()( result_type n );
+        result_type operator()();
 
         template<typename V>
         static void shuffle( V& vector ) {
             RandomNumberGenerator rng;
             std::shuffle( vector.begin(), vector.end(), rng );
         }
+
+    private:
+        std::default_random_engine generator;
     };
 
 }

--- a/include/internal/catch_run_context.cpp
+++ b/include/internal/catch_run_context.cpp
@@ -294,8 +294,6 @@ namespace Catch {
         m_shouldReportUnexpected = true;
         m_lastAssertionInfo = { "TEST_CASE"_sr, testCaseInfo.lineInfo, StringRef(), ResultDisposition::Normal };
 
-        seedRng(*m_config);
-
         Timer timer;
         try {
             if (m_reporter->getPreferences().shouldRedirectStdOut) {

--- a/include/internal/catch_session.cpp
+++ b/include/internal/catch_session.cpp
@@ -258,8 +258,6 @@ namespace Catch {
         {
             config(); // Force config to be constructed
 
-            seedRng( *m_config );
-
             if( m_configData.filenamesAsTags )
                 applyFilenamesAsTags( *m_config );
 

--- a/include/internal/catch_test_case_registry_impl.cpp
+++ b/include/internal/catch_test_case_registry_impl.cpp
@@ -27,7 +27,6 @@ namespace Catch {
                 std::sort( sorted.begin(), sorted.end() );
                 break;
             case RunTests::InRandomOrder:
-                seedRng( config );
                 RandomNumberGenerator::shuffle( sorted );
                 break;
             case RunTests::InDeclarationOrder:


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
A modern C++11 framework shouldn't use rand/srand but rather the utilities in the `<random>` library.

Turns the RandomNumberGenerator into a wrapper over `default_random_generator`. The seed defaults to what's specified in the configuration, or can be manually overridden.

I do not quite follow why `seedRng` was called in so many places. Is Catch also meant to be setting a random seed for `rand()` calls inside test cases? If there is a good explanation I can reinstate this, but Catch itself does not use `std::srand` anymore.

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
Should take care of #443 
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
