### PR TITLE
Fixes disagreement between `operator<<` available for SFINAE and actually usable

### DIFF
--- a/include/internal/catch_common.h
+++ b/include/internal/catch_common.h
@@ -22,6 +22,10 @@
 #include <string>
 #include <cstdint>
 
+// We need a dummy global operator<< so we can bring it into Catch namespace later
+struct Catch_global_namespace_dummy {};
+std::ostream& operator<<(std::ostream&, Catch_global_namespace_dummy);
+
 namespace Catch {
 
     struct CaseSensitive { enum Choice {
@@ -62,6 +66,11 @@ namespace Catch {
     };
 
     std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info );
+
+    // Bring in operator<< from global namespace into Catch namespace
+    // This is necessary because the overload of operator<< above makes
+    // lookup stop at namespace Catch
+    using ::operator<<;
 
     // Use this in variadic streaming macros to allow
     //    >> +StreamEndStop

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -29,15 +29,7 @@
 #pragma warning(disable:4180) // We attempt to stream a function (address) by const&, which MSVC complains about but is harmless
 #endif
 
-
-// We need a dummy global operator<< so we can bring it into Catch namespace later
-struct Catch_global_namespace_dummy {};
-std::ostream& operator<<(std::ostream&, Catch_global_namespace_dummy);
-
 namespace Catch {
-    // Bring in operator<< from global namespace into Catch namespace
-    using ::operator<<;
-
     namespace Detail {
 
         extern const std::string unprintableString;

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -13,6 +13,7 @@ Misc.tests.cpp:<line number>: passed:
 Compilation.tests.cpp:<line number>: passed: std::memcmp(uarr, "123", sizeof(uarr)) == 0 for: 0 == 0 with 2 messages: 'uarr := "123"' and 'sarr := "456"'
 Compilation.tests.cpp:<line number>: passed: std::memcmp(sarr, "456", sizeof(sarr)) == 0 for: 0 == 0 with 2 messages: 'uarr := "123"' and 'sarr := "456"'
 Compilation.tests.cpp:<line number>: passed:
+Compilation.tests.cpp:<line number>: passed: h1 == h2 for: [1403 helper] == [1403 helper]
 Exception.tests.cpp:<line number>: failed: unexpected exception with message: 'answer := 42' with 1 message: 'expected exception'
 Exception.tests.cpp:<line number>: failed: unexpected exception with message: 'answer := 42'; expression was: thisThrows() with 1 message: 'expected exception'
 Exception.tests.cpp:<line number>: passed: thisThrows() with 1 message: 'answer := 42'

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -1096,6 +1096,6 @@ due to unexpected exception with message:
   Why would you throw a std::string?
 
 ===============================================================================
-test cases:  213 |  160 passed |  49 failed |  4 failed as expected
-assertions: 1228 | 1099 passed | 108 failed | 21 failed as expected
+test cases:  214 |  161 passed |  49 failed |  4 failed as expected
+assertions: 1229 | 1100 passed | 108 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -136,6 +136,18 @@ Compilation.tests.cpp:<line number>:
 PASSED:
 
 -------------------------------------------------------------------------------
+#1403
+-------------------------------------------------------------------------------
+Compilation.tests.cpp:<line number>
+...............................................................................
+
+Compilation.tests.cpp:<line number>:
+PASSED:
+  REQUIRE( h1 == h2 )
+with expansion:
+  [1403 helper] == [1403 helper]
+
+-------------------------------------------------------------------------------
 #748 - captures with unexpected exceptions
   outside assertions
 -------------------------------------------------------------------------------
@@ -10834,6 +10846,6 @@ Misc.tests.cpp:<line number>:
 PASSED:
 
 ===============================================================================
-test cases:  213 |  147 passed |  62 failed |  4 failed as expected
-assertions: 1242 | 1099 passed | 122 failed | 21 failed as expected
+test cases:  214 |  148 passed |  62 failed |  4 failed as expected
+assertions: 1243 | 1100 passed | 122 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.swa4.approved.txt
+++ b/projects/SelfTest/Baselines/console.swa4.approved.txt
@@ -136,6 +136,18 @@ Compilation.tests.cpp:<line number>:
 PASSED:
 
 -------------------------------------------------------------------------------
+#1403
+-------------------------------------------------------------------------------
+Compilation.tests.cpp:<line number>
+...............................................................................
+
+Compilation.tests.cpp:<line number>:
+PASSED:
+  REQUIRE( h1 == h2 )
+with expansion:
+  [1403 helper] == [1403 helper]
+
+-------------------------------------------------------------------------------
 #748 - captures with unexpected exceptions
   outside assertions
 -------------------------------------------------------------------------------
@@ -341,6 +353,6 @@ with expansion:
   !true
 
 ===============================================================================
-test cases: 14 | 11 passed | 1 failed | 2 failed as expected
-assertions: 38 | 31 passed | 4 failed | 3 failed as expected
+test cases: 15 | 12 passed | 1 failed | 2 failed as expected
+assertions: 39 | 32 passed | 4 failed | 3 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="106" tests="1243" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="106" tests="1244" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <testcase classname="<exe-name>.global" name="# A test name that starts with a #" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1005: Comparing pointer to int and long (NULL can be either on various systems)" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1027" time="{duration}"/>
@@ -9,6 +9,7 @@
     <testcase classname="<exe-name>.global" name="#1175 - Hidden Test" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1238" time="{duration}"/>
     <testcase classname="<exe-name>.(Fixture_1245&lt;int, int>)" name="#1245" time="{duration}"/>
+    <testcase classname="<exe-name>.global" name="#1403" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#748 - captures with unexpected exceptions/outside assertions" time="{duration}">
       <error type="TEST_CASE">
 expected exception

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -130,6 +130,17 @@
     <TestCase name="#1245" tags="[compilation]" filename="projects/<exe-name>/UsageTests/Compilation.tests.cpp" >
       <OverallResult success="true"/>
     </TestCase>
+    <TestCase name="#1403" tags="[compilation]" filename="projects/<exe-name>/UsageTests/Compilation.tests.cpp" >
+      <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Compilation.tests.cpp" >
+        <Original>
+          h1 == h2
+        </Original>
+        <Expanded>
+          [1403 helper] == [1403 helper]
+        </Expanded>
+      </Expression>
+      <OverallResult success="true"/>
+    </TestCase>
     <TestCase name="#748 - captures with unexpected exceptions" tags="[!shouldfail][!throws][.][failing]" filename="projects/<exe-name>/UsageTests/Exception.tests.cpp" >
       <Section name="outside assertions" filename="projects/<exe-name>/UsageTests/Exception.tests.cpp" >
         <Info>
@@ -11321,7 +11332,7 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="1099" failures="123" expectedFailures="21"/>
+    <OverallResults successes="1100" failures="123" expectedFailures="21"/>
   </Group>
-  <OverallResults successes="1099" failures="122" expectedFailures="21"/>
+  <OverallResults successes="1100" failures="122" expectedFailures="21"/>
 </Catch>

--- a/projects/SelfTest/UsageTests/Compilation.tests.cpp
+++ b/projects/SelfTest/UsageTests/Compilation.tests.cpp
@@ -5,6 +5,27 @@
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
  */
 
+// Setup for #1403 -- look for global overloads of operator << for classes
+// in a different namespace.
+
+#include <ostream>
+
+
+
+namespace foo {
+    struct helper_1403 {
+        bool operator==(helper_1403) const { return true; }
+    };
+}
+
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
+#endif
+std::ostream& operator<<(std::ostream& out, foo::helper_1403 const&) {
+    return out << "[1403 helper]";
+}
+///////////////////////////////
+ 
 #include "catch.hpp"
 
 #include <cstring>
@@ -153,5 +174,12 @@ namespace { namespace CompilationTests {
     TEST_CASE_METHOD((Fixture_1245<int, int>), "#1245", "[compilation]") {
         SUCCEED();
     }
-
+    
+    TEST_CASE("#1403", "[compilation]") {
+        ::foo::helper_1403 h1, h2;
+        REQUIRE(h1 == h2);
+    }
+    
 }} // namespace CompilationTests
+
+


### PR DESCRIPTION
## Description

Originally I reported a bug, [1403](https://github.com/catchorg/Catch2/issues/1403) about how user code provides an insertion overload (an overload for `operator<<`) for an `std` type in the global namespace, however, the code fails to compile in Clang at the point Catch tries to use it, at `ReusableStringStream::operator<<`.  This happens because the SFINAE tests for insertion availability happen after `using ::operator<<`, thus the global overload is available, which activates the `Reusable`..., but when actually attempted to use them at `ReusableStringStream::operator<<` they are **not** available because:
1. there hasn't been the `using ::operator<<` at that point
2. at the namespace `Catch` there has been one overload for `operator<<(std::ostream &, SourceLineInfo const &)` that makes the global overloads not available.

This is not a strict bug because the user is providing an overload for types in `std` in the global namespace, which is not "the same namespace" as indicated in the Catch documentation.

However, adding to the `std` namespace overloads of `operator<<` are **undefined behavior**, and thus the only other choice for a user who wants to allow catch to stream-insert `std` types would be to put the overloads for `std` types into `Catch`, which then are inconvenient to use from the global namespace or the user namespaces.  It seems the code tries to use `operator<<` global overloads, which works in GCC and perhaps other compilers that have broken two-phase lookup, but does not work in Clang which does it correctly in this case.

With the fix presented, users will now be able to provide inserters in either the same namespace as their types (this does not change) or the global namespace, and Catch2 would be able to *consistently* test for insertion and use the given insertion operations.

The fix is simple, to hoist the `using ::operator<<` directive to right after introducing an overload into `Catch` namespace, which is the point at which the global overloads become non-available.

I am thankful to Github user @mpark for his help elucidating ADL.

## GitHub Issues
[1403](https://github.com/catchorg/Catch2/issues/1403)
#Closes 1403
