### PR TITLE
Catch::LeakDetector: added cleanup call to destructor

### DIFF
--- a/include/internal/catch_leak_detector.cpp
+++ b/include/internal/catch_leak_detector.cpp
@@ -6,6 +6,7 @@
  */
 
  #include "catch_leak_detector.h"
+ #include "catch_interfaces_registry_hub.h"
 
 
 #ifdef CATCH_CONFIG_WINDOWS_CRTDBG
@@ -30,3 +31,7 @@ namespace Catch {
     Catch::LeakDetector::LeakDetector() {}
 
 #endif
+
+Catch::LeakDetector::~LeakDetector() {
+    Catch::cleanUp();
+}

--- a/include/internal/catch_leak_detector.h
+++ b/include/internal/catch_leak_detector.h
@@ -11,6 +11,7 @@ namespace Catch {
 
     struct LeakDetector {
         LeakDetector();
+        ~LeakDetector();
     };
 
 }


### PR DESCRIPTION
simple code with provided main function which just returns 0
leaks memory due to fact that singletons are not cleaned up

running valgrind on such simple application reports that 752 bytes
are still available in 11 blocks

this commit adds destructor to Catch::LeakDetector which calls
Catch::cleanUp()

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
There is already existing https://github.com/catchorg/Catch2/pull/1063 which added the destructor but seems to be abandoned.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->