### PR TITLE
Add the static library Catch2::Main for non-standalone builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,14 @@ endif()
 # provide a namespaced alias for clients to 'link' against if catch is included as a sub-project
 add_library(Catch2::Catch2 ALIAS Catch2)
 
+if (NOT NOT_SUBPROJECT)
+    add_library(Catch2Main src/catch_with_main.cpp)
+
+    target_link_libraries(Catch2Main Catch2)
+
+    add_library(Catch2::Main ALIAS Catch2Main)
+endif ()
+
 # Only perform the installation steps when Catch is not being used as
 # a subproject via `add_subdirectory`, or the destinations will break,
 # see https://github.com/catchorg/Catch2/issues/1373

--- a/docs/slow-compiles.md
+++ b/docs/slow-compiles.md
@@ -64,6 +64,18 @@ tests-factorial.cpp:11: failed: Factorial(0) == 1 for: 0 == 1
 Failed 1 test case, failed 1 assertion.
 ```
 
+## Using the static library Catch2Main
+
+Catch also provides a static library that implements the runner. When
+Catch2 is included with `add_subdirectory` using CMake, it is possible to simply
+link against this library which also provides the include path for the header.
+
+```cmake
+add_executable(tests-factorial tests-factorial.cpp)
+
+target_link_libraries(tests-factorial Catch2::Main)
+```
+
 ## Other possible solutions
 You can also opt to sacrifice some features in order to speed-up Catch's compilation times. For details see the [documentation on Catch's compile-time configuration](configuration.md#other-toggles).
 

--- a/src/catch_with_main.cpp
+++ b/src/catch_with_main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>


### PR DESCRIPTION
While the current method of adding the compile definition to a single translation unit that builds up a program is viable for multiple translation units, single executable scenarios, it is also possible that each translation unit becomes its own program. In such cases, the user needs to make a dummy source such as the one in this PR and link all objects against the dummy object corresponding to it.

This PR adds a new static library that lets users to opt-in to linking in CMake to streamline using the library.