### PR TITLE
catch_matchers: Fix compilation error with -Wnon-virtual-dtor

### DIFF
--- a/include/internal/catch_matchers.h
+++ b/include/internal/catch_matchers.h
@@ -34,6 +34,11 @@ namespace Matchers {
             mutable std::string m_cachedToString;
         };
 
+#ifdef __clang__
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wnon-virtual-dtor"
+#endif
+
         template<typename ObjectT>
         struct MatcherMethod {
             virtual bool match( ObjectT const& arg ) const = 0;
@@ -42,6 +47,10 @@ namespace Matchers {
         struct MatcherMethod<PtrT*> {
             virtual bool match( PtrT* arg ) const = 0;
         };
+
+#ifdef __clang__
+#    pragma clang diagnostic pop
+#endif
 
         template<typename T>
         struct MatcherBase : MatcherUntypedBase, MatcherMethod<T> {


### PR DESCRIPTION
Comping with clang and ```-Wnon-virtual-dtor``` fails as follows:

```
include/internal/catch_matchers.h:38:16: error:
  'Catch::Matchers::Impl::MatcherMethod<std::__1::basic_string<char> >'
  has virtual functions but non-virtual destructor [-Werror,-Wnon-virtual-dtor
```

This CL wraps the offending code in a pragma ignore.

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
