### PR TITLE
Add float/int literal for Approx

### DIFF
--- a/include/internal/catch_approx.cpp
+++ b/include/internal/catch_approx.cpp
@@ -35,6 +35,13 @@ namespace Detail {
         return Approx( 0 );
     }
 
+    Approx Approx::operator-() const {
+        auto temp(*this);
+        temp.m_value = -temp.m_value;
+        return temp;
+    }
+
+
     std::string Approx::toString() const {
         ReusableStringStream rss;
         rss << "Approx( " << ::Catch::Detail::stringify( m_value ) << " )";
@@ -48,6 +55,15 @@ namespace Detail {
     }
 
 } // end namespace Detail
+
+namespace literals {
+    Detail::Approx operator "" _a(long double val) {
+        return Detail::Approx(val);
+    }
+    Detail::Approx operator "" _a(unsigned long long val) {
+        return Detail::Approx(val);
+    }
+} // end namespace literals
 
 std::string StringMaker<Catch::Detail::Approx>::convert(Catch::Detail::Approx const& value) {
     return value.toString();

--- a/include/internal/catch_approx.h
+++ b/include/internal/catch_approx.h
@@ -25,6 +25,8 @@ namespace Detail {
 
         static Approx custom();
 
+        Approx operator-() const;
+
         template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
         Approx operator()( T const& value ) {
             Approx approx( static_cast<double>(value) );
@@ -121,7 +123,12 @@ namespace Detail {
         double m_scale;
         double m_value;
     };
-}
+} // end namespace Detail
+    
+namespace literals {
+    Detail::Approx operator "" _a(long double val);
+    Detail::Approx operator "" _a(unsigned long long val);
+} // end namespace literals
 
 template<>
 struct StringMaker<Catch::Detail::Approx> {

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -60,6 +60,12 @@ Class.tests.cpp:<line number>: failed: s == "world" for: "hello" == "world"
 Class.tests.cpp:<line number>: passed: s == "hello" for: "hello" == "hello"
 Class.tests.cpp:<line number>: failed: m_a == 2 for: 1 == 2
 Class.tests.cpp:<line number>: passed: m_a == 1 for: 1 == 1
+Approx.tests.cpp:<line number>: passed: d == 1.23_a for: 1.23 == Approx( 1.23 )
+Approx.tests.cpp:<line number>: passed: d != 1.22_a for: 1.23 != Approx( 1.22 )
+Approx.tests.cpp:<line number>: passed: -d == -1.23_a for: -1.23 == Approx( -1.23 )
+Approx.tests.cpp:<line number>: passed: d == 1.2_a .epsilon(.1) for: 1.23 == Approx( 1.2 )
+Approx.tests.cpp:<line number>: passed: d != 1.2_a .epsilon(.001) for: 1.23 != Approx( 1.2 )
+Approx.tests.cpp:<line number>: passed: d == 1_a .epsilon(.3) for: 1.23 == Approx( 1.0 )
 Misc.tests.cpp:<line number>: passed: with 1 message: 'that's not flying - that's failing in style'
 Misc.tests.cpp:<line number>: failed: explicitly with 1 message: 'to infinity and beyond'
 Tricky.tests.cpp:<line number>: failed: &o1 == &o2 for: 0x<hex digits> == 0x<hex digits>
@@ -614,6 +620,8 @@ A string sent to stderr via clog
 Approx.tests.cpp:<line number>: passed: d == Approx( 1.23 ) for: 1.23 == Approx( 1.23 )
 Approx.tests.cpp:<line number>: passed: d != Approx( 1.22 ) for: 1.23 != Approx( 1.22 )
 Approx.tests.cpp:<line number>: passed: d != Approx( 1.24 ) for: 1.23 != Approx( 1.24 )
+Approx.tests.cpp:<line number>: passed: d == 1.23_a for: 1.23 == Approx( 1.23 )
+Approx.tests.cpp:<line number>: passed: d != 1.22_a for: 1.23 != Approx( 1.22 )
 Approx.tests.cpp:<line number>: passed: Approx( d ) == 1.23 for: Approx( 1.23 ) == 1.23
 Approx.tests.cpp:<line number>: passed: Approx( d ) != 1.22 for: Approx( 1.23 ) != 1.22
 Approx.tests.cpp:<line number>: passed: Approx( d ) != 1.24 for: Approx( 1.23 ) != 1.24

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -1084,6 +1084,6 @@ due to unexpected exception with message:
   Why would you throw a std::string?
 
 ===============================================================================
-test cases:  207 | 154 passed |  49 failed |  4 failed as expected
-assertions: 1064 | 936 passed | 107 failed | 21 failed as expected
+test cases:  208 | 155 passed |  49 failed |  4 failed as expected
+assertions: 1072 | 944 passed | 107 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -536,6 +536,48 @@ with expansion:
   1 == 1
 
 -------------------------------------------------------------------------------
+A comparison that uses literals instead of the normal constructor
+-------------------------------------------------------------------------------
+Approx.tests.cpp:<line number>
+...............................................................................
+
+Approx.tests.cpp:<line number>:
+PASSED:
+  REQUIRE( d == 1.23_a )
+with expansion:
+  1.23 == Approx( 1.23 )
+
+Approx.tests.cpp:<line number>:
+PASSED:
+  REQUIRE( d != 1.22_a )
+with expansion:
+  1.23 != Approx( 1.22 )
+
+Approx.tests.cpp:<line number>:
+PASSED:
+  REQUIRE( -d == -1.23_a )
+with expansion:
+  -1.23 == Approx( -1.23 )
+
+Approx.tests.cpp:<line number>:
+PASSED:
+  REQUIRE( d == 1.2_a .epsilon(.1) )
+with expansion:
+  1.23 == Approx( 1.2 )
+
+Approx.tests.cpp:<line number>:
+PASSED:
+  REQUIRE( d != 1.2_a .epsilon(.001) )
+with expansion:
+  1.23 != Approx( 1.2 )
+
+Approx.tests.cpp:<line number>:
+PASSED:
+  REQUIRE( d == 1_a .epsilon(.3) )
+with expansion:
+  1.23 == Approx( 1.0 )
+
+-------------------------------------------------------------------------------
 A couple of nested sections followed by a failure
   Outer
   Inner
@@ -4874,6 +4916,18 @@ with expansion:
 
 Approx.tests.cpp:<line number>:
 PASSED:
+  REQUIRE( d == 1.23_a )
+with expansion:
+  1.23 == Approx( 1.23 )
+
+Approx.tests.cpp:<line number>:
+PASSED:
+  REQUIRE( d != 1.22_a )
+with expansion:
+  1.23 != Approx( 1.22 )
+
+Approx.tests.cpp:<line number>:
+PASSED:
   REQUIRE( Approx( d ) == 1.23 )
 with expansion:
   Approx( 1.23 ) == 1.23
@@ -8978,6 +9032,6 @@ Misc.tests.cpp:<line number>:
 PASSED:
 
 ===============================================================================
-test cases:  207 | 141 passed |  62 failed |  4 failed as expected
-assertions: 1078 | 936 passed | 121 failed | 21 failed as expected
+test cases:  208 | 142 passed |  62 failed |  4 failed as expected
+assertions: 1086 | 944 passed | 121 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="105" tests="1079" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="105" tests="1087" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <testcase classname="<exe-name>.global" name="# A test name that starts with a #" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1005: Comparing pointer to int and long (NULL can be either on various systems)" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1027" time="{duration}"/>
@@ -81,6 +81,7 @@ Class.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.Fixture" name="A TEST_CASE_METHOD based test run that succeeds" time="{duration}"/>
+    <testcase classname="<exe-name>.global" name="A comparison that uses literals instead of the normal constructor" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="A couple of nested sections followed by a failure" time="{duration}">
       <failure type="FAIL">
 to infinity and beyond

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -554,6 +554,57 @@
       </Expression>
       <OverallResult success="true"/>
     </TestCase>
+    <TestCase name="A comparison that uses literals instead of the normal constructor" tags="[Approx]" filename="projects/<exe-name>/UsageTests/Approx.tests.cpp" >
+      <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Approx.tests.cpp" >
+        <Original>
+          d == 1.23_a
+        </Original>
+        <Expanded>
+          1.23 == Approx( 1.23 )
+        </Expanded>
+      </Expression>
+      <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Approx.tests.cpp" >
+        <Original>
+          d != 1.22_a
+        </Original>
+        <Expanded>
+          1.23 != Approx( 1.22 )
+        </Expanded>
+      </Expression>
+      <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Approx.tests.cpp" >
+        <Original>
+          -d == -1.23_a
+        </Original>
+        <Expanded>
+          -1.23 == Approx( -1.23 )
+        </Expanded>
+      </Expression>
+      <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Approx.tests.cpp" >
+        <Original>
+          d == 1.2_a .epsilon(.1)
+        </Original>
+        <Expanded>
+          1.23 == Approx( 1.2 )
+        </Expanded>
+      </Expression>
+      <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Approx.tests.cpp" >
+        <Original>
+          d != 1.2_a .epsilon(.001)
+        </Original>
+        <Expanded>
+          1.23 != Approx( 1.2 )
+        </Expanded>
+      </Expression>
+      <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Approx.tests.cpp" >
+        <Original>
+          d == 1_a .epsilon(.3)
+        </Original>
+        <Expanded>
+          1.23 == Approx( 1.0 )
+        </Expanded>
+      </Expression>
+      <OverallResult success="true"/>
+    </TestCase>
     <TestCase name="A couple of nested sections followed by a failure" tags="[.][failing]" filename="projects/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Section name="Outer" filename="projects/<exe-name>/UsageTests/Misc.tests.cpp" >
         <Section name="Inner" filename="projects/<exe-name>/UsageTests/Misc.tests.cpp" >
@@ -5593,6 +5644,22 @@ A string sent to stderr via clog
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Approx.tests.cpp" >
         <Original>
+          d == 1.23_a
+        </Original>
+        <Expanded>
+          1.23 == Approx( 1.23 )
+        </Expanded>
+      </Expression>
+      <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Approx.tests.cpp" >
+        <Original>
+          d != 1.22_a
+        </Original>
+        <Expanded>
+          1.23 != Approx( 1.22 )
+        </Expanded>
+      </Expression>
+      <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Approx.tests.cpp" >
+        <Original>
           Approx( d ) == 1.23
         </Original>
         <Expanded>
@@ -9923,7 +9990,7 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="936" failures="122" expectedFailures="21"/>
+    <OverallResults successes="944" failures="122" expectedFailures="21"/>
   </Group>
-  <OverallResults successes="936" failures="121" expectedFailures="21"/>
+  <OverallResults successes="944" failures="121" expectedFailures="21"/>
 </Catch>

--- a/projects/SelfTest/UsageTests/Approx.tests.cpp
+++ b/projects/SelfTest/UsageTests/Approx.tests.cpp
@@ -33,14 +33,30 @@ namespace { namespace ApproxTests {
 
 #endif
 
+using namespace Catch::literals;
 
 ///////////////////////////////////////////////////////////////////////////////
+TEST_CASE( "A comparison that uses literals instead of the normal constructor", "[Approx]" ) {
+    double d = 1.23;
+
+    REQUIRE( d == 1.23_a );
+    REQUIRE( d != 1.22_a );
+    REQUIRE( -d == -1.23_a );
+
+    REQUIRE( d == 1.2_a .epsilon(.1) );
+    REQUIRE( d != 1.2_a .epsilon(.001) );
+    REQUIRE( d == 1_a .epsilon(.3) );
+}
+
 TEST_CASE( "Some simple comparisons between doubles", "[Approx]" ) {
     double d = 1.23;
 
     REQUIRE( d == Approx( 1.23 ) );
     REQUIRE( d != Approx( 1.22 ) );
     REQUIRE( d != Approx( 1.24 ) );
+
+    REQUIRE( d == 1.23_a );
+    REQUIRE( d != 1.22_a );
 
     REQUIRE( Approx( d ) == 1.23 );
     REQUIRE( Approx( d ) != 1.22 );


### PR DESCRIPTION
## Description

This adds access to Approx using C++11's custom literals. *(WHAT)* Since approximate values can be often written directly in the source code, this is a handy shortcut that reduces paratheses when checking lots of values. *(WHY)*

Example:

```cpp
// Before
CHECK(myval == Approx(1.5));
CHECK(otherval == Approx(1.5).epsilon(.1));

// After
using namespace Catch::literals;
CHECK(myval == 1.5_a);
CHECK(otherval == 1.5_a .epsilon(.1));
```

This also required a unary `-` operator for Approx due to the way literals are constructed.

## GitHub Issues

None, small new feature.

Notes:
* Is `_a` best? `_unc` is a bit long.
* Due to C++11 [syntax](http://en.cppreference.com/w/cpp/language/user_literal), a space is required between a number literal and a following dot.
* Probably should have ~~a test and~~ a note in the documentation. (Test added)
