### PR TITLE
Fix catch_discover_tests() - should find tests with commas | Related to #1327

### DIFF
--- a/contrib/CatchAddTests.cmake
+++ b/contrib/CatchAddTests.cmake
@@ -51,12 +51,14 @@ string(REPLACE "\n" ";" output "${output}")
 # Parse output
 foreach(line ${output})
   set(test ${line})
+  # use escape commas to handle properly test cases with commans inside the name
+  string(REPLACE "," "\\," test_name ${test})
   # ...and add to script
   add_command(add_test
     "${prefix}${test}${suffix}"
     ${TEST_EXECUTOR}
     "${TEST_EXECUTABLE}"
-    "${test}"
+    "${test_name}"
     ${extra_args}
   )
   add_command(set_tests_properties


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
Fix for issue described in #1327 

As Catch requires escape commas to find tests with commas. I've added proper command creation for test cases.

"Fixed" output will show correct test name (as before) but test will run correctly and command will include "\\," for easier manual running of the test. 

```
[...]
test 1
    Start 1: Test case with a, in it

1: Test command: /home/mpatro/projects/open_source/catch_comma/mytest "Test case with a\, in it"
1: Test timeout computed to be: 1500
1: 
1: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1: mytest is a Catch v2.4.1 host application.
1: Run with -? for options
1: 
1: -------------------------------------------------------------------------------
1: Test case with a, in it
1: -------------------------------------------------------------------------------
1: /home/mpatro/projects/open_source/catch_comma/test.cpp:4
1: ...............................................................................
1: 
1: /home/mpatro/projects/open_source/catch_comma/test.cpp:6: FAILED:
1:   REQUIRE( 1 == 0 )
1: 
1: ===============================================================================
1: test cases: 1 | 1 failed
1: assertions: 1 | 1 failed
1: 
1/1 Test #1: Test case with a, in it ..........***Failed    0.01 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.02 sec

The following tests FAILED:
	  1 - Test case with a, in it (Failed)
Errors while running CTest

```

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
#1327 