### PR TITLE
Add PARSE_CATCH_TEST_PROXY variable.

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -168,6 +168,7 @@ function(ParseFile SourceFile TestTarget)
 
             # Add the test and set its properties
             add_test(NAME "\"${CTestName}\"" COMMAND ${PARSE_CATCH_TESTS_PROXY} $<TARGET_FILE:${TestTarget}> ${Name} ${AdditionalCatchParameters})
+                     WORKING_DIRECTORY $<TARGET_FILE_DIR:${TestTarget}>)
             set_tests_properties("\"${CTestName}\"" PROPERTIES FAIL_REGULAR_EXPRESSION "No tests ran"
                     LABELS "${Labels}")
         endif()

--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -167,7 +167,7 @@ function(ParseFile SourceFile TestTarget)
             endif()
 
             # Add the test and set its properties
-            add_test(NAME "\"${CTestName}\"" COMMAND ${PARSE_CATCH_TESTS_PROXY} ${TestTarget} ${Name} ${AdditionalCatchParameters})
+            add_test(NAME "\"${CTestName}\"" COMMAND ${PARSE_CATCH_TESTS_PROXY} $<TARGET_FILE:${TestTarget}> ${Name} ${AdditionalCatchParameters})
             set_tests_properties("\"${CTestName}\"" PROPERTIES FAIL_REGULAR_EXPRESSION "No tests ran"
                     LABELS "${Labels}")
         endif()

--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -38,6 +38,8 @@
 #    -- adds cmake target name to the test name                                                    #
 #    PARSE_CATCH_TESTS_ADD_TO_CONFIGURE_DEPENDS (Default OFF)                                      #
 #    -- causes CMake to rerun when file with tests changes so that new tests will be discovered    #
+#    PARSE_CATCH_TESTS_PROXY
+#    -- causes tests to be executed through a proxy
 #                                                                                                  #
 #==================================================================================================#
 
@@ -165,9 +167,9 @@ function(ParseFile SourceFile TestTarget)
             endif()
 
             # Add the test and set its properties
-            add_test(NAME "\"${CTestName}\"" COMMAND ${TestTarget} ${Name} ${AdditionalCatchParameters})
+            add_test(NAME "\"${CTestName}\"" COMMAND ${PARSE_CATCH_TESTS_PROXY} ./${TestTarget} ${Name} ${AdditionalCatchParameters})
             set_tests_properties("\"${CTestName}\"" PROPERTIES FAIL_REGULAR_EXPRESSION "No tests ran"
-                                                    LABELS "${Labels}")
+                    LABELS "${Labels}")
         endif()
 
     endforeach()

--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -167,7 +167,7 @@ function(ParseFile SourceFile TestTarget)
             endif()
 
             # Add the test and set its properties
-            add_test(NAME "\"${CTestName}\"" COMMAND ${PARSE_CATCH_TESTS_PROXY} ./${TestTarget} ${Name} ${AdditionalCatchParameters})
+            add_test(NAME "\"${CTestName}\"" COMMAND ${PARSE_CATCH_TESTS_PROXY} ${TestTarget} ${Name} ${AdditionalCatchParameters})
             set_tests_properties("\"${CTestName}\"" PROPERTIES FAIL_REGULAR_EXPRESSION "No tests ran"
                     LABELS "${Labels}")
         endif()

--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -167,7 +167,7 @@ function(ParseFile SourceFile TestTarget)
             endif()
 
             # Add the test and set its properties
-            add_test(NAME "\"${CTestName}\"" COMMAND ${PARSE_CATCH_TESTS_PROXY} $<TARGET_FILE:${TestTarget}> ${Name} ${AdditionalCatchParameters})
+            add_test(NAME "\"${CTestName}\"" COMMAND ${PARSE_CATCH_TESTS_PROXY} $<TARGET_FILE:${TestTarget}> ${Name} ${AdditionalCatchParameters}
                      WORKING_DIRECTORY $<TARGET_FILE_DIR:${TestTarget}>)
             set_tests_properties("\"${CTestName}\"" PROPERTIES FAIL_REGULAR_EXPRESSION "No tests ran"
                     LABELS "${Labels}")


### PR DESCRIPTION
This causes catch tests to be executed through a proxy.

An example of this would be used like this to execute tests on a developers PC and CI device consistently :

SET(SERVER_ARGS "/usr/bin/xvfb-run" "--server-args=-screen 0 800x600x16" "-e" "/dev/stdout" )
set(PARSE_CATCH_TESTS_PROXY ${SERVER_ARGS})

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
