### PR TITLE
add no-rtti and no-exception support to catch2

### DIFF
--- a/include/internal/catch_approx.h
+++ b/include/internal/catch_approx.h
@@ -8,6 +8,7 @@
 #ifndef TWOBLUECUBES_CATCH_APPROX_HPP_INCLUDED
 #define TWOBLUECUBES_CATCH_APPROX_HPP_INCLUDED
 
+#include "catch_common.h"
 #include "catch_tostring.h"
 
 #include <type_traits>
@@ -84,10 +85,10 @@ namespace Detail {
         Approx& epsilon( T const& newEpsilon ) {
             double epsilonAsDouble = static_cast<double>(newEpsilon);
             if( epsilonAsDouble < 0 || epsilonAsDouble > 1.0 ) {
-                throw std::domain_error
+              Exception::doThrow( std::domain_error
                     (   "Invalid Approx::epsilon: " +
                         Catch::Detail::stringify( epsilonAsDouble ) +
-                        ", Approx::epsilon has to be between 0 and 1" );
+                        ", Approx::epsilon has to be between 0 and 1" ) );
             }
             m_epsilon = epsilonAsDouble;
             return *this;
@@ -97,10 +98,10 @@ namespace Detail {
         Approx& margin( T const& newMargin ) {
             double marginAsDouble = static_cast<double>(newMargin);
             if( marginAsDouble < 0 ) {
-                throw std::domain_error
+                Exception::doThrow( std::domain_error
                     (   "Invalid Approx::margin: " +
                          Catch::Detail::stringify( marginAsDouble ) +
-                         ", Approx::Margin has to be non-negative." );
+                         ", Approx::Margin has to be non-negative." ) );
 
             }
             m_margin = marginAsDouble;

--- a/include/internal/catch_assertionhandler.cpp
+++ b/include/internal/catch_assertionhandler.cpp
@@ -80,7 +80,7 @@ namespace Catch {
             CATCH_BREAK_INTO_DEBUGGER();
         }
         if( m_reaction.shouldThrow )
-            throw Catch::TestFailureException();
+            Exception::doThrow( Catch::TestFailureException() );
     }
     void AssertionHandler::setCompleted() {
         m_completed = true;

--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -22,6 +22,13 @@
 
 #if defined(CATCH_CONFIG_FAST_COMPILE)
 
+struct ConvertToAny {
+  template <typename T>
+  operator T() {
+    return T{};
+  }
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 // Another way to speed-up compilation is to omit local try-catch for REQUIRE*
 // macros.
@@ -30,8 +37,8 @@
 
 #else // CATCH_CONFIG_FAST_COMPILE
 
-#define INTERNAL_CATCH_TRY try
-#define INTERNAL_CATCH_CATCH( handler ) catch(...) { handler.handleUnexpectedInflightException(); }
+#define INTERNAL_CATCH_TRY CATCH_INTERNAL_TRY
+#define INTERNAL_CATCH_CATCH( handler ) CATCH_INTERNAL_CATCH_ALL() { handler.handleUnexpectedInflightException(); }
 
 #endif
 
@@ -64,11 +71,11 @@
 #define INTERNAL_CATCH_NO_THROW( macroName, resultDisposition, ... ) \
     do { \
         Catch::AssertionHandler catchAssertionHandler( macroName, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(__VA_ARGS__), resultDisposition ); \
-        try { \
+        CATCH_INTERNAL_TRY { \
             static_cast<void>(__VA_ARGS__); \
             catchAssertionHandler.handleExceptionNotThrownAsExpected(); \
         } \
-        catch( ... ) { \
+        CATCH_INTERNAL_CATCH_ALL() { \
             catchAssertionHandler.handleUnexpectedInflightException(); \
         } \
         INTERNAL_CATCH_REACT( catchAssertionHandler ) \

--- a/include/internal/catch_capture_matchers.h
+++ b/include/internal/catch_capture_matchers.h
@@ -55,7 +55,7 @@ namespace Catch {
 #define INTERNAL_CHECK_THAT( macroName, matcher, resultDisposition, arg ) \
     do { \
         Catch::AssertionHandler catchAssertionHandler( macroName, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(arg) ", " CATCH_INTERNAL_STRINGIFY(matcher), resultDisposition ); \
-        INTERNAL_CATCH_TRY { \
+        CATCH_INTERNAL_TRY { \
             catchAssertionHandler.handleExpr( Catch::makeMatchExpr( arg, matcher, #matcher ) ); \
         } INTERNAL_CATCH_CATCH( catchAssertionHandler ) \
         INTERNAL_CATCH_REACT( catchAssertionHandler ) \

--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -56,6 +56,14 @@
 #       define CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
             _Pragma( "clang diagnostic pop" )
 
+#if  !__has_feature(cxx_rtti)
+#    define CATCH_CONFIG_USE_RTTI 0
+#endif
+
+#if !__has_feature(cxx_exceptions)
+#    define CATCH_CONFIG_USE_EXCEPTIONS 0
+#endif
+
 #endif // __clang__
 
 
@@ -139,6 +147,13 @@
 #   define CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS
 #endif
 
+#if !defined(CATCH_CONFIG_USE_RTTI)
+#  define CATCH_CONFIG_USE_RTTI 1
+#endif
+
+#if !defined(CATCH_CONFIG_USE_EXCEPTIONS)
+#  define CATCH_CONFIG_USE_EXCEPTIONS 1
+#endif
 
 #endif // TWOBLUECUBES_CATCH_COMPILER_CAPABILITIES_HPP_INCLUDED
 

--- a/include/internal/catch_enforce.h
+++ b/include/internal/catch_enforce.h
@@ -16,9 +16,9 @@
 #define CATCH_PREPARE_EXCEPTION( type, msg ) \
     type( static_cast<std::ostringstream&&>( Catch::ReusableStringStream().get() << msg ).str() )
 #define CATCH_INTERNAL_ERROR( msg ) \
-    throw CATCH_PREPARE_EXCEPTION( std::logic_error, CATCH_INTERNAL_LINEINFO << ": Internal Catch error: " << msg);
+    Exception::doThrow( CATCH_PREPARE_EXCEPTION( std::logic_error, CATCH_INTERNAL_LINEINFO << ": Internal Catch error: " << msg) );
 #define CATCH_ERROR( msg ) \
-    throw CATCH_PREPARE_EXCEPTION( std::domain_error, msg )
+    Exception::doThrow( CATCH_PREPARE_EXCEPTION( std::domain_error, msg ) )
 #define CATCH_ENFORCE( condition, msg ) \
     do{ if( !(condition) ) CATCH_ERROR( msg ); } while(false)
 

--- a/include/internal/catch_exception_translator_registry.cpp
+++ b/include/internal/catch_exception_translator_registry.cpp
@@ -23,7 +23,7 @@ namespace Catch {
     }
 
     std::string ExceptionTranslatorRegistry::translateActiveException() const {
-        try {
+        CATCH_INTERNAL_TRY {
 #ifdef __OBJC__
             // In Objective-C try objective-c exceptions first
             @try {
@@ -47,19 +47,19 @@ namespace Catch {
             return tryTranslators();
 #endif
         }
-        catch( TestFailureException& ) {
+        CATCH_INTERNAL_CATCH_UNNAMED( TestFailureException& ) {
             std::rethrow_exception(std::current_exception());
         }
-        catch( std::exception& ex ) {
+        CATCH_INTERNAL_CATCH( std::exception&, ex ) {
             return ex.what();
         }
-        catch( std::string& msg ) {
+        CATCH_INTERNAL_CATCH( std::string&, msg ) {
             return msg;
         }
-        catch( const char* msg ) {
+        CATCH_INTERNAL_CATCH( const char*, msg ) {
             return msg;
         }
-        catch(...) {
+        CATCH_INTERNAL_CATCH_ALL() {
             return "Unknown exception";
         }
     }

--- a/include/internal/catch_interfaces_exception.h
+++ b/include/internal/catch_interfaces_exception.h
@@ -8,6 +8,7 @@
 #ifndef TWOBLUECUBES_CATCH_INTERFACES_EXCEPTION_H_INCLUDED
 #define TWOBLUECUBES_CATCH_INTERFACES_EXCEPTION_H_INCLUDED
 
+#include "catch_capture.hpp"  // for CATCH_INTERNAL_TRY
 #include "catch_interfaces_registry_hub.h"
 
 #if defined(CATCH_CONFIG_DISABLE)
@@ -46,13 +47,13 @@ namespace Catch {
             {}
 
             std::string translate( ExceptionTranslators::const_iterator it, ExceptionTranslators::const_iterator itEnd ) const override {
-                try {
+                CATCH_INTERNAL_TRY {
                     if( it == itEnd )
                         std::rethrow_exception(std::current_exception());
                     else
                         return (*it)->translate( it+1, itEnd );
                 }
-                catch( T& ex ) {
+                CATCH_INTERNAL_CATCH ( T&, ex ) {
                     return m_translateFunction( ex );
                 }
             }

--- a/include/internal/catch_matchers_floating.cpp
+++ b/include/internal/catch_matchers_floating.cpp
@@ -81,7 +81,7 @@ namespace Floating {
     WithinAbsMatcher::WithinAbsMatcher(double target, double margin)
         :m_target{ target }, m_margin{ margin } {
         if (m_margin < 0) {
-            throw std::domain_error("Allowed margin difference has to be >= 0");
+          Exception::doThrow( std::domain_error("Allowed margin difference has to be >= 0") );
         }
     }
 
@@ -99,7 +99,7 @@ namespace Floating {
     WithinUlpsMatcher::WithinUlpsMatcher(double target, int ulps, FloatingPointKind baseType)
         :m_target{ target }, m_ulps{ ulps }, m_type{ baseType } {
         if (m_ulps < 0) {
-            throw std::domain_error("Allowed ulp difference has to be >= 0");
+          Exception::doThrow( std::domain_error("Allowed ulp difference has to be >= 0") );
         }
     }
 
@@ -110,7 +110,7 @@ namespace Floating {
         case FloatingPointKind::Double:
             return almostEqualUlps<double>(matchee, m_target, m_ulps);
         default:
-            throw std::domain_error("Unknown FloatingPointKind value");
+            Exception::doThrow( std::domain_error("Unknown FloatingPointKind value") );
         }
     }
 

--- a/include/internal/catch_run_context.cpp
+++ b/include/internal/catch_run_context.cpp
@@ -297,7 +297,7 @@ namespace Catch {
         seedRng(*m_config);
 
         Timer timer;
-        try {
+        CATCH_INTERNAL_TRY {
             if (m_reporter->getPreferences().shouldRedirectStdOut) {
                 RedirectedStdOut redirectedStdOut;
                 RedirectedStdErr redirectedStdErr;
@@ -311,9 +311,9 @@ namespace Catch {
                 invokeActiveTestCase();
             }
             duration = timer.getElapsedSeconds();
-        } catch (TestFailureException&) {
+        } CATCH_INTERNAL_CATCH_UNNAMED (TestFailureException&) {
             // This just means the test was aborted due to failure
-        } catch (...) {
+        } CATCH_INTERNAL_CATCH_ALL() {
             // Under CATCH_CONFIG_FAST_COMPILE, unexpected exceptions under REQUIRE assertions
             // are reported without translation at the point of origin.
             if( m_shouldReportUnexpected ) {

--- a/include/internal/catch_session.cpp
+++ b/include/internal/catch_session.cpp
@@ -5,6 +5,7 @@
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
  */
 
+#include "catch_common.h"
 #include "catch_session.h"
 #include "catch_commandline.h"
 #include "catch_console_colour.h"
@@ -111,8 +112,10 @@ namespace Catch {
     Session::Session() {
         static bool alreadyInstantiated = false;
         if( alreadyInstantiated ) {
-            try         { CATCH_INTERNAL_ERROR( "Only one instance of Catch::Session can ever be used" ); }
-            catch(...)  { getMutableRegistryHub().registerStartupException(); }
+            CATCH_INTERNAL_TRY {
+                CATCH_INTERNAL_ERROR( "Only one instance of Catch::Session can ever be used" );
+            }
+            CATCH_INTERNAL_CATCH_ALL() { getMutableRegistryHub().registerStartupException(); }
         }
 
         const auto& exceptions = getRegistryHub().getStartupExceptionRegistry().getExceptions();
@@ -122,9 +125,9 @@ namespace Catch {
             Catch::cerr() << "Errors occured during startup!" << '\n';
             // iterate over all exceptions and notify user
             for ( const auto& ex_ptr : exceptions ) {
-                try {
+                CATCH_INTERNAL_TRY {
                     std::rethrow_exception(ex_ptr);
-                } catch ( std::exception const& ex ) {
+                } CATCH_INTERNAL_CATCH ( std::exception const&, ex ) {
                     Catch::cerr() << Column( ex.what() ).indent(2) << '\n';
                 }
             }
@@ -246,7 +249,7 @@ namespace Catch {
         if( m_configData.showHelp || m_configData.libIdentify )
             return 0;
 
-        try
+        CATCH_INTERNAL_TRY
         {
             config(); // Force config to be constructed
 
@@ -264,7 +267,7 @@ namespace Catch {
             // of 256 tests has failed
             return (std::min)( MaxExitCode, static_cast<int>( runTests( m_config ).assertions.failed ) );
         }
-        catch( std::exception& ex ) {
+        CATCH_INTERNAL_CATCH ( std::exception&, ex ) {
             Catch::cerr() << ex.what() << std::endl;
             return MaxExitCode;
         }

--- a/include/internal/catch_startup_exception_registry.cpp
+++ b/include/internal/catch_startup_exception_registry.cpp
@@ -7,13 +7,14 @@
  */
 
 #include "catch_startup_exception_registry.h"
+#include "catch_common.h"
 
 namespace Catch {
     void StartupExceptionRegistry::add( std::exception_ptr const& exception ) noexcept {
-        try {
+        CATCH_INTERNAL_TRY {
             m_exceptions.push_back(exception);
         }
-        catch(...) {
+        CATCH_INTERNAL_CATCH_ALL() {
             // If we run out of memory during start-up there's really not a lot more we can do about it
             std::terminate();
         }

--- a/include/internal/catch_tag_alias_autoregistrar.cpp
+++ b/include/internal/catch_tag_alias_autoregistrar.cpp
@@ -4,9 +4,9 @@
 namespace Catch {
     
     RegistrarForTagAliases::RegistrarForTagAliases(char const* alias, char const* tag, SourceLineInfo const& lineInfo) {
-        try {
+        CATCH_INTERNAL_TRY {
             getMutableRegistryHub().registerTagAlias(alias, tag, lineInfo);
-        } catch (...) {
+        } CATCH_INTERNAL_CATCH_ALL() {
             // Do not throw when constructing global objects, instead register the exception to be processed later
             getMutableRegistryHub().registerStartupException();
         }

--- a/include/internal/catch_test_registry.cpp
+++ b/include/internal/catch_test_registry.cpp
@@ -18,7 +18,7 @@ namespace Catch {
     NameAndTags::NameAndTags( StringRef name_ , StringRef tags_ ) noexcept : name( name_ ), tags( tags_ ) {}
 
     AutoReg::AutoReg( ITestInvoker* invoker, SourceLineInfo const& lineInfo, StringRef classOrMethod, NameAndTags const& nameAndTags ) noexcept {
-        try {
+        CATCH_INTERNAL_TRY {
             getMutableRegistryHub()
                     .registerTest(
                         makeTestCase(
@@ -27,7 +27,7 @@ namespace Catch {
                             nameAndTags.name,
                             nameAndTags.tags,
                             lineInfo));
-        } catch (...) {
+        } CATCH_INTERNAL_CATCH_ALL() {
             // Do not throw when constructing global objects, instead register the exception to be processed later
             getMutableRegistryHub().registerStartupException();
         }

--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -33,7 +33,7 @@ namespace Catch {
         {
             m_reporterPrefs.shouldRedirectStdOut = false;
             if( !DerivedT::getSupportedVerbosities().count( m_config->verbosity() ) )
-                throw std::domain_error( "Verbosity level not supported by this reporter" );
+                Exception::doThrow( std::domain_error( "Verbosity level not supported by this reporter" ) );
         }
 
         ReporterPreferences getPreferences() const override {
@@ -148,7 +148,7 @@ namespace Catch {
         {
             m_reporterPrefs.shouldRedirectStdOut = false;
             if( !DerivedT::getSupportedVerbosities().count( m_config->verbosity() ) )
-                throw std::domain_error( "Verbosity level not supported by this reporter" );
+                Exception::doThrow( std::domain_error( "Verbosity level not supported by this reporter" ) );
         }
         ~CumulativeReporterBase() override = default;
 

--- a/include/reporters/catch_reporter_teamcity.hpp
+++ b/include/reporters/catch_reporter_teamcity.hpp
@@ -97,12 +97,12 @@ namespace Catch {
                     case ResultWas::Ok:
                     case ResultWas::Info:
                     case ResultWas::Warning:
-                        throw std::domain_error( "Internal error in TeamCity reporter" );
+                        Exception::doThrow( std::domain_error( "Internal error in TeamCity reporter" ) );
                     // These cases are here to prevent compiler warnings
                     case ResultWas::Unknown:
                     case ResultWas::FailureBit:
                     case ResultWas::Exception:
-                        throw std::domain_error( "Not implemented" );
+                        Exception::doThrow( std::domain_error( "Not implemented" ) );
                 }
                 if( assertionStats.infoMessages.size() == 1 )
                     msg << " with message:";

--- a/projects/SelfTest/IntrospectiveTests/TagAlias.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/TagAlias.tests.cpp
@@ -9,7 +9,9 @@
 #include "catch.hpp"
 #include "internal/catch_tag_alias_registry.h"
 
+
 TEST_CASE( "Tag alias can be registered against tag patterns" ) {
+#if CATCH_CONFIG_USE_EXCEPTIONS
 
     Catch::TagAliasRegistry registry;
 
@@ -39,4 +41,6 @@ TEST_CASE( "Tag alias can be registered against tag patterns" ) {
         CHECK_THROWS( registry.add( "@no square bracket at start]", "", Catch::SourceLineInfo( "file", 3 ) ) );
         CHECK_THROWS( registry.add( "[@no square bracket at end", "", Catch::SourceLineInfo( "file", 3 ) ) );
     }
+
+#endif
 }

--- a/projects/SelfTest/UsageTests/Approx.tests.cpp
+++ b/projects/SelfTest/UsageTests/Approx.tests.cpp
@@ -149,13 +149,17 @@ TEST_CASE("Approx setters validate their arguments", "[Approx]") {
     REQUIRE_NOTHROW(Approx(0).margin(0));
     REQUIRE_NOTHROW(Approx(0).margin(1234656));
 
+#if CATCH_CONFIG_USE_EXCEPTIONS
     REQUIRE_THROWS_AS(Approx(0).margin(-2), std::domain_error);
+#endif
 
     REQUIRE_NOTHROW(Approx(0).epsilon(0));
     REQUIRE_NOTHROW(Approx(0).epsilon(1));
 
+#if CATCH_CONFIG_USE_EXCEPTIONS
     REQUIRE_THROWS_AS(Approx(0).epsilon(-0.001), std::domain_error);
     REQUIRE_THROWS_AS(Approx(0).epsilon(1.0001), std::domain_error);
+#endif
 }
 
 TEST_CASE("Default scale is invisible to comparison", "[Approx]") {

--- a/projects/SelfTest/UsageTests/Compilation.tests.cpp
+++ b/projects/SelfTest/UsageTests/Compilation.tests.cpp
@@ -41,7 +41,11 @@ namespace { namespace CompilationTests {
 
     void throws_int(bool b) {
         if (b) {
+#if CATCH_CONFIG_USE_EXCEPTIONS
             throw 1;
+#else
+            std::terminate();
+#endif
         }
     }
 
@@ -50,8 +54,10 @@ namespace { namespace CompilationTests {
         int a = 3;
         REQUIRE(a == t);
         CHECK(a == t);
+#if CATCH_CONFIG_USE_EXCEPTIONS
         REQUIRE_THROWS(throws_int(true));
         CHECK_THROWS_AS(throws_int(true), int);
+#endif
         REQUIRE_NOTHROW(throws_int(false));
 #ifndef CATCH_CONFIG_DISABLE_MATCHERS
         REQUIRE_THAT("aaa", Catch::EndsWith("aaa"));

--- a/projects/SelfTest/UsageTests/Exception.tests.cpp
+++ b/projects/SelfTest/UsageTests/Exception.tests.cpp
@@ -20,6 +20,10 @@
 #pragma clang diagnostic ignored "-Wmissing-noreturn"
 #endif
 
+#if CATCH_CONFIG_USE_EXCEPTIONS
+// Cannot use try/catch keywords with -fno-exceptions.
+// Even if an exception was to be "thrown" it would just call std::terminate instead.
+
 namespace { namespace ExceptionTests {
 
 #ifndef EXCEPTION_TEST_HELPERS_INCLUDED // Don't compile this more than once per TU
@@ -194,6 +198,8 @@ TEST_CASE( "#748 - captures with unexpected exceptions", "[.][failing][!throws][
 }
 
 }} // namespace ExceptionTests
+
+#endif // CATCH_CONFIG_USE_EXCEPTIONS
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/projects/SelfTest/UsageTests/Matchers.tests.cpp
+++ b/projects/SelfTest/UsageTests/Matchers.tests.cpp
@@ -45,6 +45,7 @@ namespace { namespace MatchersTests {
         int i;
     };
 
+#if CATCH_CONFIG_USE_EXCEPTIONS
     void doesNotThrow() {}
 
     [[noreturn]]
@@ -56,6 +57,7 @@ namespace { namespace MatchersTests {
     void throwsAsInt(int i) {
         throw i;
     }
+#endif
 
     class ExceptionMatcher : public Catch::MatcherBase<SpecialException> {
         int m_expected;
@@ -273,6 +275,7 @@ namespace { namespace MatchersTests {
             }
         }
 
+#if CATCH_CONFIG_USE_EXCEPTIONS
         TEST_CASE("Exception matchers that succeed", "[matchers][exceptions][!throws]") {
             CHECK_THROWS_MATCHES(throws(1), SpecialException, ExceptionMatcher{1});
             REQUIRE_THROWS_MATCHES(throws(2), SpecialException, ExceptionMatcher{2});
@@ -292,6 +295,7 @@ namespace { namespace MatchersTests {
                 REQUIRE_THROWS_MATCHES(throws(4), SpecialException, ExceptionMatcher{1});
             }
         }
+#endif
 
         TEST_CASE("Floating point matchers: float", "[matchers][floating-point]") {
             SECTION("Margin") {
@@ -322,6 +326,7 @@ namespace { namespace MatchersTests {
 
                 REQUIRE_THAT(NAN, !(WithinAbs(NAN, 100) || WithinULP(NAN, 123)));
             }
+#if CHECK_CONFIG_USE_EXCEPTIONS
             SECTION("Constructor validation") {
                 REQUIRE_NOTHROW(WithinAbs(1.f, 0.f));
                 REQUIRE_THROWS_AS(WithinAbs(1.f, -1.f), std::domain_error);
@@ -329,6 +334,7 @@ namespace { namespace MatchersTests {
                 REQUIRE_NOTHROW(WithinULP(1.f, 0));
                 REQUIRE_THROWS_AS(WithinULP(1.f, -1), std::domain_error);
             }
+#endif
         }
 
         TEST_CASE("Floating point matchers: double", "[matchers][floating-point]") {
@@ -359,6 +365,7 @@ namespace { namespace MatchersTests {
 
                 REQUIRE_THAT(NAN, !(WithinAbs(NAN, 100) || WithinULP(NAN, 123)));
             }
+#if CHECK_CONFIG_USE_EXCEPTIONS
             SECTION("Constructor validation") {
                 REQUIRE_NOTHROW(WithinAbs(1., 0.));
                 REQUIRE_THROWS_AS(WithinAbs(1., -1.), std::domain_error);
@@ -366,6 +373,7 @@ namespace { namespace MatchersTests {
                 REQUIRE_NOTHROW(WithinULP(1., 0));
                 REQUIRE_THROWS_AS(WithinULP(1., -1), std::domain_error);
             }
+#endif
         }
 
 } } // namespace MatchersTests

--- a/projects/SelfTest/UsageTests/Tricky.tests.cpp
+++ b/projects/SelfTest/UsageTests/Tricky.tests.cpp
@@ -383,16 +383,20 @@ TEST_CASE( "has printf" ) {
 }
 
 namespace {
+#if CHECK_CONFIG_USE_EXCEPTIONS
     struct constructor_throws {
         [[noreturn]] constructor_throws() {
             throw 1;
         }
     };
+#endif
 }
 
 TEST_CASE("Commas in various macros are allowed") {
+#if CHECK_CONFIG_USE_EXCEPTIONS
     REQUIRE_THROWS( std::vector<constructor_throws>{constructor_throws{}, constructor_throws{}} );
     CHECK_THROWS( std::vector<constructor_throws>{constructor_throws{}, constructor_throws{}} );
+#endif
     REQUIRE_NOTHROW( std::vector<int>{1, 2, 3} == std::vector<int>{1, 2, 3} );
     CHECK_NOTHROW( std::vector<int>{1, 2, 3} == std::vector<int>{1, 2, 3} );
 
@@ -416,9 +420,11 @@ TEST_CASE( "null deref", "[.][failing][!nonportable]" ) {
 }
 
 TEST_CASE( "non-copyable objects", "[.][failing]" ) {
+#if CHECK_CONFIG_USE_RTTI
     // Thanks to Agustin Bergé (@k-ballo on the cpplang Slack) for raising this
     std::type_info const& ti = typeid(int);
     CHECK( ti == typeid(int) );
+#endif
 }
 
 // #925

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1570,12 +1570,12 @@ namespace Catch {
 ///////////////////////////////////////////////////////////////////////////////
 // Another way to speed-up compilation is to omit local try-catch for REQUIRE*
 // macros.
-#define INTERNAL_CATCH_TRY
+#define CATCH_INTERNAL_TRY
 #define INTERNAL_CATCH_CATCH( capturer )
 
 #else // CATCH_CONFIG_FAST_COMPILE
 
-#define INTERNAL_CATCH_TRY try
+#define CATCH_INTERNAL_TRY try
 #define INTERNAL_CATCH_CATCH( handler ) catch(...) { handler.handleUnexpectedInflightException(); }
 
 #endif
@@ -1586,7 +1586,7 @@ namespace Catch {
 #define INTERNAL_CATCH_TEST( macroName, resultDisposition, ... ) \
     do { \
         Catch::AssertionHandler catchAssertionHandler( macroName, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(__VA_ARGS__), resultDisposition ); \
-        INTERNAL_CATCH_TRY { \
+        CATCH_INTERNAL_TRY { \
             CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
             catchAssertionHandler.handleExpr( Catch::Decomposer() <= __VA_ARGS__ ); \
             CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
@@ -2592,7 +2592,7 @@ namespace Catch {
 #define INTERNAL_CHECK_THAT( macroName, matcher, resultDisposition, arg ) \
     do { \
         Catch::AssertionHandler catchAssertionHandler( macroName, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(arg) ", " CATCH_INTERNAL_STRINGIFY(matcher), resultDisposition ); \
-        INTERNAL_CATCH_TRY { \
+        CATCH_INTERNAL_TRY { \
             catchAssertionHandler.handleExpr( Catch::makeMatchExpr( arg, matcher, #matcher ) ); \
         } INTERNAL_CATCH_CATCH( catchAssertionHandler ) \
         INTERNAL_CATCH_REACT( catchAssertionHandler ) \


### PR DESCRIPTION
Hi, I'm trying to port catch2 so we can use it in aosp (https://source.android.com/) and also because rxcpp (https://github.com/ReactiveX/RxCpp) is using catch2 for its test suite (which I'm also in the process of downstreaming to aosp). 

All of our code is compiled with clang -fno-exceptions -fno-rtti, so do you have any interest in taking patches to add support for this?

This is my initial attempt. If there's interest I can make any changes as you see fit, I would like to avoid having an aosp-only fork.

-----------------------

(This is a work-in-progress)

try/catch/throw/typeid become illegal keywords when their compiler
support is disabled.

By quering the compiler __has__feature we can determine if those
keywords would be legal to use or not.

For RTTI, disable the offending tests and replace dynamic_cast with
virtual calls.

For exceptions, replace try/catch with macros and throw with an
std::terminate.

Limitations: Currently when a REQUIRE() call fails it immediately
calls std::terminate, causing the rest of the test run to abort.

Correctness: Running the SelfTest main by itself passes 100%.

However running approvalTests script (without rtti and exceptions) fails,
largely because the .txt files that are diffed against have test output
that is now disabled without exceptions.

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
