### PR TITLE
Clang templated stream op

### DIFF
--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -105,7 +105,9 @@ namespace Catch {
         typename std::enable_if<::Catch::Detail::IsStreamInsertable<Fake>::value, std::string>::type
             convert(const Fake& value) {
                 ReusableStringStream rss;
-                rss << value;
+                // NB: call using the function-like syntax to avoid ambiguity with
+                // user-defined templated operator<< under clang.
+                rss.operator<<(value);
                 return rss.str();
         }
 

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -1065,6 +1065,9 @@ ToStringWhich.tests.cpp:<line number>: passed: ::Catch::Detail::stringify(item) 
 ToStringWhich.tests.cpp:<line number>: passed: ::Catch::Detail::stringify( item ) == "operator<<( has_operator )" for: "operator<<( has_operator )"
 ==
 "operator<<( has_operator )"
+ToStringWhich.tests.cpp:<line number>: passed: ::Catch::Detail::stringify( item ) == "operator<<( has_template_operator )" for: "operator<<( has_template_operator )"
+==
+"operator<<( has_template_operator )"
 ToStringWhich.tests.cpp:<line number>: passed: ::Catch::Detail::stringify( v ) == "{ StringMaker<has_maker> }" for: "{ StringMaker<has_maker> }"
 ==
 "{ StringMaker<has_maker> }"

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -1084,6 +1084,6 @@ due to unexpected exception with message:
   Why would you throw a std::string?
 
 ===============================================================================
-test cases:  207 | 154 passed |  49 failed |  4 failed as expected
-assertions: 1064 | 936 passed | 107 failed | 21 failed as expected
+test cases:  208 | 155 passed |  49 failed |  4 failed as expected
+assertions: 1065 | 937 passed | 107 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -8408,6 +8408,20 @@ with expansion:
   "operator<<( has_operator )"
 
 -------------------------------------------------------------------------------
+stringify( has_template_operator )
+-------------------------------------------------------------------------------
+ToStringWhich.tests.cpp:<line number>
+...............................................................................
+
+ToStringWhich.tests.cpp:<line number>:
+PASSED:
+  REQUIRE( ::Catch::Detail::stringify( item ) == "operator<<( has_template_operator )" )
+with expansion:
+  "operator<<( has_template_operator )"
+  ==
+  "operator<<( has_template_operator )"
+
+-------------------------------------------------------------------------------
 stringify( vectors<has_maker> )
 -------------------------------------------------------------------------------
 ToStringWhich.tests.cpp:<line number>
@@ -8978,6 +8992,6 @@ Misc.tests.cpp:<line number>:
 PASSED:
 
 ===============================================================================
-test cases:  207 | 141 passed |  62 failed |  4 failed as expected
-assertions: 1078 | 936 passed | 121 failed | 21 failed as expected
+test cases:  208 | 142 passed |  62 failed |  4 failed as expected
+assertions: 1079 | 937 passed | 121 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="105" tests="1079" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="105" tests="1080" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <testcase classname="<exe-name>.global" name="# A test name that starts with a #" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1005: Comparing pointer to int and long (NULL can be either on various systems)" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1027" time="{duration}"/>
@@ -838,6 +838,7 @@ Tricky.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="stringify( has_maker_and_operator )" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="stringify( has_neither )" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="stringify( has_operator )" time="{duration}"/>
+    <testcase classname="<exe-name>.global" name="stringify( has_template_operator )" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="stringify( vectors&lt;has_maker> )" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="stringify( vectors&lt;has_maker_and_operator> )" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="stringify( vectors&lt;has_operator> )" time="{duration}"/>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -9366,6 +9366,19 @@ loose text artifact
       </Expression>
       <OverallResult success="true"/>
     </TestCase>
+    <TestCase name="stringify( has_template_operator )" tags="[toString]" filename="projects/<exe-name>/UsageTests/ToStringWhich.tests.cpp" >
+      <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/ToStringWhich.tests.cpp" >
+        <Original>
+          ::Catch::Detail::stringify( item ) == "operator&lt;&lt;( has_template_operator )"
+        </Original>
+        <Expanded>
+          "operator&lt;&lt;( has_template_operator )"
+==
+"operator&lt;&lt;( has_template_operator )"
+        </Expanded>
+      </Expression>
+      <OverallResult success="true"/>
+    </TestCase>
     <TestCase name="stringify( vectors&lt;has_maker> )" tags="[toString]" filename="projects/<exe-name>/UsageTests/ToStringWhich.tests.cpp" >
       <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/ToStringWhich.tests.cpp" >
         <Original>
@@ -9923,7 +9936,7 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="936" failures="122" expectedFailures="21"/>
+    <OverallResults successes="937" failures="122" expectedFailures="21"/>
   </Group>
-  <OverallResults successes="936" failures="121" expectedFailures="21"/>
+  <OverallResults successes="937" failures="121" expectedFailures="21"/>
 </Catch>

--- a/projects/SelfTest/UsageTests/ToStringWhich.tests.cpp
+++ b/projects/SelfTest/UsageTests/ToStringWhich.tests.cpp
@@ -20,6 +20,7 @@ struct has_operator { };
 struct has_maker {};
 struct has_maker_and_operator {};
 struct has_neither {};
+struct has_template_operator {};
 
 std::ostream& operator<<(std::ostream& os, const has_operator&) {
     os << "operator<<( has_operator )";
@@ -28,6 +29,12 @@ std::ostream& operator<<(std::ostream& os, const has_operator&) {
 
 std::ostream& operator<<(std::ostream& os, const has_maker_and_operator&) {
     os << "operator<<( has_maker_and_operator )";
+    return os;
+}
+
+template <typename StreamT>
+StreamT& operator<<(StreamT& os, const has_template_operator&) {
+    os << "operator<<( has_template_operator )";
     return os;
 }
 
@@ -67,6 +74,12 @@ TEST_CASE( "stringify( has_maker_and_operator )", "[toString]" ) {
 TEST_CASE("stringify( has_neither )", "[toString]") {
     has_neither item;
     REQUIRE( ::Catch::Detail::stringify(item) == "{ !!! }" );
+}
+
+// Call the templated operator
+TEST_CASE( "stringify( has_template_operator )", "[toString]" ) {
+    has_template_operator item;
+    REQUIRE( ::Catch::Detail::stringify( item ) == "operator<<( has_template_operator )" );
 }
 
 


### PR DESCRIPTION
## Description
What: use function syntax to call operator<< in StringMaker...
Why: ...so that it is not ambiguous with user-defined templated operator<< under clang.
Currently, the code below is ambiguous between the user defined operator<< and operator<<(StringMaker&, T) because both are templates and need one substitution.

```
struct myType {/* ... */};

template <class stream>
stream& operator<<(stream& out, const myType& myT) {
  out << myT.string_value();
  return out;
}
```

## GitHub Issues
Closes  #1285