### PR TITLE
Add the optional variable OptionalCatchTestLauncher

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -39,6 +39,11 @@
 #    PARSE_CATCH_TESTS_ADD_TO_CONFIGURE_DEPENDS (Default OFF)                                      #
 #    -- causes CMake to rerun when file with tests changes so that new tests will be discovered    #
 #                                                                                                  #
+# One can also set (locally) the optional variable OptionalCatchTestLauncher to precise the way    #
+# a test should be run. For instance to use test MPI, one can write                                #
+#     set(OptionalCatchTestLauncher ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NUMPROC})                 #
+# just before calling this ParseAndAddCatchTests function                                          #
+#                                                                                                  #
 #==================================================================================================#
 
 cmake_minimum_required(VERSION 2.8.8)
@@ -168,7 +173,7 @@ function(ParseFile SourceFile TestTarget)
             endif()
 
             # Add the test and set its properties
-            add_test(NAME "\"${CTestName}\"" COMMAND ${TestTarget} ${Name} ${AdditionalCatchParameters})
+            add_test(NAME "\"${CTestName}\"" COMMAND ${OptionalCatchTestLauncher} ${TestTarget} ${Name} ${AdditionalCatchParameters})
             set_tests_properties("\"${CTestName}\"" PROPERTIES FAIL_REGULAR_EXPRESSION "No tests ran"
                                                     LABELS "${Labels}")
         endif()

--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -172,6 +172,16 @@ step will be re-ran when the test files change, letting new tests be
 automatically discovered. Defaults to `OFF`.
 
 
+Optionally, one can specify a launching command to run tests by setting the
+variable `OptionalCatchTestLauncher` before calling `ParseAndAddCatchTests`. For
+instance to run some tests using `MPI` and other sequentially, one can write
+```cmake
+set(OptionalCatchTestLauncher ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NUMPROC})
+ParseAndAddCatchTests(mpi_foo)
+unset(OptionalCatchTestLauncher)
+ParseAndAddCatchTests(bar)
+```
+
 ## CMake project options
 
 Catch2's CMake project also provides some options for other projects


### PR DESCRIPTION
This is related to the `contrib/ParseAndAddCatchTests.cmake` script.

This is a very small but (I think) useful situational change.

This variable is set to allow the use of the nice `ParseAndAddCatchTests` script
in the case where a launcher is needed to execute  the script.

This is introduced to allow to launch unit tests using mpi. In this case one can write for instance `set(OptionalCatchTestLauncher ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NUMPROC})` before calling the `ParseAndAddCatchTests` function.

Note that the `OptionalCatchTestLauncher` is not a global CMake variable/option but is meant to be set to different values while registrating tests. In my case for instance, I register sequential unit tests as well a MPI unit tests.

Best regards,
Stéphane.
