### PR TITLE
Fix build in GCC 7

### DIFF
--- a/include/internal/catch_tostring.cpp
+++ b/include/internal/catch_tostring.cpp
@@ -214,7 +214,7 @@ std::string StringMaker<char>::convert(char value) {
         return "'\\n'";
     } else if (value == '\t') {
         return "'\\t'";
-    } else if ('\0' <= value && value < ' ') {
+    } else if (value < ' ') {
         return ::Catch::Detail::stringify(static_cast<unsigned int>(value));
     } else {
         char chstr[] = "' '";


### PR DESCRIPTION
The following error is emitted by gcc 7.3:

include/internal/catch_tostring.cpp:217:21: error: comparison is always true due to limited range of data type [-Werror=type-limits]
|      } else if ('\0' <= value && value < ' ') {
|                 ~~~~~^~~~~~~~
| cc1plus: all warnings being treated as errors

We can drop the first part of the if since '\0' == 0 and it will always
be <= than value of char (which is unsigned by default).

Signed-off-by: Bartosz Golaszewski <bgolaszewski@baylibre.com>

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
