### PR TITLE
Abort when assertions failed is greater than or equal to config value

### DIFF
--- a/include/internal/catch_run_context.cpp
+++ b/include/internal/catch_run_context.cpp
@@ -313,7 +313,7 @@ namespace Catch {
     }
 
     bool RunContext::aborting() const {
-        return m_totals.assertions.failed == static_cast<std::size_t>(m_config->abortAfter());
+        return m_totals.assertions.failed >= static_cast<std::size_t>(m_config->abortAfter());
     }
 
     void RunContext::runCurrentTest(std::string & redirectedCout, std::string & redirectedCerr) {


### PR DESCRIPTION
## Description

Changes the `aborting()` comparison to also handle when `m_totals.assertions.failed` is greater than `m_config->abortAfter()`.

It is possible for this to occur under incorrect (but valid) use of assertions such as `REQUIRED`.

## GitHub Issues

Fixes issue https://github.com/catchorg/Catch2/issues/1391
