### PR TITLE
ConsoleReporter: minor formatting fix

### DIFF
--- a/include/reporters/catch_reporter_console.cpp
+++ b/include/reporters/catch_reporter_console.cpp
@@ -111,8 +111,6 @@ public:
     void print() const {
         printSourceInfo();
         if (stats.totals.assertions.total() > 0) {
-            if (result.isOk())
-                stream << '\n';
             printResultType();
             printOriginalExpression();
             printReconstructedExpression();

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -392,8 +392,7 @@ Message.tests.cpp:<line number>: FAILED:
 explicitly with message:
   This is a failure
 
-Message.tests.cpp:<line number>:
-warning:
+Message.tests.cpp:<line number>: warning:
   This message appears in the output
 
 -------------------------------------------------------------------------------
@@ -402,8 +401,7 @@ INFO and WARN do not abort tests
 Message.tests.cpp:<line number>
 ...............................................................................
 
-Message.tests.cpp:<line number>:
-warning:
+Message.tests.cpp:<line number>: warning:
   this is a warning
 
 -------------------------------------------------------------------------------
@@ -528,8 +526,7 @@ Nice descriptive name
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-warning:
+Misc.tests.cpp:<line number>: warning:
   This one ran
 
 -------------------------------------------------------------------------------
@@ -909,8 +906,7 @@ Where the LHS is not a simple value
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-warning:
+Tricky.tests.cpp:<line number>: warning:
   Uncomment the code in this test to check that it gives a sensible compiler
   error
 
@@ -920,8 +916,7 @@ Where there is more to the expression after the RHS
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-warning:
+Tricky.tests.cpp:<line number>: warning:
   Uncomment the code in this test to check that it gives a sensible compiler
   error
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -11,8 +11,7 @@ Randomness seeded to: 1
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   yay
 
@@ -23,14 +22,12 @@ with message:
 Decomposition.tests.cpp:<line number>
 ...............................................................................
 
-Decomposition.tests.cpp:<line number>:
-PASSED:
+Decomposition.tests.cpp:<line number>: PASSED:
   REQUIRE( fptr == 0 )
 with expansion:
   0 == 0
 
-Decomposition.tests.cpp:<line number>:
-PASSED:
+Decomposition.tests.cpp:<line number>: PASSED:
   REQUIRE( fptr == 0l )
 with expansion:
   0 == 0
@@ -41,14 +38,12 @@ with expansion:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( y.v == 0 )
 with expansion:
   0 == 0
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( 0 == y.v )
 with expansion:
   0 == 0
@@ -59,38 +54,32 @@ with expansion:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( t1 == t2 )
 with expansion:
   {?} == {?}
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( t1 != t2 )
 with expansion:
   {?} != {?}
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( t1 < t2 )
 with expansion:
   {?} < {?}
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( t1 > t2 )
 with expansion:
   {?} > {?}
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( t1 <= t2 )
 with expansion:
   {?} <= {?}
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( t1 >= t2 )
 with expansion:
   {?} >= {?}
@@ -101,8 +90,7 @@ with expansion:
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 #1238
@@ -110,8 +98,7 @@ PASSED:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( std::memcmp(uarr, "123", sizeof(uarr)) == 0 )
 with expansion:
   0 == 0
@@ -119,8 +106,7 @@ with messages:
   uarr := "123"
   sarr := "456"
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( std::memcmp(sarr, "456", sizeof(sarr)) == 0 )
 with expansion:
   0 == 0
@@ -134,8 +120,7 @@ with messages:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 #1403
@@ -143,8 +128,7 @@ PASSED:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( h1 == h2 )
 with expansion:
   [1403 helper] == [1403 helper]
@@ -181,8 +165,7 @@ due to unexpected exception with messages:
 Exception.tests.cpp:<line number>
 ...............................................................................
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS( thisThrows() )
 with message:
   answer := 42
@@ -193,8 +176,7 @@ with message:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( 42 == f )
 with expansion:
   42 == {?}
@@ -205,38 +187,31 @@ with expansion:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( a == t )
 with expansion:
   3 == 3
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   CHECK( a == t )
 with expansion:
   3 == 3
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS( throws_int(true) )
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   CHECK_THROWS_AS( throws_int(true), int )
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( throws_int(false) )
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( "aaa", Catch::EndsWith("aaa") )
 with expansion:
   "aaa" ends with: "aaa"
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( templated_tests<int>(3) )
 with expansion:
   true
@@ -252,8 +227,7 @@ Misc.tests.cpp:<line number>: FAILED:
 with expansion:
   1 == 0
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( errno == 1 )
 with expansion:
   1 == 1
@@ -264,8 +238,7 @@ with expansion:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( x == 4 )
 with expansion:
   {?} == 4
@@ -279,8 +252,7 @@ with message:
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   Everything is OK
 
@@ -291,8 +263,7 @@ with message:
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   Everything is OK
 
@@ -303,8 +274,7 @@ with message:
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   Everything is OK
 
@@ -315,8 +285,7 @@ with message:
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   Everything is OK
 
@@ -327,8 +296,7 @@ with message:
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   Everything is OK
 
@@ -378,46 +346,38 @@ Condition.tests.cpp:<line number>: FAILED:
 Condition.tests.cpp:<line number>
 ...............................................................................
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( false == false )
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( true == true )
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( !false )
 with expansion:
   true
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE_FALSE( false )
 with expansion:
   !false
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( !falseValue )
 with expansion:
   true
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE_FALSE( falseValue )
 with expansion:
   !false
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( !(1 == 2) )
 with expansion:
   true
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE_FALSE( 1 == 2 )
 
 -------------------------------------------------------------------------------
@@ -427,14 +387,12 @@ PASSED:
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( is_true<true>::value == true )
 with expansion:
   true == true
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( true == is_true<true>::value )
 with expansion:
   true == true
@@ -446,14 +404,12 @@ with expansion:
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( is_true<false>::value == false )
 with expansion:
   false == false
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( false == is_true<false>::value )
 with expansion:
   false == false
@@ -465,8 +421,7 @@ with expansion:
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( !is_true<false>::value )
 with expansion:
   true
@@ -478,8 +433,7 @@ with expansion:
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( !!is_true<true>::value )
 with expansion:
   true
@@ -491,14 +445,12 @@ with expansion:
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( is_true<true>::value )
 with expansion:
   true
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE_FALSE( is_true<false>::value )
 with expansion:
   !false
@@ -509,8 +461,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 101
@@ -521,8 +472,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 102
@@ -533,8 +483,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 103
@@ -545,8 +494,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 104
@@ -557,8 +505,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 105
@@ -569,8 +516,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 106
@@ -581,8 +527,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 107
@@ -593,8 +538,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 108
@@ -605,8 +549,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 109
@@ -617,8 +560,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 110
@@ -629,8 +571,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 101
@@ -641,8 +582,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 102
@@ -653,8 +593,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 103
@@ -665,8 +604,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 104
@@ -677,8 +615,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 105
@@ -689,8 +626,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 106
@@ -701,8 +637,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 107
@@ -713,8 +648,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 108
@@ -725,8 +659,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 109
@@ -737,8 +670,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 110
@@ -749,8 +681,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 101
@@ -761,8 +692,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 102
@@ -773,8 +703,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 103
@@ -785,8 +714,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 104
@@ -797,8 +725,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 105
@@ -809,8 +736,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 106
@@ -821,8 +747,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 107
@@ -833,8 +758,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 108
@@ -845,8 +769,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 109
@@ -857,8 +780,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 110
@@ -869,8 +791,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   4 < 101
@@ -881,8 +802,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   4 < 102
@@ -893,8 +813,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   4 < 103
@@ -905,8 +824,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   4 < 104
@@ -917,8 +835,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   4 < 105
@@ -929,8 +846,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   4 < 106
@@ -941,8 +857,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   4 < 107
@@ -953,8 +868,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   4 < 108
@@ -965,8 +879,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   4 < 109
@@ -977,8 +890,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   4 < 110
@@ -989,8 +901,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   5 < 101
@@ -1001,8 +912,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   5 < 102
@@ -1013,8 +923,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   5 < 103
@@ -1025,8 +934,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   5 < 104
@@ -1037,8 +945,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   5 < 105
@@ -1049,8 +956,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   5 < 106
@@ -1061,8 +967,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   5 < 107
@@ -1073,8 +978,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   5 < 108
@@ -1085,8 +989,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   5 < 109
@@ -1097,8 +1000,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   5 < 110
@@ -1109,8 +1011,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   6 < 101
@@ -1121,8 +1022,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   6 < 102
@@ -1133,8 +1033,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   6 < 103
@@ -1145,8 +1044,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   6 < 104
@@ -1157,8 +1055,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   6 < 105
@@ -1169,8 +1066,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   6 < 106
@@ -1181,8 +1077,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   6 < 107
@@ -1193,8 +1088,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   6 < 108
@@ -1205,8 +1099,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   6 < 109
@@ -1217,8 +1110,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   6 < 110
@@ -1229,8 +1121,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   7 < 101
@@ -1241,8 +1132,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   7 < 102
@@ -1253,8 +1143,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   7 < 103
@@ -1265,8 +1154,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   7 < 104
@@ -1277,8 +1165,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   7 < 105
@@ -1289,8 +1176,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   7 < 106
@@ -1301,8 +1187,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   7 < 107
@@ -1313,8 +1198,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   7 < 108
@@ -1325,8 +1209,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   7 < 109
@@ -1337,8 +1220,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   7 < 110
@@ -1349,8 +1231,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   8 < 101
@@ -1361,8 +1242,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   8 < 102
@@ -1373,8 +1253,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   8 < 103
@@ -1385,8 +1264,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   8 < 104
@@ -1397,8 +1275,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   8 < 105
@@ -1409,8 +1286,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   8 < 106
@@ -1421,8 +1297,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   8 < 107
@@ -1433,8 +1308,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   8 < 108
@@ -1445,8 +1319,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   8 < 109
@@ -1457,8 +1330,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   8 < 110
@@ -1469,8 +1341,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   9 < 101
@@ -1481,8 +1352,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   9 < 102
@@ -1493,8 +1363,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   9 < 103
@@ -1505,8 +1374,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   9 < 104
@@ -1517,8 +1385,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   9 < 105
@@ -1529,8 +1396,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   9 < 106
@@ -1541,8 +1407,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   9 < 107
@@ -1553,8 +1418,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   9 < 108
@@ -1565,8 +1429,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   9 < 109
@@ -1577,8 +1440,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   9 < 110
@@ -1589,8 +1451,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   10 < 101
@@ -1601,8 +1462,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   10 < 102
@@ -1613,8 +1473,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   10 < 103
@@ -1625,8 +1484,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   10 < 104
@@ -1637,8 +1495,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   10 < 105
@@ -1649,8 +1506,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   10 < 106
@@ -1661,8 +1517,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   10 < 107
@@ -1673,8 +1528,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   10 < 108
@@ -1685,8 +1539,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   10 < 109
@@ -1697,8 +1550,7 @@ with expansion:
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   10 < 110
@@ -1720,8 +1572,7 @@ A METHOD_AS_TEST_CASE based test run that succeeds
 Class.tests.cpp:<line number>
 ...............................................................................
 
-Class.tests.cpp:<line number>:
-PASSED:
+Class.tests.cpp:<line number>: PASSED:
   REQUIRE( s == "hello" )
 with expansion:
   "hello" == "hello"
@@ -1743,8 +1594,7 @@ A TEST_CASE_METHOD based test run that succeeds
 Class.tests.cpp:<line number>
 ...............................................................................
 
-Class.tests.cpp:<line number>:
-PASSED:
+Class.tests.cpp:<line number>: PASSED:
   REQUIRE( m_a == 1 )
 with expansion:
   1 == 1
@@ -1755,38 +1605,32 @@ A comparison that uses literals instead of the normal constructor
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d == 1.23_a )
 with expansion:
   1.23 == Approx( 1.23 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d != 1.22_a )
 with expansion:
   1.23 != Approx( 1.22 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( -d == -1.23_a )
 with expansion:
   -1.23 == Approx( -1.23 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d == 1.2_a .epsilon(.1) )
 with expansion:
   1.23 == Approx( 1.2 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d != 1.2_a .epsilon(.001) )
 with expansion:
   1.23 != Approx( 1.2 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d == 1_a .epsilon(.3) )
 with expansion:
   1.23 == Approx( 1.0 )
@@ -1799,8 +1643,7 @@ A couple of nested sections followed by a failure
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   that's not flying - that's failing in style
 
@@ -1836,38 +1679,32 @@ Absolute margin
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 104.0 != Approx(100.0) )
 with expansion:
   104.0 != Approx( 100.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 104.0 == Approx(100.0).margin(5) )
 with expansion:
   104.0 == Approx( 100.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 104.0 == Approx(100.0).margin(4) )
 with expansion:
   104.0 == Approx( 100.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 104.0 != Approx(100.0).margin(3) )
 with expansion:
   104.0 != Approx( 100.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 100.3 != Approx(100.0) )
 with expansion:
   100.3 != Approx( 100.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 100.3 == Approx(100.0).margin(0.5) )
 with expansion:
   100.3 == Approx( 100.0 )
@@ -1887,14 +1724,12 @@ An expression with side-effects should only be evaluated once
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( i++ == 7 )
 with expansion:
   7 == 7
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( i++ == 8 )
 with expansion:
   8 == 8
@@ -1905,8 +1740,7 @@ An unchecked exception reports the line of the last assertion
 Exception.tests.cpp:<line number>
 ...............................................................................
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   CHECK( 1 == 1 )
 
 Exception.tests.cpp:<line number>: FAILED:
@@ -1920,8 +1754,7 @@ Anonymous test case 1
 VariadicMacros.tests.cpp:<line number>
 ...............................................................................
 
-VariadicMacros.tests.cpp:<line number>:
-PASSED:
+VariadicMacros.tests.cpp:<line number>: PASSED:
 with message:
   anonymous test case
 
@@ -1931,32 +1764,25 @@ Approx setters validate their arguments
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( Approx(0).margin(0) )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( Approx(0).margin(1234656) )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_AS( Approx(0).margin(-2), std::domain_error )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( Approx(0).epsilon(0) )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( Approx(0).epsilon(1) )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_AS( Approx(0).epsilon(-0.001), std::domain_error )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_AS( Approx(0).epsilon(1.0001), std::domain_error )
 
 -------------------------------------------------------------------------------
@@ -1965,32 +1791,27 @@ Approx with exactly-representable margin
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   CHECK( 0.25f == Approx(0.0f).margin(0.25f) )
 with expansion:
   0.25f == Approx( 0.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   CHECK( 0.0f == Approx(0.25f).margin(0.25f) )
 with expansion:
   0.0f == Approx( 0.25 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   CHECK( 0.5f == Approx(0.25f).margin(0.25f) )
 with expansion:
   0.5f == Approx( 0.25 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   CHECK( 245.0f == Approx(245.25f).margin(0.25f) )
 with expansion:
   245.0f == Approx( 245.25 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   CHECK( 245.5f == Approx(245.25f).margin(0.25f) )
 with expansion:
   245.5f == Approx( 245.25 )
@@ -2001,14 +1822,12 @@ Approximate PI
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( divide( 22, 7 ) == Approx( 3.141 ).epsilon( 0.001 ) )
 with expansion:
   3.1428571429 == Approx( 3.141 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( divide( 22, 7 ) != Approx( 3.141 ).epsilon( 0.0001 ) )
 with expansion:
   3.1428571429 != Approx( 3.141 )
@@ -2019,14 +1838,12 @@ Approximate comparisons with different epsilons
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d != Approx( 1.231 ) )
 with expansion:
   1.23 != Approx( 1.231 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d == Approx( 1.231 ).epsilon( 0.1 ) )
 with expansion:
   1.23 == Approx( 1.231 )
@@ -2037,14 +1854,12 @@ Approximate comparisons with floats
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 1.23f == Approx( 1.23f ) )
 with expansion:
   1.23f == Approx( 1.2300000191 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 0.0f == Approx( 0.0f ) )
 with expansion:
   0.0f == Approx( 0.0 )
@@ -2055,14 +1870,12 @@ Approximate comparisons with ints
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 1 == Approx( 1 ) )
 with expansion:
   1 == Approx( 1.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 0 == Approx( 0 ) )
 with expansion:
   0 == Approx( 0.0 )
@@ -2073,32 +1886,27 @@ Approximate comparisons with mixed numeric types
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 1.0f == Approx( 1 ) )
 with expansion:
   1.0f == Approx( 1.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 0 == Approx( dZero) )
 with expansion:
   0 == Approx( 0.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 0 == Approx( dSmall ).margin( 0.001 ) )
 with expansion:
   0 == Approx( 0.00001 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 1.234f == Approx( dMedium ) )
 with expansion:
   1.234f == Approx( 1.234 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( dMedium == Approx( 1.234f ) )
 with expansion:
   1.234 == Approx( 1.2339999676 )
@@ -2110,14 +1918,12 @@ Arbitrary predicate matcher
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 1, Predicate<int>(alwaysTrue, "always true") )
 with expansion:
   1 matches predicate: "always true"
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 1, !Predicate<int>(alwaysFalse, "always false") )
 with expansion:
   1 not matches predicate: "always false"
@@ -2129,14 +1935,12 @@ Arbitrary predicate matcher
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( "Hello olleH", Predicate<std::string>( [] (std::string const& str) -> bool { return str.front() == str.back(); }, "First and last character should be equal") )
 with expansion:
   "Hello olleH" matches predicate: "First and last character should be equal"
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( "This wouldn't pass", !Predicate<std::string>( [] (std::string const& str) -> bool { return str.front() == str.back(); } ) )
 with expansion:
   "This wouldn't pass" not matches undescribed predicate
@@ -2147,8 +1951,7 @@ Assertions then sections
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( true )
 
 -------------------------------------------------------------------------------
@@ -2158,8 +1961,7 @@ Assertions then sections
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( true )
 
 -------------------------------------------------------------------------------
@@ -2170,8 +1972,7 @@ Assertions then sections
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( true )
 
 -------------------------------------------------------------------------------
@@ -2180,8 +1981,7 @@ Assertions then sections
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( true )
 
 -------------------------------------------------------------------------------
@@ -2191,8 +1991,7 @@ Assertions then sections
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( true )
 
 -------------------------------------------------------------------------------
@@ -2203,8 +2002,7 @@ Assertions then sections
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( true )
 
 -------------------------------------------------------------------------------
@@ -2213,20 +2011,17 @@ Assorted miscellaneous tests
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( INFINITY == Approx(INFINITY) )
 with expansion:
   inff == Approx( inf )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( NAN != Approx(NAN) )
 with expansion:
   nanf != Approx( nan )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE_FALSE( NAN == Approx(NAN) )
 with expansion:
   !(nanf == Approx( nan ))
@@ -2237,14 +2032,12 @@ Bitfields can be captured (#1027)
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( y.v == 0 )
 with expansion:
   0 == 0
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( 0 == y.v )
 with expansion:
   0 == 0
@@ -2256,8 +2049,7 @@ Capture and info messages
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( true )
 with message:
   i := 2
@@ -2269,8 +2061,7 @@ Capture and info messages
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( true )
 with message:
   3
@@ -2282,26 +2073,22 @@ Character pretty printing
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   CHECK( tab == '\t' )
 with expansion:
   '\t' == '\t'
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   CHECK( newline == '\n' )
 with expansion:
   '\n' == '\n'
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   CHECK( carr_return == '\r' )
 with expansion:
   '\r' == '\r'
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   CHECK( form_feed == '\f' )
 with expansion:
   '\f' == '\f'
@@ -2313,32 +2100,27 @@ Character pretty printing
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   CHECK( space == ' ' )
 with expansion:
   ' ' == ' '
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( c == chars[i] )
 with expansion:
   'a' == 'a'
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( c == chars[i] )
 with expansion:
   'z' == 'z'
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( c == chars[i] )
 with expansion:
   'A' == 'A'
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( c == chars[i] )
 with expansion:
   'Z' == 'Z'
@@ -2350,32 +2132,27 @@ Character pretty printing
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   CHECK( null_terminator == '\0' )
 with expansion:
   0 == 0
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( c == i )
 with expansion:
   2 == 2
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( c == i )
 with expansion:
   3 == 3
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( c == i )
 with expansion:
   4 == 4
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( c == i )
 with expansion:
   5 == 5
@@ -2386,64 +2163,52 @@ Commas in various macros are allowed
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS( std::vector<constructor_throws>{constructor_throws{}, constructor_throws{}} )
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   CHECK_THROWS( std::vector<constructor_throws>{constructor_throws{}, constructor_throws{}} )
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( std::vector<int>{1, 2, 3} == std::vector<int>{1, 2, 3} )
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   CHECK_NOTHROW( std::vector<int>{1, 2, 3} == std::vector<int>{1, 2, 3} )
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( std::vector<int>{1, 2} == std::vector<int>{1, 2} )
 with expansion:
   { 1, 2 } == { 1, 2 }
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   CHECK( std::vector<int>{1, 2} == std::vector<int>{1, 2} )
 with expansion:
   { 1, 2 } == { 1, 2 }
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE_FALSE( std::vector<int>{1, 2} == std::vector<int>{1, 2, 3} )
 with expansion:
   !({ 1, 2 } == { 1, 2, 3 })
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   CHECK_FALSE( std::vector<int>{1, 2} == std::vector<int>{1, 2, 3} )
 with expansion:
   !({ 1, 2 } == { 1, 2, 3 })
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   CHECK_NOFAIL( std::vector<int>{1, 2} == std::vector<int>{1, 2} )
 with expansion:
   { 1, 2 } == { 1, 2 }
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   CHECKED_IF( std::vector<int>{1, 2} == std::vector<int>{1, 2} )
 with expansion:
   { 1, 2 } == { 1, 2 }
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( true )
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   CHECKED_ELSE( std::vector<int>{1, 2} == std::vector<int>{1, 2} )
 with expansion:
   { 1, 2 } == { 1, 2 }
@@ -2454,14 +2219,12 @@ Comparing function pointers
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( a )
 with expansion:
   0x<hex digits>
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( a == &foo )
 with expansion:
   0x<hex digits> == 0x<hex digits>
@@ -2472,74 +2235,62 @@ Comparison with explicitly convertible types
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( td == Approx(10.0) )
 with expansion:
   StrongDoubleTypedef(10) == Approx( 10.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( Approx(10.0) == td )
 with expansion:
   Approx( 10.0 ) == StrongDoubleTypedef(10)
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( td != Approx(11.0) )
 with expansion:
   StrongDoubleTypedef(10) != Approx( 11.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( Approx(11.0) != td )
 with expansion:
   Approx( 11.0 ) != StrongDoubleTypedef(10)
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( td <= Approx(10.0) )
 with expansion:
   StrongDoubleTypedef(10) <= Approx( 10.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( td <= Approx(11.0) )
 with expansion:
   StrongDoubleTypedef(10) <= Approx( 11.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( Approx(10.0) <= td )
 with expansion:
   Approx( 10.0 ) <= StrongDoubleTypedef(10)
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( Approx(9.0) <= td )
 with expansion:
   Approx( 9.0 ) <= StrongDoubleTypedef(10)
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( td >= Approx(9.0) )
 with expansion:
   StrongDoubleTypedef(10) >= Approx( 9.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( td >= Approx(td) )
 with expansion:
   StrongDoubleTypedef(10) >= Approx( 10.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( Approx(td) >= td )
 with expansion:
   Approx( 10.0 ) >= StrongDoubleTypedef(10)
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( Approx(11.0) >= td )
 with expansion:
   Approx( 11.0 ) >= StrongDoubleTypedef(10)
@@ -2550,8 +2301,7 @@ Comparisons between ints where one side is computed
 Condition.tests.cpp:<line number>
 ...............................................................................
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   CHECK( 54 == 6*9 )
 with expansion:
   54 == 54
@@ -2563,38 +2313,32 @@ behaviour
 Condition.tests.cpp:<line number>
 ...............................................................................
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   CHECK( ( -1 > 2u ) )
 with expansion:
   true
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   CHECK( -1 > 2u )
 with expansion:
   -1 > 2
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   CHECK( ( 2u < -1 ) )
 with expansion:
   true
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   CHECK( 2u < -1 )
 with expansion:
   2 < -1
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   CHECK( ( minInt > 2u ) )
 with expansion:
   true
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   CHECK( minInt > 2u )
 with expansion:
   -2147483648 > 2
@@ -2605,80 +2349,67 @@ Comparisons with int literals don't warn when mixing signed/ unsigned
 Condition.tests.cpp:<line number>
 ...............................................................................
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( i == 1 )
 with expansion:
   1 == 1
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( ui == 2 )
 with expansion:
   2 == 2
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( l == 3 )
 with expansion:
   3 == 3
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( ul == 4 )
 with expansion:
   4 == 4
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( c == 5 )
 with expansion:
   5 == 5
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( uc == 6 )
 with expansion:
   6 == 6
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( 1 == i )
 with expansion:
   1 == 1
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( 2 == ui )
 with expansion:
   2 == 2
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( 3 == l )
 with expansion:
   3 == 3
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( 4 == ul )
 with expansion:
   4 == 4
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( 5 == c )
 with expansion:
   5 == 5
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( 6 == uc )
 with expansion:
   6 == 6
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( (std::numeric_limits<uint32_t>::max)() > ul )
 with expansion:
   4294967295 (0x<hex digits>) > 4
@@ -2738,14 +2469,12 @@ Default scale is invisible to comparison
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 101.000001 != Approx(100).epsilon(0.01) )
 with expansion:
   101.000001 != Approx( 100.0 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( std::pow(10, -5) != Approx(std::pow(10, -7)) )
 with expansion:
   0.00001 != Approx( 0.0000001 )
@@ -2773,8 +2502,7 @@ Epsilon only applies to Approx's value
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( 101.01 != Approx(100).epsilon(0.01) )
 with expansion:
   101.01 != Approx( 100.0 )
@@ -2856,44 +2584,37 @@ Equality checks that should succeed
 Condition.tests.cpp:<line number>
 ...............................................................................
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.int_seven == 7 )
 with expansion:
   7 == 7
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.float_nine_point_one == Approx( 9.1f ) )
 with expansion:
   9.1f == Approx( 9.1000003815 )
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.double_pi == Approx( 3.1415926535 ) )
 with expansion:
   3.1415926535 == Approx( 3.1415926535 )
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str_hello == "hello" )
 with expansion:
   "hello" == "hello"
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( "hello" == data.str_hello )
 with expansion:
   "hello" == "hello"
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str_hello.size() == 5 )
 with expansion:
   5 == 5
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( x == Approx( 1.3 ) )
 with expansion:
   1.3 == Approx( 1.3 )
@@ -2904,15 +2625,13 @@ Equals
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching(), Equals("this string contains 'abc' as a substring") )
 with expansion:
   "this string contains 'abc' as a substring" equals: "this string contains
   'abc' as a substring"
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching(), Equals("this string contains 'ABC' as a substring", Catch::CaseSensitive::No) )
 with expansion:
   "this string contains 'abc' as a substring" equals: "this string contains
@@ -2942,22 +2661,19 @@ Exception as a value (e.g. in REQUIRE_THROWS_MATCHES) can be stringified
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(WhatException{}) == "This exception has overriden what() method" )
 with expansion:
   "This exception has overriden what() method"
   ==
   "This exception has overriden what() method"
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(OperatorException{}) == "OperatorException" )
 with expansion:
   "OperatorException" == "OperatorException"
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(StringMakerException{}) == "StringMakerException" )
 with expansion:
   "StringMakerException"
@@ -3019,14 +2735,12 @@ Exception matchers that succeed
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THROWS_MATCHES( throws(1), SpecialException, ExceptionMatcher{1} )
 with expansion:
   SpecialException::what special exception has value of 1
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_MATCHES( throws(2), SpecialException, ExceptionMatcher{2} )
 with expansion:
   SpecialException::what special exception has value of 2
@@ -3038,8 +2752,7 @@ Exception messages can be tested for
 Exception.tests.cpp:<line number>
 ...............................................................................
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_WITH( thisThrows(), "expected exception" )
 with expansion:
   "expected exception" equals: "expected exception"
@@ -3051,8 +2764,7 @@ Exception messages can be tested for
 Exception.tests.cpp:<line number>
 ...............................................................................
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_WITH( thisThrows(), Equals( "expecteD Exception", Catch::CaseSensitive::No ) )
 with expansion:
   "expected exception" equals: "expected exception" (case insensitive)
@@ -3064,26 +2776,22 @@ Exception messages can be tested for
 Exception.tests.cpp:<line number>
 ...............................................................................
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_WITH( thisThrows(), StartsWith( "expected" ) )
 with expansion:
   "expected exception" starts with: "expected"
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_WITH( thisThrows(), EndsWith( "exception" ) )
 with expansion:
   "expected exception" ends with: "exception"
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_WITH( thisThrows(), Contains( "except" ) )
 with expansion:
   "expected exception" contains: "except"
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_WITH( thisThrows(), Contains( "exCept", Catch::CaseSensitive::No ) )
 with expansion:
   "expected exception" contains: "except" (case insensitive)
@@ -3136,8 +2844,7 @@ Message.tests.cpp:<line number>: FAILED:
 explicitly with message:
   This is a failure
 
-Message.tests.cpp:<line number>:
-warning:
+Message.tests.cpp:<line number>: warning:
   This message appears in the output
 
 -------------------------------------------------------------------------------
@@ -3146,32 +2853,27 @@ Factorials are computed
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( Factorial(0) == 1 )
 with expansion:
   1 == 1
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( Factorial(1) == 1 )
 with expansion:
   1 == 1
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( Factorial(2) == 2 )
 with expansion:
   2 == 2
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( Factorial(3) == 6 )
 with expansion:
   6 == 6
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( Factorial(10) == 3628800 )
 with expansion:
   3628800 (0x<hex digits>) == 3628800 (0x<hex digits>)
@@ -3183,56 +2885,47 @@ Floating point matchers: double
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 1., WithinAbs(1., 0) )
 with expansion:
   1.0 is within 0.0 of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 0., WithinAbs(1., 1) )
 with expansion:
   0.0 is within 1.0 of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 0., !WithinAbs(1., 0.99) )
 with expansion:
   0.0 not is within 0.99 of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 0., !WithinAbs(1., 0.99) )
 with expansion:
   0.0 not is within 0.99 of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( NAN, !WithinAbs(NAN, 0) )
 with expansion:
   nanf not is within 0.0 of nan
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 11., !WithinAbs(10., 0.5) )
 with expansion:
   11.0 not is within 0.5 of 10.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 10., !WithinAbs(11., 0.5) )
 with expansion:
   10.0 not is within 0.5 of 11.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( -10., WithinAbs(-10., 0.5) )
 with expansion:
   -10.0 is within 0.5 of -10.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( -10., WithinAbs(-9.6, 0.5) )
 with expansion:
   -10.0 is within 0.5 of -9.6
@@ -3244,44 +2937,37 @@ Floating point matchers: double
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 1., WithinULP(1., 0) )
 with expansion:
   1.0 is within 0 ULPs of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( nextafter(1., 2.), WithinULP(1., 1) )
 with expansion:
   1.0 is within 1 ULPs of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( nextafter(1., 0.), WithinULP(1., 1) )
 with expansion:
   1.0 is within 1 ULPs of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( nextafter(1., 2.), !WithinULP(1., 0) )
 with expansion:
   1.0 not is within 0 ULPs of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 1., WithinULP(1., 0) )
 with expansion:
   1.0 is within 0 ULPs of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( -0., WithinULP(0., 0) )
 with expansion:
   -0.0 is within 0 ULPs of 0.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( NAN, !WithinULP(NAN, 123) )
 with expansion:
   nanf not is within 123 ULPs of nanf
@@ -3293,20 +2979,17 @@ Floating point matchers: double
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 1., WithinAbs(1., 0.5) || WithinULP(2., 1) )
 with expansion:
   1.0 ( is within 0.5 of 1.0 or is within 1 ULPs of 2.0 )
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 1., WithinAbs(2., 0.5) || WithinULP(1., 0) )
 with expansion:
   1.0 ( is within 0.5 of 2.0 or is within 0 ULPs of 1.0 )
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( NAN, !(WithinAbs(NAN, 100) || WithinULP(NAN, 123)) )
 with expansion:
   nanf not ( is within 100.0 of nan or is within 123 ULPs of nanf )
@@ -3318,20 +3001,16 @@ Floating point matchers: double
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( WithinAbs(1., 0.) )
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_AS( WithinAbs(1., -1.), std::domain_error )
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( WithinULP(1., 0) )
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_AS( WithinULP(1., -1), std::domain_error )
 
 -------------------------------------------------------------------------------
@@ -3341,62 +3020,52 @@ Floating point matchers: float
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 1.f, WithinAbs(1.f, 0) )
 with expansion:
   1.0f is within 0.0 of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 0.f, WithinAbs(1.f, 1) )
 with expansion:
   0.0f is within 1.0 of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 0.f, !WithinAbs(1.f, 0.99f) )
 with expansion:
   0.0f not is within 0.9900000095 of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 0.f, !WithinAbs(1.f, 0.99f) )
 with expansion:
   0.0f not is within 0.9900000095 of 1.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 0.f, WithinAbs(-0.f, 0) )
 with expansion:
   0.0f is within 0.0 of -0.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( NAN, !WithinAbs(NAN, 0) )
 with expansion:
   nanf not is within 0.0 of nan
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 11.f, !WithinAbs(10.f, 0.5f) )
 with expansion:
   11.0f not is within 0.5 of 10.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 10.f, !WithinAbs(11.f, 0.5f) )
 with expansion:
   10.0f not is within 0.5 of 11.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( -10.f, WithinAbs(-10.f, 0.5f) )
 with expansion:
   -10.0f is within 0.5 of -10.0
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( -10.f, WithinAbs(-9.6f, 0.5f) )
 with expansion:
   -10.0f is within 0.5 of -9.6000003815
@@ -3408,44 +3077,37 @@ Floating point matchers: float
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 1.f, WithinULP(1.f, 0) )
 with expansion:
   1.0f is within 0 ULPs of 1.0f
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( nextafter(1.f, 2.f), WithinULP(1.f, 1) )
 with expansion:
   1.0f is within 1 ULPs of 1.0f
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( nextafter(1.f, 0.f), WithinULP(1.f, 1) )
 with expansion:
   1.0f is within 1 ULPs of 1.0f
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( nextafter(1.f, 2.f), !WithinULP(1.f, 0) )
 with expansion:
   1.0f not is within 0 ULPs of 1.0f
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 1.f, WithinULP(1.f, 0) )
 with expansion:
   1.0f is within 0 ULPs of 1.0f
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( -0.f, WithinULP(0.f, 0) )
 with expansion:
   -0.0f is within 0 ULPs of 0.0f
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( NAN, !WithinULP(NAN, 123) )
 with expansion:
   nanf not is within 123 ULPs of nanf
@@ -3457,20 +3119,17 @@ Floating point matchers: float
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 1.f, WithinAbs(1.f, 0.5) || WithinULP(1.f, 1) )
 with expansion:
   1.0f ( is within 0.5 of 1.0 or is within 1 ULPs of 1.0f )
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( 1.f, WithinAbs(2.f, 0.5) || WithinULP(1.f, 0) )
 with expansion:
   1.0f ( is within 0.5 of 2.0 or is within 0 ULPs of 1.0f )
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( NAN, !(WithinAbs(NAN, 100) || WithinULP(NAN, 123)) )
 with expansion:
   nanf not ( is within 100.0 of nan or is within 123 ULPs of nanf )
@@ -3482,20 +3141,16 @@ Floating point matchers: float
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( WithinAbs(1.f, 0.f) )
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_AS( WithinAbs(1.f, -1.f), std::domain_error )
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( WithinULP(1.f, 0) )
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_AS( WithinULP(1.f, -1), std::domain_error )
 
 -------------------------------------------------------------------------------
@@ -3505,8 +3160,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "a"
   j := 8
@@ -3518,8 +3172,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "a"
   j := 9
@@ -3531,8 +3184,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "a"
   j := 10
@@ -3544,8 +3196,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "a"
   j := 2
@@ -3557,8 +3208,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "a"
   j := 3.141
@@ -3570,8 +3220,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "a"
   j := 1.379
@@ -3583,8 +3232,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "b"
   j := 8
@@ -3596,8 +3244,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "b"
   j := 9
@@ -3609,8 +3256,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "b"
   j := 10
@@ -3622,8 +3268,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "b"
   j := 2
@@ -3635,8 +3280,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "b"
   j := 3.141
@@ -3648,8 +3292,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "b"
   j := 1.379
@@ -3661,8 +3304,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "c"
   j := 8
@@ -3674,8 +3316,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "c"
   j := 9
@@ -3687,8 +3328,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "c"
   j := 10
@@ -3700,8 +3340,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "c"
   j := 2
@@ -3713,8 +3352,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "c"
   j := 3.141
@@ -3726,8 +3364,7 @@ Generators
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
 with messages:
   i := "c"
   j := 1.379
@@ -3739,20 +3376,17 @@ Generators impl
 GeneratorsImpl.tests.cpp:<line number>
 ...............................................................................
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen.size() == 2 )
 with expansion:
   2 == 2
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[0] == 1 )
 with expansion:
   1 == 1
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[1] == 2 )
 with expansion:
   2 == 2
@@ -3764,32 +3398,27 @@ Generators impl
 GeneratorsImpl.tests.cpp:<line number>
 ...............................................................................
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen.size() == 4 )
 with expansion:
   4 == 4
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[0] == 3 )
 with expansion:
   3 == 3
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[1] == 1 )
 with expansion:
   1 == 1
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[2] == 4 )
 with expansion:
   4 == 4
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[3] == 1 )
 with expansion:
   1 == 1
@@ -3801,32 +3430,27 @@ Generators impl
 GeneratorsImpl.tests.cpp:<line number>
 ...............................................................................
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen.size() == 4 )
 with expansion:
   4 == 4
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[0] == 1 )
 with expansion:
   1 == 1
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[1] == 2 )
 with expansion:
   2 == 2
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[2] == 9 )
 with expansion:
   9 == 9
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[3] == 7 )
 with expansion:
   7 == 7
@@ -3838,20 +3462,17 @@ Generators impl
 GeneratorsImpl.tests.cpp:<line number>
 ...............................................................................
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen.size() == 2 )
 with expansion:
   2 == 2
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[0] == 3 )
 with expansion:
   3 == 3
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[1] == 1 )
 with expansion:
   1 == 1
@@ -3863,20 +3484,17 @@ Generators impl
 GeneratorsImpl.tests.cpp:<line number>
 ...............................................................................
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen.size() == 2 )
 with expansion:
   2 == 2
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[0] == 3 )
 with expansion:
   3 == 3
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( gen[1] == 1 )
 with expansion:
   1 == 1
@@ -3888,32 +3506,27 @@ Generators impl
 GeneratorsImpl.tests.cpp:<line number>
 ...............................................................................
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( base->size() == 4 )
 with expansion:
   4 == 4
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   REQUIRE( typed )
 with expansion:
   0x<hex digits>
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( typed->size() == 4 )
 with expansion:
   4 == 4
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( (*typed)[0] == 7 )
 with expansion:
   7 == 7
 
-GeneratorsImpl.tests.cpp:<line number>:
-PASSED:
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
   CHECK( (*typed)[3] == 11 )
 with expansion:
   11 == 11
@@ -3924,26 +3537,22 @@ Greater-than inequalities with different epsilons
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d >= Approx( 1.22 ) )
 with expansion:
   1.23 >= Approx( 1.22 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d >= Approx( 1.23 ) )
 with expansion:
   1.23 >= Approx( 1.23 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE_FALSE( d >= Approx( 1.24 ) )
 with expansion:
   !(1.23 >= Approx( 1.24 ))
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d >= Approx( 1.24 ).epsilon(0.1) )
 with expansion:
   1.23 >= Approx( 1.24 )
@@ -3954,8 +3563,7 @@ INFO and WARN do not abort tests
 Message.tests.cpp:<line number>
 ...............................................................................
 
-Message.tests.cpp:<line number>:
-warning:
+Message.tests.cpp:<line number>: warning:
   this is a message
   this is a warning
 
@@ -3982,8 +3590,7 @@ INFO gets logged on failure, even if captured before successful assertions
 Message.tests.cpp:<line number>
 ...............................................................................
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
   CHECK( a == 2 )
 with expansion:
   2 == 2
@@ -4007,8 +3614,7 @@ with messages:
   this message should be logged
   and this, but later
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
   CHECK( a == 2 )
 with expansion:
   2 == 2
@@ -4024,8 +3630,7 @@ INFO is reset for each loop
 Message.tests.cpp:<line number>
 ...............................................................................
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 10 )
 with expansion:
   0 < 10
@@ -4033,8 +3638,7 @@ with messages:
   current counter 0
   i := 0
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 10 )
 with expansion:
   1 < 10
@@ -4042,8 +3646,7 @@ with messages:
   current counter 1
   i := 1
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 10 )
 with expansion:
   2 < 10
@@ -4051,8 +3654,7 @@ with messages:
   current counter 2
   i := 2
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 10 )
 with expansion:
   3 < 10
@@ -4060,8 +3662,7 @@ with messages:
   current counter 3
   i := 3
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 10 )
 with expansion:
   4 < 10
@@ -4069,8 +3670,7 @@ with messages:
   current counter 4
   i := 4
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 10 )
 with expansion:
   5 < 10
@@ -4078,8 +3678,7 @@ with messages:
   current counter 5
   i := 5
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 10 )
 with expansion:
   6 < 10
@@ -4087,8 +3686,7 @@ with messages:
   current counter 6
   i := 6
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 10 )
 with expansion:
   7 < 10
@@ -4096,8 +3694,7 @@ with messages:
   current counter 7
   i := 7
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 10 )
 with expansion:
   8 < 10
@@ -4105,8 +3702,7 @@ with messages:
   current counter 8
   i := 8
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 10 )
 with expansion:
   9 < 10
@@ -4159,68 +3755,57 @@ Inequality checks that should succeed
 Condition.tests.cpp:<line number>
 ...............................................................................
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.int_seven != 6 )
 with expansion:
   7 != 6
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.int_seven != 8 )
 with expansion:
   7 != 8
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.float_nine_point_one != Approx( 9.11f ) )
 with expansion:
   9.1f != Approx( 9.1099996567 )
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.float_nine_point_one != Approx( 9.0f ) )
 with expansion:
   9.1f != Approx( 9.0 )
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.float_nine_point_one != Approx( 1 ) )
 with expansion:
   9.1f != Approx( 1.0 )
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.float_nine_point_one != Approx( 0 ) )
 with expansion:
   9.1f != Approx( 0.0 )
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.double_pi != Approx( 3.1415 ) )
 with expansion:
   3.1415926535 != Approx( 3.1415 )
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str_hello != "goodbye" )
 with expansion:
   "hello" != "goodbye"
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str_hello != "hell" )
 with expansion:
   "hello" != "hell"
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str_hello != "hello1" )
 with expansion:
   "hello" != "hello1"
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str_hello.size() != 6 )
 with expansion:
   5 != 6
@@ -4231,26 +3816,22 @@ Less-than inequalities with different epsilons
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d <= Approx( 1.24 ) )
 with expansion:
   1.23 <= Approx( 1.24 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d <= Approx( 1.23 ) )
 with expansion:
   1.23 <= Approx( 1.23 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE_FALSE( d <= Approx( 1.22 ) )
 with expansion:
   !(1.23 <= Approx( 1.22 ))
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d <= Approx( 1.22 ).epsilon(0.1) )
 with expansion:
   1.23 <= Approx( 1.22 )
@@ -4261,8 +3842,7 @@ ManuallyRegistered
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   was called
 
@@ -4272,8 +3852,7 @@ Matchers can be (AllOf) composed with the && operator
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching(), Contains("string") && Contains("abc") && Contains("substring") && Contains("contains") )
 with expansion:
   "this string contains 'abc' as a substring" ( contains: "string" and
@@ -4285,15 +3864,13 @@ Matchers can be (AnyOf) composed with the || operator
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching(), Contains("string") || Contains("different") || Contains("random") )
 with expansion:
   "this string contains 'abc' as a substring" ( contains: "string" or contains:
   "different" or contains: "random" )
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching2(), Contains("string") || Contains("different") || Contains("random") )
 with expansion:
   "some completely different text that contains one common word" ( contains:
@@ -4305,8 +3882,7 @@ Matchers can be composed with both && and ||
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching(), (Contains("string") || Contains("different")) && Contains("substring") )
 with expansion:
   "this string contains 'abc' as a substring" ( ( contains: "string" or
@@ -4330,8 +3906,7 @@ Matchers can be negated (Not) with the ! operator
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching(), !Contains("different") )
 with expansion:
   "this string contains 'abc' as a substring" not contains: "different"
@@ -4353,8 +3928,7 @@ Mismatching exception messages failing the test
 Exception.tests.cpp:<line number>
 ...............................................................................
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_WITH( thisThrows(), "expected exception" )
 with expansion:
   "expected exception" equals: "expected exception"
@@ -4370,8 +3944,7 @@ Nice descriptive name
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-warning:
+Misc.tests.cpp:<line number>: warning:
   This one ran
 
 
@@ -4393,20 +3966,17 @@ Objects that evaluated in boolean contexts can be checked
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   CHECK( True )
 with expansion:
   {?}
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   CHECK( !False )
 with expansion:
   true
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   CHECK_FALSE( False )
 with expansion:
   !{?}
@@ -4417,13 +3987,11 @@ Optionally static assertions
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
 with message:
   std::is_void<void>::value
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
 with message:
   !(std::is_void<int>::value)
 
@@ -4534,104 +4102,87 @@ Ordering comparison checks that should succeed
 Condition.tests.cpp:<line number>
 ...............................................................................
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.int_seven < 8 )
 with expansion:
   7 < 8
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.int_seven > 6 )
 with expansion:
   7 > 6
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.int_seven > 0 )
 with expansion:
   7 > 0
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.int_seven > -1 )
 with expansion:
   7 > -1
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.int_seven >= 7 )
 with expansion:
   7 >= 7
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.int_seven >= 6 )
 with expansion:
   7 >= 6
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.int_seven <= 7 )
 with expansion:
   7 <= 7
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.int_seven <= 8 )
 with expansion:
   7 <= 8
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.float_nine_point_one > 9 )
 with expansion:
   9.1f > 9
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.float_nine_point_one < 10 )
 with expansion:
   9.1f < 10
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.float_nine_point_one < 9.2 )
 with expansion:
   9.1f < 9.2
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str_hello <= "hello" )
 with expansion:
   "hello" <= "hello"
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str_hello >= "hello" )
 with expansion:
   "hello" >= "hello"
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str_hello < "hellp" )
 with expansion:
   "hello" < "hellp"
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str_hello < "zebra" )
 with expansion:
   "hello" < "zebra"
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str_hello > "hellm" )
 with expansion:
   "hello" > "hellm"
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str_hello > "a" )
 with expansion:
   "hello" > "a"
@@ -4665,20 +4216,17 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
@@ -4690,20 +4238,17 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches(tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
@@ -4715,20 +4260,17 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
@@ -4740,20 +4282,17 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == true )
 with expansion:
   true == true
@@ -4765,20 +4304,17 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == true )
 with expansion:
   true == true
@@ -4790,26 +4326,22 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == false )
 with expansion:
   false == false
@@ -4821,38 +4353,32 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( parseTestSpec( "*a" ).matches( tcA ) == true )
 with expansion:
   true == true
@@ -4864,38 +4390,32 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( parseTestSpec( "a*" ).matches( tcA ) == true )
 with expansion:
   true == true
@@ -4907,38 +4427,32 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( parseTestSpec( "*a*" ).matches( tcA ) == true )
 with expansion:
   true == true
@@ -4950,20 +4464,17 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
@@ -4975,20 +4486,17 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
@@ -5000,20 +4508,17 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
@@ -5025,32 +4530,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == true )
 with expansion:
   true == true
@@ -5062,32 +4562,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == true )
 with expansion:
   true == true
@@ -5099,26 +4594,22 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == false )
 with expansion:
   false == false
@@ -5130,26 +4621,22 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
@@ -5161,26 +4648,22 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
@@ -5192,26 +4675,22 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
@@ -5223,32 +4702,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == false )
 with expansion:
   false == false
@@ -5260,26 +4734,22 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
@@ -5291,26 +4761,22 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == false )
 with expansion:
   false == false
@@ -5322,32 +4788,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == true )
 with expansion:
   true == true
@@ -5359,32 +4820,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == true )
 with expansion:
   true == true
@@ -5396,32 +4852,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == true )
 with expansion:
   true == true
@@ -5433,32 +4884,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == false )
 with expansion:
   false == false
@@ -5470,32 +4916,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == false )
 with expansion:
   false == false
@@ -5507,32 +4948,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == false )
 with expansion:
   false == false
@@ -5544,32 +4980,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == false )
 with expansion:
   false == false
@@ -5581,32 +5012,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == false )
 with expansion:
   false == false
@@ -5618,32 +5044,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == false )
 with expansion:
   false == false
@@ -5655,32 +5076,27 @@ Parse test names and tags
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.hasFilters() == true )
 with expansion:
   true == true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcA ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcB ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcC ) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( spec.matches( tcD ) == true )
 with expansion:
   true == true
@@ -5691,50 +5107,42 @@ Pointers can be compared to null
 Condition.tests.cpp:<line number>
 ...............................................................................
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( p == 0 )
 with expansion:
   0 == 0
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( p == pNULL )
 with expansion:
   0 == 0
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( p != 0 )
 with expansion:
   0x<hex digits> != 0
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( cp != 0 )
 with expansion:
   0x<hex digits> != 0
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( cpc != 0 )
 with expansion:
   0x<hex digits> != 0
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( returnsNull() == 0 )
 with expansion:
   {null string} == 0
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( returnsConstNull() == 0 )
 with expansion:
   {null string} == 0
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( 0 != p )
 with expansion:
   0 != 0x<hex digits>
@@ -5745,8 +5153,7 @@ Predicate matcher can accept const char*
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( "foo", Predicate<const char*>([] (const char* const&) { return true; }) )
 with expansion:
   "foo" matches undescribed predicate
@@ -5758,14 +5165,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( result )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( config.processName == "" )
 with expansion:
   "" == ""
@@ -5777,44 +5182,37 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( result )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( config.processName == "test" )
 with expansion:
   "test" == "test"
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( config.shouldDebugBreak == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( config.abortAfter == -1 )
 with expansion:
   -1 == -1
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( config.noThrow == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( config.reporterName == "console" )
 with expansion:
   "console" == "console"
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK_FALSE( cfg.hasTestFilters() )
 with expansion:
   !false
@@ -5827,26 +5225,22 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( result )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( cfg.hasTestFilters() )
 with expansion:
   true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( cfg.testSpec().matches(fakeTestCase("notIncluded")) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( cfg.testSpec().matches(fakeTestCase("test1")) )
 with expansion:
   true
@@ -5859,26 +5253,22 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( result )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( cfg.hasTestFilters() )
 with expansion:
   true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( cfg.testSpec().matches(fakeTestCase("test1")) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( cfg.testSpec().matches(fakeTestCase("alwaysIncluded")) )
 with expansion:
   true
@@ -5891,26 +5281,22 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( result )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( cfg.hasTestFilters() )
 with expansion:
   true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( cfg.testSpec().matches(fakeTestCase("test1")) == false )
 with expansion:
   false == false
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( cfg.testSpec().matches(fakeTestCase("alwaysIncluded")) )
 with expansion:
   true
@@ -5923,14 +5309,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "-r", "console"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.reporterName == "console" )
 with expansion:
   "console" == "console"
@@ -5943,14 +5327,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "-r", "xml"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.reporterName == "xml" )
 with expansion:
   "xml" == "xml"
@@ -5963,14 +5345,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--reporter", "junit"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.reporterName == "junit" )
 with expansion:
   "junit" == "junit"
@@ -5983,8 +5363,7 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE_FALSE( cli.parse({ "test", "-r", "xml", "-r", "junit" }) )
 with expansion:
   !{?}
@@ -5997,14 +5376,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( !result )
 with expansion:
   true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( result.errorMessage(), Contains("Unrecognized reporter") )
 with expansion:
   "Unrecognized reporter, 'unsupported'. Check available with --list-reporters"
@@ -6018,14 +5395,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "-b"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.shouldDebugBreak == true )
 with expansion:
   true == true
@@ -6038,14 +5413,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--break"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.shouldDebugBreak )
 with expansion:
   true
@@ -6058,14 +5431,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "-a"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.abortAfter == 1 )
 with expansion:
   1 == 1
@@ -6078,14 +5449,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "-x", "2"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.abortAfter == 2 )
 with expansion:
   2 == 2
@@ -6098,14 +5467,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( !result )
 with expansion:
   true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( result.errorMessage(), Contains("convert") && Contains("oops") )
 with expansion:
   "Unable to convert 'oops' to destination type" ( contains: "convert" and
@@ -6119,14 +5486,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "-e"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.noThrow )
 with expansion:
   true
@@ -6139,14 +5504,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--nothrow"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.noThrow )
 with expansion:
   true
@@ -6159,14 +5522,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "-o", "filename.ext"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.outputFilename == "filename.ext" )
 with expansion:
   "filename.ext" == "filename.ext"
@@ -6179,14 +5540,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--out", "filename.ext"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.outputFilename == "filename.ext" )
 with expansion:
   "filename.ext" == "filename.ext"
@@ -6199,26 +5558,22 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "-abe"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( config.abortAfter == 1 )
 with expansion:
   1 == 1
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( config.shouldDebugBreak )
 with expansion:
   true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( config.noThrow == true )
 with expansion:
   true == true
@@ -6231,14 +5586,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.useColour == UseColour::Auto )
 with expansion:
   0 == 0
@@ -6251,14 +5604,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--use-colour", "auto"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.useColour == UseColour::Auto )
 with expansion:
   0 == 0
@@ -6271,14 +5622,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--use-colour", "yes"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.useColour == UseColour::Yes )
 with expansion:
   1 == 1
@@ -6291,14 +5640,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--use-colour", "no"}) )
 with expansion:
   {?}
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.useColour == UseColour::No )
 with expansion:
   2 == 2
@@ -6311,14 +5658,12 @@ Process can be configured on command line
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( !result )
 with expansion:
   true
 
-CmdLine.tests.cpp:<line number>:
-PASSED:
+CmdLine.tests.cpp:<line number>: PASSED:
   CHECK_THAT( result.errorMessage(), Contains( "colour mode must be one of" ) )
 with expansion:
   "colour mode must be one of: auto, yes or no. 'wrong' not recognised"
@@ -6365,8 +5710,7 @@ Regression test #1
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( actual, !UnorderedEquals(expected) )
 with expansion:
   { 'a', 'b' } not UnorderedEquals: { 'c', 'b' }
@@ -6377,8 +5721,7 @@ SUCCEED counts as a test pass
 Message.tests.cpp:<line number>
 ...............................................................................
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
 with message:
   this is a success
 
@@ -6388,8 +5731,7 @@ SUCCEED does not require an argument
 Message.tests.cpp:<line number>
 ...............................................................................
 
-Message.tests.cpp:<line number>:
-PASSED:
+Message.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 Scenario: BDD tests requiring Fixtures to provide commonly-accessed data or
@@ -6399,8 +5741,7 @@ Scenario: BDD tests requiring Fixtures to provide commonly-accessed data or
 BDD.tests.cpp:<line number>
 ...............................................................................
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
   REQUIRE( before == 0 )
 with expansion:
   0 == 0
@@ -6415,8 +5756,7 @@ Scenario: BDD tests requiring Fixtures to provide commonly-accessed data or
 BDD.tests.cpp:<line number>
 ...............................................................................
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
   REQUIRE( after > before )
 with expansion:
   1 > 0
@@ -6431,8 +5771,7 @@ Scenario: Do that thing with the thing
 BDD.tests.cpp:<line number>
 ...............................................................................
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
   REQUIRE( itDoesThis() )
 with expansion:
   true
@@ -6448,8 +5787,7 @@ Scenario: Do that thing with the thing
 BDD.tests.cpp:<line number>
 ...............................................................................
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
   REQUIRE( itDoesThat() )
 with expansion:
   true
@@ -6467,8 +5805,7 @@ Scenario: This is a really long scenario name to see how the list command deals
 BDD.tests.cpp:<line number>
 ...............................................................................
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
 with message:
   boo!
 
@@ -6479,8 +5816,7 @@ Scenario: Vector resizing affects size and capacity
 BDD.tests.cpp:<line number>
 ...............................................................................
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 0 )
 with expansion:
   0 == 0
@@ -6494,14 +5830,12 @@ Scenario: Vector resizing affects size and capacity
 BDD.tests.cpp:<line number>
 ...............................................................................
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 10 )
 with expansion:
   10 == 10
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
   REQUIRE( v.capacity() >= 10 )
 with expansion:
   10 >= 10
@@ -6517,14 +5851,12 @@ Scenario: Vector resizing affects size and capacity
 BDD.tests.cpp:<line number>
 ...............................................................................
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 5 )
 with expansion:
   5 == 5
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
   REQUIRE( v.capacity() >= 10 )
 with expansion:
   10 >= 10
@@ -6536,8 +5868,7 @@ Scenario: Vector resizing affects size and capacity
 BDD.tests.cpp:<line number>
 ...............................................................................
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 0 )
 with expansion:
   0 == 0
@@ -6551,14 +5882,12 @@ Scenario: Vector resizing affects size and capacity
 BDD.tests.cpp:<line number>
 ...............................................................................
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
   REQUIRE( v.capacity() >= 10 )
 with expansion:
   10 >= 10
 
-BDD.tests.cpp:<line number>:
-PASSED:
+BDD.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 0 )
 with expansion:
   0 == 0
@@ -6581,56 +5910,47 @@ Some simple comparisons between doubles
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d == Approx( 1.23 ) )
 with expansion:
   1.23 == Approx( 1.23 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d != Approx( 1.22 ) )
 with expansion:
   1.23 != Approx( 1.22 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d != Approx( 1.24 ) )
 with expansion:
   1.23 != Approx( 1.24 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d == 1.23_a )
 with expansion:
   1.23 == Approx( 1.23 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d != 1.22_a )
 with expansion:
   1.23 != Approx( 1.22 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( Approx( d ) == 1.23 )
 with expansion:
   Approx( 1.23 ) == 1.23
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( Approx( d ) != 1.22 )
 with expansion:
   Approx( 1.23 ) != 1.22
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( Approx( d ) != 1.24 )
 with expansion:
   Approx( 1.23 ) != 1.24
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( INFINITY == Approx(INFINITY) )
 with expansion:
   inff == Approx( inf )
@@ -6681,8 +6001,7 @@ Static arrays are convertible to string
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( Catch::Detail::stringify(singular) == "{ 1 }" )
 with expansion:
   "{ 1 }" == "{ 1 }"
@@ -6694,8 +6013,7 @@ Static arrays are convertible to string
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( Catch::Detail::stringify(arr) == "{ 3, 2, 1 }" )
 with expansion:
   "{ 3, 2, 1 }" == "{ 3, 2, 1 }"
@@ -6707,8 +6025,7 @@ Static arrays are convertible to string
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( Catch::Detail::stringify(arr) == R"({ { "1:1", "1:2", "1:3" }, { "2:1", "2:2" } })" )
 with expansion:
   "{ { "1:1", "1:2", "1:3" }, { "2:1", "2:2" } }"
@@ -6721,53 +6038,45 @@ String matchers
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( testStringForMatching(), Contains("string") )
 with expansion:
   "this string contains 'abc' as a substring" contains: "string"
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( testStringForMatching(), Contains("string", Catch::CaseSensitive::No) )
 with expansion:
   "this string contains 'abc' as a substring" contains: "string" (case
   insensitive)
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching(), Contains("abc") )
 with expansion:
   "this string contains 'abc' as a substring" contains: "abc"
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching(), Contains("aBC", Catch::CaseSensitive::No) )
 with expansion:
   "this string contains 'abc' as a substring" contains: "abc" (case
   insensitive)
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching(), StartsWith("this") )
 with expansion:
   "this string contains 'abc' as a substring" starts with: "this"
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching(), StartsWith("THIS", Catch::CaseSensitive::No) )
 with expansion:
   "this string contains 'abc' as a substring" starts with: "this" (case
   insensitive)
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching(), EndsWith("substring") )
 with expansion:
   "this string contains 'abc' as a substring" ends with: "substring"
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( testStringForMatching(), EndsWith(" SuBsTrInG", Catch::CaseSensitive::No) )
 with expansion:
   "this string contains 'abc' as a substring" ends with: " substring" (case
@@ -6780,20 +6089,17 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( empty.empty() )
 with expansion:
   true
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( empty.size() == 0 )
 with expansion:
   0 == 0
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( std::strcmp( empty.c_str(), "" ) == 0 )
 with expansion:
   0 == 0
@@ -6805,26 +6111,22 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( s.empty() == false )
 with expansion:
   false == false
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( s.size() == 5 )
 with expansion:
   5 == 5
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( isSubstring( s ) == false )
 with expansion:
   false == false
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( std::strcmp( rawChars, "hello" ) == 0 )
 with expansion:
   0 == 0
@@ -6837,20 +6139,17 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( isOwned( s ) == false )
 with expansion:
   false == false
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( s.c_str() == rawChars )
 with expansion:
   "hello" == "hello"
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( isOwned( s ) == false )
 with expansion:
   false == false
@@ -6862,30 +6161,25 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( original == "original" )
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( isSubstring( original ) )
 with expansion:
   true
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( isOwned( original ) == false )
 with expansion:
   false == false
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( isSubstring( original ) == false )
 with expansion:
   false == false
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( isOwned( original ) )
 with expansion:
   true
@@ -6898,26 +6192,22 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( ss.empty() == false )
 with expansion:
   false == false
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( ss.size() == 5 )
 with expansion:
   5 == 5
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( std::strcmp( ss.c_str(), "hello" ) == 0 )
 with expansion:
   0 == 0
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( ss == "hello" )
 with expansion:
   hello == "hello"
@@ -6930,44 +6220,37 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( isSubstring( ss ) )
 with expansion:
   true
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( isOwned( ss ) == false )
 with expansion:
   false == false
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( rawChars == s.currentData() )
 with expansion:
   "hello world!" == "hello world!"
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( ss.c_str() != rawChars )
 with expansion:
   "hello" != "hello world!"
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( isSubstring( ss ) == false )
 with expansion:
   false == false
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( isOwned( ss ) )
 with expansion:
   true
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( ss.currentData() != s.currentData() )
 with expansion:
   "hello" != "hello world!"
@@ -6980,14 +6263,12 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( ss.size() == 6 )
 with expansion:
   6 == 6
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( std::strcmp( ss.c_str(), "world!" ) == 0 )
 with expansion:
   0 == 0
@@ -7000,8 +6281,7 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( s.c_str() == s2.c_str() )
 with expansion:
   "hello world!" == "hello world!"
@@ -7014,8 +6294,7 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( s.c_str() != ss.c_str() )
 with expansion:
   "hello world!" != "hello"
@@ -7027,14 +6306,12 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( StringRef("hello") == StringRef("hello") )
 with expansion:
   hello == hello
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( StringRef("hello") != StringRef("cello") )
 with expansion:
   hello != cello
@@ -7047,14 +6324,12 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( sr == "a standard string" )
 with expansion:
   a standard string == "a standard string"
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( sr.size() == stdStr.size() )
 with expansion:
   17 == 17
@@ -7067,14 +6342,12 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( sr == "a standard string" )
 with expansion:
   a standard string == "a standard string"
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( sr.size() == stdStr.size() )
 with expansion:
   17 == 17
@@ -7087,14 +6360,12 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( sr == "a standard string" )
 with expansion:
   a standard string == "a standard string"
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( sr.size() == stdStr.size() )
 with expansion:
   17 == 17
@@ -7107,14 +6378,12 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( stdStr == "a stringref" )
 with expansion:
   "a stringref" == "a stringref"
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( stdStr.size() == sr.size() )
 with expansion:
   11 == 11
@@ -7127,14 +6396,12 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( stdStr == "a stringref" )
 with expansion:
   "a stringref" == "a stringref"
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( stdStr.size() == sr.size() )
 with expansion:
   11 == 11
@@ -7147,14 +6414,12 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( stdStr == "a stringref" )
 with expansion:
   "a stringref" == "a stringref"
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( stdStr.size() == sr.size() )
 with expansion:
   11 == 11
@@ -7166,20 +6431,17 @@ StringRef
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( ascii.numberOfCharacters() == ascii.size() )
 with expansion:
   39 == 39
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( simpleu8.numberOfCharacters() == 30 )
 with expansion:
   30 == 30
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   REQUIRE( emojis.numberOfCharacters() == 9 )
 with expansion:
   9 == 9
@@ -7190,26 +6452,22 @@ Stringifying std::chrono::duration helpers
 ToStringChrono.tests.cpp:<line number>
 ...............................................................................
 
-ToStringChrono.tests.cpp:<line number>:
-PASSED:
+ToStringChrono.tests.cpp:<line number>: PASSED:
   REQUIRE( minute == seconds )
 with expansion:
   1 m == 60 s
 
-ToStringChrono.tests.cpp:<line number>:
-PASSED:
+ToStringChrono.tests.cpp:<line number>: PASSED:
   REQUIRE( hour != seconds )
 with expansion:
   1 h != 60 s
 
-ToStringChrono.tests.cpp:<line number>:
-PASSED:
+ToStringChrono.tests.cpp:<line number>: PASSED:
   REQUIRE( micro != milli )
 with expansion:
   1 us != 1 ms
 
-ToStringChrono.tests.cpp:<line number>:
-PASSED:
+ToStringChrono.tests.cpp:<line number>: PASSED:
   REQUIRE( nano != micro )
 with expansion:
   1 ns != 1 us
@@ -7220,14 +6478,12 @@ Stringifying std::chrono::duration with weird ratios
 ToStringChrono.tests.cpp:<line number>
 ...............................................................................
 
-ToStringChrono.tests.cpp:<line number>:
-PASSED:
+ToStringChrono.tests.cpp:<line number>: PASSED:
   REQUIRE( half_minute != femto_second )
 with expansion:
   1 [30/1]s != 1 fs
 
-ToStringChrono.tests.cpp:<line number>:
-PASSED:
+ToStringChrono.tests.cpp:<line number>: PASSED:
   REQUIRE( pico_second != atto_second )
 with expansion:
   1 ps != 1 as
@@ -7238,8 +6494,7 @@ Stringifying std::chrono::time_point<system_clock>
 ToStringChrono.tests.cpp:<line number>
 ...............................................................................
 
-ToStringChrono.tests.cpp:<line number>:
-PASSED:
+ToStringChrono.tests.cpp:<line number>: PASSED:
   REQUIRE( now != later )
 with expansion:
   {iso8601-timestamp}
@@ -7271,32 +6526,28 @@ Tag alias can be registered against tag patterns
 TagAlias.tests.cpp:<line number>
 ...............................................................................
 
-TagAlias.tests.cpp:<line number>:
-PASSED:
+TagAlias.tests.cpp:<line number>: PASSED:
   CHECK_THAT( what, Contains( "[@zzz]" ) )
 with expansion:
   "error: tag alias, '[@zzz]' already registered.
   	First seen at: file:2
   	Redefined at: file:10" contains: "[@zzz]"
 
-TagAlias.tests.cpp:<line number>:
-PASSED:
+TagAlias.tests.cpp:<line number>: PASSED:
   CHECK_THAT( what, Contains( "file" ) )
 with expansion:
   "error: tag alias, '[@zzz]' already registered.
   	First seen at: file:2
   	Redefined at: file:10" contains: "file"
 
-TagAlias.tests.cpp:<line number>:
-PASSED:
+TagAlias.tests.cpp:<line number>: PASSED:
   CHECK_THAT( what, Contains( "2" ) )
 with expansion:
   "error: tag alias, '[@zzz]' already registered.
   	First seen at: file:2
   	Redefined at: file:10" contains: "2"
 
-TagAlias.tests.cpp:<line number>:
-PASSED:
+TagAlias.tests.cpp:<line number>: PASSED:
   CHECK_THAT( what, Contains( "10" ) )
 with expansion:
   "error: tag alias, '[@zzz]' already registered.
@@ -7310,20 +6561,16 @@ Tag alias can be registered against tag patterns
 TagAlias.tests.cpp:<line number>
 ...............................................................................
 
-TagAlias.tests.cpp:<line number>:
-PASSED:
+TagAlias.tests.cpp:<line number>: PASSED:
   CHECK_THROWS( registry.add( "[no ampersat]", "", Catch::SourceLineInfo( "file", 3 ) ) )
 
-TagAlias.tests.cpp:<line number>:
-PASSED:
+TagAlias.tests.cpp:<line number>: PASSED:
   CHECK_THROWS( registry.add( "[the @ is not at the start]", "", Catch::SourceLineInfo( "file", 3 ) ) )
 
-TagAlias.tests.cpp:<line number>:
-PASSED:
+TagAlias.tests.cpp:<line number>: PASSED:
   CHECK_THROWS( registry.add( "@no square bracket at start]", "", Catch::SourceLineInfo( "file", 3 ) ) )
 
-TagAlias.tests.cpp:<line number>:
-PASSED:
+TagAlias.tests.cpp:<line number>: PASSED:
   CHECK_THROWS( registry.add( "[@no square bracket at end", "", Catch::SourceLineInfo( "file", 3 ) ) )
 
 -------------------------------------------------------------------------------
@@ -7332,8 +6579,7 @@ Test case with one argument
 VariadicMacros.tests.cpp:<line number>
 ...............................................................................
 
-VariadicMacros.tests.cpp:<line number>:
-PASSED:
+VariadicMacros.tests.cpp:<line number>: PASSED:
 with message:
   no assertions
 
@@ -7343,8 +6589,7 @@ Test enum bit values
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( 0x<hex digits> == bit30and31 )
 with expansion:
   3221225472 (0x<hex digits>) == 3221225472
@@ -7355,8 +6600,7 @@ The NO_FAIL macro reports a failure but does not fail the test
 Message.tests.cpp:<line number>
 ...............................................................................
 
-Message.tests.cpp:<line number>:
-FAILED - but was ok:
+Message.tests.cpp:<line number>: FAILED - but was ok:
   CHECK_NOFAIL( 1 == 2 )
 
 
@@ -7368,8 +6612,7 @@ This test 'should' fail but doesn't
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   oops!
 
@@ -7389,14 +6632,12 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isOpen() )
 with expansion:
   true
@@ -7408,26 +6649,22 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isSuccessfullyCompleted() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( ctx.completedCycle() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isSuccessfullyCompleted() )
 with expansion:
   true
@@ -7438,14 +6675,12 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isOpen() )
 with expansion:
   true
@@ -7457,32 +6692,27 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isSuccessfullyCompleted() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( ctx.completedCycle() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isSuccessfullyCompleted() == false )
 with expansion:
   false == false
@@ -7495,32 +6725,27 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1b.isOpen() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( ctx.completedCycle() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isSuccessfullyCompleted() )
 with expansion:
   true
@@ -7531,14 +6756,12 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isOpen() )
 with expansion:
   true
@@ -7550,32 +6773,27 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isSuccessfullyCompleted() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( ctx.completedCycle() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isSuccessfullyCompleted() == false )
 with expansion:
   false == false
@@ -7588,38 +6806,32 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1b.isOpen() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( ctx.completedCycle() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isSuccessfullyCompleted() )
 with expansion:
   true
@@ -7630,14 +6842,12 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isOpen() )
 with expansion:
   true
@@ -7649,14 +6859,12 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2.isOpen() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isComplete() == false )
 with expansion:
   false == false
@@ -7669,26 +6877,22 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1b.isOpen() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2b.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( ctx.completedCycle() == false )
 with expansion:
   false == false
@@ -7702,26 +6906,22 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( ctx.completedCycle() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2b.isSuccessfullyCompleted() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isSuccessfullyCompleted() )
 with expansion:
   true
@@ -7732,14 +6932,12 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isOpen() )
 with expansion:
   true
@@ -7751,14 +6949,12 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2.isOpen() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isComplete() == false )
 with expansion:
   false == false
@@ -7771,26 +6967,22 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1b.isOpen() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2b.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( ctx.completedCycle() == false )
 with expansion:
   false == false
@@ -7804,50 +6996,42 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( ctx.completedCycle() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2b.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2b.isSuccessfullyCompleted() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isSuccessfullyCompleted() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase3.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1c.isOpen() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2c.isOpen() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase3.isSuccessfullyCompleted() )
 with expansion:
   true
@@ -7858,14 +7042,12 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isOpen() )
 with expansion:
   true
@@ -7877,38 +7059,32 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isComplete() )
 with expansion:
   true
@@ -7919,14 +7095,12 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isOpen() )
 with expansion:
   true
@@ -7938,26 +7112,22 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1.index() == 0 )
 with expansion:
   0 == 0
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isComplete() == false )
 with expansion:
   false == false
@@ -7970,14 +7140,12 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isSuccessfullyCompleted() == false )
 with expansion:
   false == false
@@ -7991,50 +7159,42 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1b.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1b.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1b.index() == 1 )
 with expansion:
   1 == 1
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1b.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1b.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isComplete() )
 with expansion:
   true
@@ -8045,14 +7205,12 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isOpen() )
 with expansion:
   true
@@ -8064,26 +7222,22 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1.index() == 0 )
 with expansion:
   0 == 0
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isComplete() == false )
 with expansion:
   false == false
@@ -8096,26 +7250,22 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isComplete() == false )
 with expansion:
   false == false
@@ -8129,56 +7279,47 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1b.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1b.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1b.index() == 1 )
 with expansion:
   1 == 1
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2b.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2b.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1b.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1b.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isComplete() )
 with expansion:
   true
@@ -8189,14 +7330,12 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isOpen() )
 with expansion:
   true
@@ -8208,26 +7347,22 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1.index() == 0 )
 with expansion:
   0 == 0
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isComplete() == false )
 with expansion:
   false == false
@@ -8240,32 +7375,27 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2.isSuccessfullyCompleted() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase.isComplete() == false )
 with expansion:
   false == false
@@ -8279,104 +7409,87 @@ Tracker
 PartTracker.tests.cpp:<line number>
 ...............................................................................
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1b.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1b.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1b.index() == 0 )
 with expansion:
   0 == 0
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2b.isOpen() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1b.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1b.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase2.isComplete() == false )
 with expansion:
   false == false
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase3.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1c.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1c.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1c.index() == 1 )
 with expansion:
   1 == 1
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2c.isOpen() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s2c.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( g1c.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( s1c.isComplete() )
 with expansion:
   true
 
-PartTracker.tests.cpp:<line number>:
-PASSED:
+PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( testCase3.isComplete() )
 with expansion:
   true
@@ -8397,50 +7510,42 @@ Use a custom approx
 Approx.tests.cpp:<line number>
 ...............................................................................
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d == approx( 1.23 ) )
 with expansion:
   1.23 == Approx( 1.23 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d == approx( 1.22 ) )
 with expansion:
   1.23 == Approx( 1.22 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d == approx( 1.24 ) )
 with expansion:
   1.23 == Approx( 1.24 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( d != approx( 1.25 ) )
 with expansion:
   1.23 != Approx( 1.25 )
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( approx( d ) == 1.23 )
 with expansion:
   Approx( 1.23 ) == 1.23
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( approx( d ) == 1.22 )
 with expansion:
   Approx( 1.23 ) == 1.22
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( approx( d ) == 1.24 )
 with expansion:
   Approx( 1.23 ) == 1.24
 
-Approx.tests.cpp:<line number>:
-PASSED:
+Approx.tests.cpp:<line number>: PASSED:
   REQUIRE( approx( d ) != 1.25 )
 with expansion:
   Approx( 1.23 ) != 1.25
@@ -8452,8 +7557,7 @@ Variadic macros
 VariadicMacros.tests.cpp:<line number>
 ...............................................................................
 
-VariadicMacros.tests.cpp:<line number>:
-PASSED:
+VariadicMacros.tests.cpp:<line number>: PASSED:
 with message:
   no assertions
 
@@ -8464,14 +7568,12 @@ Vector matchers
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( v, VectorContains(1) )
 with expansion:
   { 1, 2, 3 } Contains: 1
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( v, VectorContains(2) )
 with expansion:
   { 1, 2, 3 } Contains: 2
@@ -8483,26 +7585,22 @@ Vector matchers
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( v, Contains(v2) )
 with expansion:
   { 1, 2, 3 } Contains: { 1, 2 }
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( v, Contains(v2) )
 with expansion:
   { 1, 2, 3 } Contains: { 1, 2, 3 }
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( v, Contains(empty) )
 with expansion:
   { 1, 2, 3 } Contains: {  }
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( empty, Contains(empty) )
 with expansion:
   {  } Contains: {  }
@@ -8514,8 +7612,7 @@ Vector matchers
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( v, VectorContains(1) && VectorContains(2) )
 with expansion:
   { 1, 2, 3 } ( Contains: 1 and Contains: 2 )
@@ -8527,20 +7624,17 @@ Vector matchers
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( v, Equals(v) )
 with expansion:
   { 1, 2, 3 } Equals: { 1, 2, 3 }
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( empty, Equals(empty) )
 with expansion:
   {  } Equals: {  }
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( v, Equals(v2) )
 with expansion:
   { 1, 2, 3 } Equals: { 1, 2, 3 }
@@ -8552,26 +7646,22 @@ Vector matchers
 Matchers.tests.cpp:<line number>
 ...............................................................................
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( v, UnorderedEquals(v) )
 with expansion:
   { 1, 2, 3 } UnorderedEquals: { 1, 2, 3 }
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   CHECK_THAT( empty, UnorderedEquals(empty) )
 with expansion:
   {  } UnorderedEquals: {  }
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( permuted, UnorderedEquals(v) )
 with expansion:
   { 1, 3, 2 } UnorderedEquals: { 1, 2, 3 }
 
-Matchers.tests.cpp:<line number>:
-PASSED:
+Matchers.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( permuted, UnorderedEquals(v) )
 with expansion:
   { 2, 3, 1 } UnorderedEquals: { 1, 2, 3 }
@@ -8670,16 +7760,13 @@ When checked exceptions are thrown they can be expected or unexpected
 Exception.tests.cpp:<line number>
 ...............................................................................
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_AS( thisThrows(), std::domain_error )
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( thisDoesntThrow() )
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS( thisThrows() )
 
 -------------------------------------------------------------------------------
@@ -8752,8 +7839,7 @@ Where the LHS is not a simple value
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-warning:
+Tricky.tests.cpp:<line number>: warning:
   Uncomment the code in this test to check that it gives a sensible compiler
   error
 
@@ -8766,8 +7852,7 @@ Where there is more to the expression after the RHS
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-warning:
+Tricky.tests.cpp:<line number>: warning:
   Uncomment the code in this test to check that it gives a sensible compiler
   error
 
@@ -8780,8 +7865,7 @@ X/level/0/a
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 X/level/0/b
@@ -8789,8 +7873,7 @@ X/level/0/b
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 X/level/1/a
@@ -8798,8 +7881,7 @@ X/level/1/a
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 X/level/1/b
@@ -8807,8 +7889,7 @@ X/level/1/b
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 XmlEncode
@@ -8817,8 +7898,7 @@ XmlEncode
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   REQUIRE( encode( "normal string" ) == "normal string" )
 with expansion:
   "normal string" == "normal string"
@@ -8830,8 +7910,7 @@ XmlEncode
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   REQUIRE( encode( "" ) == "" )
 with expansion:
   "" == ""
@@ -8843,8 +7922,7 @@ XmlEncode
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   REQUIRE( encode( "smith & jones" ) == "smith &amp; jones" )
 with expansion:
   "smith &amp; jones" == "smith &amp; jones"
@@ -8856,8 +7934,7 @@ XmlEncode
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   REQUIRE( encode( "smith < jones" ) == "smith &lt; jones" )
 with expansion:
   "smith &lt; jones" == "smith &lt; jones"
@@ -8869,14 +7946,12 @@ XmlEncode
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   REQUIRE( encode( "smith > jones" ) == "smith > jones" )
 with expansion:
   "smith > jones" == "smith > jones"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   REQUIRE( encode( "smith ]]> jones" ) == "smith ]]&gt; jones" )
 with expansion:
   "smith ]]&gt; jones"
@@ -8890,16 +7965,14 @@ XmlEncode
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   REQUIRE( encode( stringWithQuotes ) == stringWithQuotes )
 with expansion:
   "don't "quote" me on that"
   ==
   "don't "quote" me on that"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   REQUIRE( encode( stringWithQuotes, Catch::XmlEncode::ForAttributes ) == "don't &quot;quote&quot; me on that" )
 with expansion:
   "don't &quot;quote&quot; me on that"
@@ -8913,8 +7986,7 @@ XmlEncode
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   REQUIRE( encode( "[\x01]" ) == "[\\x01]" )
 with expansion:
   "[\x01]" == "[\x01]"
@@ -8926,8 +7998,7 @@ XmlEncode
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   REQUIRE( encode( "[\x7F]" ) == "[\\x7F]" )
 with expansion:
   "[\x7F]" == "[\x7F]"
@@ -8939,56 +8010,47 @@ XmlEncode: UTF-8
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode(u8"Here be üëæ") == u8"Here be üëæ" )
 with expansion:
   "Here be üëæ" == "Here be üëæ"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode(u8"≈°≈°") == u8"≈°≈°" )
 with expansion:
   "≈°≈°" == "≈°≈°"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xDF\xBF") == "\xDF\xBF" )
 with expansion:
   "ﬂø" == "ﬂø"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xE0\xA0\x80") == "\xE0\xA0\x80" )
 with expansion:
   "‡†Ä" == "‡†Ä"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xED\x9F\xBF") == "\xED\x9F\xBF" )
 with expansion:
   "Ìüø" == "Ìüø"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xEE\x80\x80") == "\xEE\x80\x80" )
 with expansion:
   "ÓÄÄ" == "ÓÄÄ"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xEF\xBF\xBF") == "\xEF\xBF\xBF" )
 with expansion:
   "Ôøø" == "Ôøø"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF0\x90\x80\x80") == "\xF0\x90\x80\x80" )
 with expansion:
   "êÄÄ" == "êÄÄ"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF4\x8F\xBF\xBF") == "\xF4\x8F\xBF\xBF" )
 with expansion:
   "Ùèøø" == "Ùèøø"
@@ -9001,26 +8063,22 @@ XmlEncode: UTF-8
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("Here \xFF be üëæ") == u8"Here \\xFF be üëæ" )
 with expansion:
   "Here \xFF be üëæ" == "Here \xFF be üëæ"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xFF") == "\\xFF" )
 with expansion:
   "\xFF" == "\xFF"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xC5\xC5\xA0") == u8"\\xC5≈†" )
 with expansion:
   "\xC5≈†" == "\xC5≈†"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF4\x90\x80\x80") == u8"\\xF4\\x90\\x80\\x80" )
 with expansion:
   "\xF4\x90\x80\x80" == "\xF4\x90\x80\x80"
@@ -9033,32 +8091,27 @@ XmlEncode: UTF-8
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xC0\x80") == u8"\\xC0\\x80" )
 with expansion:
   "\xC0\x80" == "\xC0\x80"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF0\x80\x80\x80") == u8"\\xF0\\x80\\x80\\x80" )
 with expansion:
   "\xF0\x80\x80\x80" == "\xF0\x80\x80\x80"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xC1\xBF") == u8"\\xC1\\xBF" )
 with expansion:
   "\xC1\xBF" == "\xC1\xBF"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xE0\x9F\xBF") == u8"\\xE0\\x9F\\xBF" )
 with expansion:
   "\xE0\x9F\xBF" == "\xE0\x9F\xBF"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF0\x8F\xBF\xBF") == u8"\\xF0\\x8F\\xBF\\xBF" )
 with expansion:
   "\xF0\x8F\xBF\xBF" == "\xF0\x8F\xBF\xBF"
@@ -9071,26 +8124,22 @@ XmlEncode: UTF-8
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xED\xA0\x80") == "\xED\xA0\x80" )
 with expansion:
   "Ì†Ä" == "Ì†Ä"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xED\xAF\xBF") == "\xED\xAF\xBF" )
 with expansion:
   "ÌØø" == "ÌØø"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xED\xB0\x80") == "\xED\xB0\x80" )
 with expansion:
   "Ì∞Ä" == "Ì∞Ä"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xED\xBF\xBF") == "\xED\xBF\xBF" )
 with expansion:
   "Ìøø" == "Ìøø"
@@ -9103,44 +8152,37 @@ XmlEncode: UTF-8
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\x80") == u8"\\x80" )
 with expansion:
   "\x80" == "\x80"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\x81") == u8"\\x81" )
 with expansion:
   "\x81" == "\x81"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xBC") == u8"\\xBC" )
 with expansion:
   "\xBC" == "\xBC"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xBF") == u8"\\xBF" )
 with expansion:
   "\xBF" == "\xBF"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF5\x80\x80\x80") == u8"\\xF5\\x80\\x80\\x80" )
 with expansion:
   "\xF5\x80\x80\x80" == "\xF5\x80\x80\x80"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF6\x80\x80\x80") == u8"\\xF6\\x80\\x80\\x80" )
 with expansion:
   "\xF6\x80\x80\x80" == "\xF6\x80\x80\x80"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF7\x80\x80\x80") == u8"\\xF7\\x80\\x80\\x80" )
 with expansion:
   "\xF7\x80\x80\x80" == "\xF7\x80\x80\x80"
@@ -9153,80 +8195,67 @@ XmlEncode: UTF-8
 Xml.tests.cpp:<line number>
 ...............................................................................
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xDE") == u8"\\xDE" )
 with expansion:
   "\xDE" == "\xDE"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xDF") == u8"\\xDF" )
 with expansion:
   "\xDF" == "\xDF"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xE0") == u8"\\xE0" )
 with expansion:
   "\xE0" == "\xE0"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xEF") == u8"\\xEF" )
 with expansion:
   "\xEF" == "\xEF"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF0") == u8"\\xF0" )
 with expansion:
   "\xF0" == "\xF0"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF4") == u8"\\xF4" )
 with expansion:
   "\xF4" == "\xF4"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xE0\x80") == u8"\\xE0\\x80" )
 with expansion:
   "\xE0\x80" == "\xE0\x80"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xE0\xBF") == u8"\\xE0\\xBF" )
 with expansion:
   "\xE0\xBF" == "\xE0\xBF"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xE1\x80") == u8"\\xE1\\x80" )
 with expansion:
   "\xE1\x80" == "\xE1\x80"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF0\x80") == u8"\\xF0\\x80" )
 with expansion:
   "\xF0\x80" == "\xF0\x80"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF4\x80") == u8"\\xF4\\x80" )
 with expansion:
   "\xF4\x80" == "\xF4\x80"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF0\x80\x80") == u8"\\xF0\\x80\\x80" )
 with expansion:
   "\xF0\x80\x80" == "\xF0\x80\x80"
 
-Xml.tests.cpp:<line number>:
-PASSED:
+Xml.tests.cpp:<line number>: PASSED:
   CHECK( encode("\xF4\x80\x80") == u8"\\xF4\\x80\\x80" )
 with expansion:
   "\xF4\x80\x80" == "\xF4\x80\x80"
@@ -9237,20 +8266,17 @@ array<int, N> -> toString
 ToStringVector.tests.cpp:<line number>
 ...............................................................................
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( Catch::Detail::stringify( empty ) == "{  }" )
 with expansion:
   "{  }" == "{  }"
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( Catch::Detail::stringify( oneValue ) == "{ 42 }" )
 with expansion:
   "{ 42 }" == "{ 42 }"
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( Catch::Detail::stringify( twoValues ) == "{ 42, 250 }" )
 with expansion:
   "{ 42, 250 }" == "{ 42, 250 }"
@@ -9261,8 +8287,7 @@ atomic if
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( x == 0 )
 with expansion:
   0 == 0
@@ -9273,8 +8298,7 @@ boolean member
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( obj.prop != 0 )
 with expansion:
   0x<hex digits> != 0
@@ -9285,14 +8309,12 @@ checkedElse
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECKED_ELSE( flag )
 with expansion:
   true
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( testCheckedElse( true ) )
 with expansion:
   true
@@ -9319,14 +8341,12 @@ checkedIf
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECKED_IF( flag )
 with expansion:
   true
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( testCheckedIf( true ) )
 with expansion:
   true
@@ -9353,26 +8373,22 @@ comparisons between const int variables
 Condition.tests.cpp:<line number>
 ...............................................................................
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( unsigned_char_var == 1 )
 with expansion:
   1 == 1
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( unsigned_short_var == 1 )
 with expansion:
   1 == 1
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( unsigned_int_var == 1 )
 with expansion:
   1 == 1
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( unsigned_long_var == 1 )
 with expansion:
   1 == 1
@@ -9383,26 +8399,22 @@ comparisons between int variables
 Condition.tests.cpp:<line number>
 ...............................................................................
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( long_var == unsigned_char_var )
 with expansion:
   1 == 1
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( long_var == unsigned_short_var )
 with expansion:
   1 == 1
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( long_var == unsigned_int_var )
 with expansion:
   1 == 1
 
-Condition.tests.cpp:<line number>:
-PASSED:
+Condition.tests.cpp:<line number>: PASSED:
   REQUIRE( long_var == unsigned_long_var )
 with expansion:
   1 == 1
@@ -9415,8 +8427,7 @@ even more nested SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 even more nested SECTION tests
@@ -9426,8 +8437,7 @@ even more nested SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 even more nested SECTION tests
@@ -9436,8 +8446,7 @@ even more nested SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 first tag
@@ -9483,8 +8492,7 @@ long long
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( l == std::numeric_limits<long long>::max() )
 with expansion:
   9223372036854775807 (0x<hex digits>)
@@ -9522,8 +8530,7 @@ looped SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( b > a )
 with expansion:
   2 > 1
@@ -9535,8 +8542,7 @@ looped SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( b > a )
 with expansion:
   3 > 1
@@ -9548,8 +8554,7 @@ looped SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( b > a )
 with expansion:
   4 > 1
@@ -9561,8 +8566,7 @@ looped SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( b > a )
 with expansion:
   5 > 1
@@ -9574,8 +8578,7 @@ looped SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( b > a )
 with expansion:
   6 > 1
@@ -9587,8 +8590,7 @@ looped SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( b > a )
 with expansion:
   7 > 1
@@ -9600,8 +8602,7 @@ looped SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( b > a )
 with expansion:
   8 > 1
@@ -9613,8 +8614,7 @@ looped SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( b > a )
 with expansion:
   9 > 1
@@ -9639,8 +8639,7 @@ with expansion:
 with message:
   Testing if fib[1] (1) is even
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( ( fib[i] % 2 ) == 0 )
 with expansion:
   0 == 0
@@ -9661,8 +8660,7 @@ with expansion:
 with message:
   Testing if fib[4] (5) is even
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( ( fib[i] % 2 ) == 0 )
 with expansion:
   0 == 0
@@ -9704,8 +8702,7 @@ more nested SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( a != b )
 with expansion:
   1 != 2
@@ -9718,8 +8715,7 @@ more nested SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( a < b )
 with expansion:
   1 < 2
@@ -9731,14 +8727,12 @@ nested SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( a != b )
 with expansion:
   1 != 2
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( b != a )
 with expansion:
   2 != 1
@@ -9751,8 +8745,7 @@ nested SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( a != b )
 with expansion:
   1 != 2
@@ -9763,8 +8756,7 @@ non streamable - with conv. op
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( s == "7" )
 with expansion:
   "7" == "7"
@@ -9775,8 +8767,7 @@ non-copyable objects
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   CHECK( ti == typeid(int) )
 with expansion:
   {?} == {?}
@@ -9787,8 +8778,7 @@ not allowed
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 null strings
@@ -9796,14 +8786,12 @@ null strings
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( makeString( false ) != static_cast<char*>(0) )
 with expansion:
   "valid string" != {null string}
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( makeString( true ) == static_cast<char*>(0) )
 with expansion:
   {null string} == {null string}
@@ -9814,8 +8802,7 @@ null_ptr
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( ptr.get() == 0 )
 with expansion:
   0 == 0
@@ -9826,8 +8813,7 @@ pair<pair<int,const char *,pair<std::string,int> > -> toString
 ToStringPair.tests.cpp:<line number>
 ...............................................................................
 
-ToStringPair.tests.cpp:<line number>:
-PASSED:
+ToStringPair.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify( pair ) == "{ { 42, \"Arthur\" }, { \"Ford\", 24 } }" )
 with expansion:
   "{ { 42, "Arthur" }, { "Ford", 24 } }"
@@ -9840,8 +8826,7 @@ pointer to class
 Tricky.tests.cpp:<line number>
 ...............................................................................
 
-Tricky.tests.cpp:<line number>:
-PASSED:
+Tricky.tests.cpp:<line number>: PASSED:
   REQUIRE( p == 0 )
 with expansion:
   0 == 0
@@ -9853,14 +8838,12 @@ random SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( a != b )
 with expansion:
   1 != 2
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( b != a )
 with expansion:
   2 != 1
@@ -9872,8 +8855,7 @@ random SECTION tests
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( a != b )
 with expansion:
   1 != 2
@@ -9885,14 +8867,12 @@ replaceInPlace
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( Catch::replaceInPlace( letters, "b", "z" ) )
 with expansion:
   true
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( letters == "azcdefcg" )
 with expansion:
   "azcdefcg" == "azcdefcg"
@@ -9904,14 +8884,12 @@ replaceInPlace
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( Catch::replaceInPlace( letters, "c", "z" ) )
 with expansion:
   true
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( letters == "abzdefzg" )
 with expansion:
   "abzdefzg" == "abzdefzg"
@@ -9923,14 +8901,12 @@ replaceInPlace
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( Catch::replaceInPlace( letters, "a", "z" ) )
 with expansion:
   true
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( letters == "zbcdefcg" )
 with expansion:
   "zbcdefcg" == "zbcdefcg"
@@ -9942,14 +8918,12 @@ replaceInPlace
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( Catch::replaceInPlace( letters, "g", "z" ) )
 with expansion:
   true
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( letters == "abcdefcz" )
 with expansion:
   "abcdefcz" == "abcdefcz"
@@ -9961,14 +8935,12 @@ replaceInPlace
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( Catch::replaceInPlace( letters, letters, "replaced" ) )
 with expansion:
   true
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( letters == "replaced" )
 with expansion:
   "replaced" == "replaced"
@@ -9980,14 +8952,12 @@ replaceInPlace
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK_FALSE( Catch::replaceInPlace( letters, "x", "z" ) )
 with expansion:
   !false
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( letters == letters )
 with expansion:
   "abcdefcg" == "abcdefcg"
@@ -9999,14 +8969,12 @@ replaceInPlace
 String.tests.cpp:<line number>
 ...............................................................................
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( Catch::replaceInPlace( s, "'", "|'" ) )
 with expansion:
   true
 
-String.tests.cpp:<line number>:
-PASSED:
+String.tests.cpp:<line number>: PASSED:
   CHECK( s == "didn|'t" )
 with expansion:
   "didn|'t" == "didn|'t"
@@ -10050,8 +9018,7 @@ std::map is convertible string
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( Catch::Detail::stringify( emptyMap ) == "{  }" )
 with expansion:
   "{  }" == "{  }"
@@ -10063,8 +9030,7 @@ std::map is convertible string
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( Catch::Detail::stringify( map ) == "{ { \"one\", 1 } }" )
 with expansion:
   "{ { "one", 1 } }" == "{ { "one", 1 } }"
@@ -10076,8 +9042,7 @@ std::map is convertible string
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( Catch::Detail::stringify( map ) == "{ { \"abc\", 1 }, { \"def\", 2 }, { \"ghi\", 3 } }" )
 with expansion:
   "{ { "abc", 1 }, { "def", 2 }, { "ghi", 3 } }"
@@ -10090,8 +9055,7 @@ std::pair<int,const std::string> -> toString
 ToStringPair.tests.cpp:<line number>
 ...............................................................................
 
-ToStringPair.tests.cpp:<line number>:
-PASSED:
+ToStringPair.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(value) == "{ 34, \"xyzzy\" }" )
 with expansion:
   "{ 34, "xyzzy" }" == "{ 34, "xyzzy" }"
@@ -10102,8 +9066,7 @@ std::pair<int,std::string> -> toString
 ToStringPair.tests.cpp:<line number>
 ...............................................................................
 
-ToStringPair.tests.cpp:<line number>:
-PASSED:
+ToStringPair.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify( value ) == "{ 34, \"xyzzy\" }" )
 with expansion:
   "{ 34, "xyzzy" }" == "{ 34, "xyzzy" }"
@@ -10115,8 +9078,7 @@ std::set is convertible string
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( Catch::Detail::stringify( emptySet ) == "{  }" )
 with expansion:
   "{  }" == "{  }"
@@ -10128,8 +9090,7 @@ std::set is convertible string
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( Catch::Detail::stringify( set ) == "{ \"one\" }" )
 with expansion:
   "{ "one" }" == "{ "one" }"
@@ -10141,8 +9102,7 @@ std::set is convertible string
 ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
-ToStringGeneral.tests.cpp:<line number>:
-PASSED:
+ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( Catch::Detail::stringify( set ) == "{ \"abc\", \"def\", \"ghi\" }" )
 with expansion:
   "{ "abc", "def", "ghi" }"
@@ -10155,8 +9115,7 @@ std::vector<std::pair<std::string,int> > -> toString
 ToStringPair.tests.cpp:<line number>
 ...............................................................................
 
-ToStringPair.tests.cpp:<line number>:
-PASSED:
+ToStringPair.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify( pr ) == "{ { \"green\", 55 } }" )
 with expansion:
   "{ { "green", 55 } }"
@@ -10180,30 +9139,26 @@ stringify ranges
 ToStringWhich.tests.cpp:<line number>
 ...............................................................................
 
-ToStringWhich.tests.cpp:<line number>:
-PASSED:
+ToStringWhich.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(streamable_range{}) == "op<<(streamable_range)" )
 with expansion:
   "op<<(streamable_range)"
   ==
   "op<<(streamable_range)"
 
-ToStringWhich.tests.cpp:<line number>:
-PASSED:
+ToStringWhich.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(stringmaker_range{}) == "stringmaker(streamable_range)" )
 with expansion:
   "stringmaker(streamable_range)"
   ==
   "stringmaker(streamable_range)"
 
-ToStringWhich.tests.cpp:<line number>:
-PASSED:
+ToStringWhich.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(just_range{}) == "{ 1, 2, 3, 4 }" )
 with expansion:
   "{ 1, 2, 3, 4 }" == "{ 1, 2, 3, 4 }"
 
-ToStringWhich.tests.cpp:<line number>:
-PASSED:
+ToStringWhich.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(disabled_range{}) == "{ !!! }" )
 with expansion:
   "{ !!! }" == "{ !!! }"
@@ -10214,8 +9169,7 @@ stringify( has_maker )
 ToStringWhich.tests.cpp:<line number>
 ...............................................................................
 
-ToStringWhich.tests.cpp:<line number>:
-PASSED:
+ToStringWhich.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify( item ) == "StringMaker<has_maker>" )
 with expansion:
   "StringMaker<has_maker>"
@@ -10228,8 +9182,7 @@ stringify( has_maker_and_operator )
 ToStringWhich.tests.cpp:<line number>
 ...............................................................................
 
-ToStringWhich.tests.cpp:<line number>:
-PASSED:
+ToStringWhich.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify( item ) == "StringMaker<has_maker_and_operator>" )
 with expansion:
   "StringMaker<has_maker_and_operator>"
@@ -10242,8 +9195,7 @@ stringify( has_neither )
 ToStringWhich.tests.cpp:<line number>
 ...............................................................................
 
-ToStringWhich.tests.cpp:<line number>:
-PASSED:
+ToStringWhich.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(item) == "{ !!! }" )
 with expansion:
   "{ !!! }" == "{ !!! }"
@@ -10254,8 +9206,7 @@ stringify( has_operator )
 ToStringWhich.tests.cpp:<line number>
 ...............................................................................
 
-ToStringWhich.tests.cpp:<line number>:
-PASSED:
+ToStringWhich.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify( item ) == "operator<<( has_operator )" )
 with expansion:
   "operator<<( has_operator )"
@@ -10268,8 +9219,7 @@ stringify( has_template_operator )
 ToStringWhich.tests.cpp:<line number>
 ...............................................................................
 
-ToStringWhich.tests.cpp:<line number>:
-PASSED:
+ToStringWhich.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify( item ) == "operator<<( has_template_operator )" )
 with expansion:
   "operator<<( has_template_operator )"
@@ -10282,8 +9232,7 @@ stringify( vectors<has_maker> )
 ToStringWhich.tests.cpp:<line number>
 ...............................................................................
 
-ToStringWhich.tests.cpp:<line number>:
-PASSED:
+ToStringWhich.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify( v ) == "{ StringMaker<has_maker> }" )
 with expansion:
   "{ StringMaker<has_maker> }"
@@ -10296,8 +9245,7 @@ stringify( vectors<has_maker_and_operator> )
 ToStringWhich.tests.cpp:<line number>
 ...............................................................................
 
-ToStringWhich.tests.cpp:<line number>:
-PASSED:
+ToStringWhich.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify( v ) == "{ StringMaker<has_maker_and_operator> }" )
 with expansion:
   "{ StringMaker<has_maker_and_operator> }"
@@ -10310,8 +9258,7 @@ stringify( vectors<has_operator> )
 ToStringWhich.tests.cpp:<line number>
 ...............................................................................
 
-ToStringWhich.tests.cpp:<line number>:
-PASSED:
+ToStringWhich.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify( v ) == "{ operator<<( has_operator ) }" )
 with expansion:
   "{ operator<<( has_operator ) }"
@@ -10324,8 +9271,7 @@ strlen3
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str.size() == data.len )
 with expansion:
   3 == 3
@@ -10336,8 +9282,7 @@ strlen3
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str.size() == data.len )
 with expansion:
   3 == 3
@@ -10348,8 +9293,7 @@ strlen3
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str.size() == data.len )
 with expansion:
   5 == 5
@@ -10360,8 +9304,7 @@ strlen3
 Generators.tests.cpp:<line number>
 ...............................................................................
 
-Generators.tests.cpp:<line number>:
-PASSED:
+Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str.size() == data.len )
 with expansion:
   4 == 4
@@ -10382,8 +9325,7 @@ toString on const wchar_t const pointer returns the string contents
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( result == "\"wide load\"" )
 with expansion:
   ""wide load"" == ""wide load""
@@ -10394,8 +9336,7 @@ toString on const wchar_t pointer returns the string contents
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( result == "\"wide load\"" )
 with expansion:
   ""wide load"" == ""wide load""
@@ -10406,8 +9347,7 @@ toString on wchar_t const pointer returns the string contents
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( result == "\"wide load\"" )
 with expansion:
   ""wide load"" == ""wide load""
@@ -10418,8 +9358,7 @@ toString on wchar_t returns the string contents
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   CHECK( result == "\"wide load\"" )
 with expansion:
   ""wide load"" == ""wide load""
@@ -10430,20 +9369,17 @@ toString(enum class w/operator<<)
 EnumToString.tests.cpp:<line number>
 ...............................................................................
 
-EnumToString.tests.cpp:<line number>:
-PASSED:
+EnumToString.tests.cpp:<line number>: PASSED:
   CHECK( ::Catch::Detail::stringify(e0) == "E2/V0" )
 with expansion:
   "E2/V0" == "E2/V0"
 
-EnumToString.tests.cpp:<line number>:
-PASSED:
+EnumToString.tests.cpp:<line number>: PASSED:
   CHECK( ::Catch::Detail::stringify(e1) == "E2/V1" )
 with expansion:
   "E2/V1" == "E2/V1"
 
-EnumToString.tests.cpp:<line number>:
-PASSED:
+EnumToString.tests.cpp:<line number>: PASSED:
   CHECK( ::Catch::Detail::stringify(e3) == "Unknown enum value 10" )
 with expansion:
   "Unknown enum value 10"
@@ -10456,14 +9392,12 @@ toString(enum class)
 EnumToString.tests.cpp:<line number>
 ...............................................................................
 
-EnumToString.tests.cpp:<line number>:
-PASSED:
+EnumToString.tests.cpp:<line number>: PASSED:
   CHECK( ::Catch::Detail::stringify(e0) == "0" )
 with expansion:
   "0" == "0"
 
-EnumToString.tests.cpp:<line number>:
-PASSED:
+EnumToString.tests.cpp:<line number>: PASSED:
   CHECK( ::Catch::Detail::stringify(e1) == "1" )
 with expansion:
   "1" == "1"
@@ -10474,14 +9408,12 @@ toString(enum w/operator<<)
 EnumToString.tests.cpp:<line number>
 ...............................................................................
 
-EnumToString.tests.cpp:<line number>:
-PASSED:
+EnumToString.tests.cpp:<line number>: PASSED:
   CHECK( ::Catch::Detail::stringify(e0) == "E2{0}" )
 with expansion:
   "E2{0}" == "E2{0}"
 
-EnumToString.tests.cpp:<line number>:
-PASSED:
+EnumToString.tests.cpp:<line number>: PASSED:
   CHECK( ::Catch::Detail::stringify(e1) == "E2{1}" )
 with expansion:
   "E2{1}" == "E2{1}"
@@ -10492,14 +9424,12 @@ toString(enum)
 EnumToString.tests.cpp:<line number>
 ...............................................................................
 
-EnumToString.tests.cpp:<line number>:
-PASSED:
+EnumToString.tests.cpp:<line number>: PASSED:
   CHECK( ::Catch::Detail::stringify(e0) == "0" )
 with expansion:
   "0" == "0"
 
-EnumToString.tests.cpp:<line number>:
-PASSED:
+EnumToString.tests.cpp:<line number>: PASSED:
   CHECK( ::Catch::Detail::stringify(e1) == "1" )
 with expansion:
   "1" == "1"
@@ -10510,14 +9440,12 @@ tuple<>
 ToStringTuple.tests.cpp:<line number>
 ...............................................................................
 
-ToStringTuple.tests.cpp:<line number>:
-PASSED:
+ToStringTuple.tests.cpp:<line number>: PASSED:
   CHECK( "{ }" == ::Catch::Detail::stringify(type{}) )
 with expansion:
   "{ }" == "{ }"
 
-ToStringTuple.tests.cpp:<line number>:
-PASSED:
+ToStringTuple.tests.cpp:<line number>: PASSED:
   CHECK( "{ }" == ::Catch::Detail::stringify(value) )
 with expansion:
   "{ }" == "{ }"
@@ -10528,14 +9456,12 @@ tuple<float,int>
 ToStringTuple.tests.cpp:<line number>
 ...............................................................................
 
-ToStringTuple.tests.cpp:<line number>:
-PASSED:
+ToStringTuple.tests.cpp:<line number>: PASSED:
   CHECK( "1.2f" == ::Catch::Detail::stringify(float(1.2)) )
 with expansion:
   "1.2f" == "1.2f"
 
-ToStringTuple.tests.cpp:<line number>:
-PASSED:
+ToStringTuple.tests.cpp:<line number>: PASSED:
   CHECK( "{ 1.2f, 0 }" == ::Catch::Detail::stringify(type{1.2f,0}) )
 with expansion:
   "{ 1.2f, 0 }" == "{ 1.2f, 0 }"
@@ -10546,8 +9472,7 @@ tuple<int>
 ToStringTuple.tests.cpp:<line number>
 ...............................................................................
 
-ToStringTuple.tests.cpp:<line number>:
-PASSED:
+ToStringTuple.tests.cpp:<line number>: PASSED:
   CHECK( "{ 0 }" == ::Catch::Detail::stringify(type{0}) )
 with expansion:
   "{ 0 }" == "{ 0 }"
@@ -10558,8 +9483,7 @@ tuple<0,int,const char *>
 ToStringTuple.tests.cpp:<line number>
 ...............................................................................
 
-ToStringTuple.tests.cpp:<line number>:
-PASSED:
+ToStringTuple.tests.cpp:<line number>: PASSED:
   CHECK( "{ 0, 42, \"Catch me\" }" == ::Catch::Detail::stringify(value) )
 with expansion:
   "{ 0, 42, "Catch me" }"
@@ -10572,8 +9496,7 @@ tuple<string,string>
 ToStringTuple.tests.cpp:<line number>
 ...............................................................................
 
-ToStringTuple.tests.cpp:<line number>:
-PASSED:
+ToStringTuple.tests.cpp:<line number>: PASSED:
   CHECK( "{ \"hello\", \"world\" }" == ::Catch::Detail::stringify(type{"hello","world"}) )
 with expansion:
   "{ "hello", "world" }"
@@ -10586,8 +9509,7 @@ tuple<tuple<int>,tuple<>,float>
 ToStringTuple.tests.cpp:<line number>
 ...............................................................................
 
-ToStringTuple.tests.cpp:<line number>:
-PASSED:
+ToStringTuple.tests.cpp:<line number>: PASSED:
   CHECK( "{ { 42 }, { }, 1.2f }" == ::Catch::Detail::stringify(value) )
 with expansion:
   "{ { 42 }, { }, 1.2f }"
@@ -10600,14 +9522,12 @@ vec<vec<string,alloc>> -> toString
 ToStringVector.tests.cpp:<line number>
 ...............................................................................
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(v) == "{  }" )
 with expansion:
   "{  }" == "{  }"
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(v) == "{ { \"hello\" }, { \"world\" } }" )
 with expansion:
   "{ { "hello" }, { "world" } }"
@@ -10620,20 +9540,17 @@ vector<bool> -> toString
 ToStringVector.tests.cpp:<line number>
 ...............................................................................
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(bools) == "{  }" )
 with expansion:
   "{  }" == "{  }"
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(bools) == "{ true }" )
 with expansion:
   "{ true }" == "{ true }"
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(bools) == "{ true, false }" )
 with expansion:
   "{ true, false }" == "{ true, false }"
@@ -10644,20 +9561,17 @@ vector<int,allocator> -> toString
 ToStringVector.tests.cpp:<line number>
 ...............................................................................
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(vv) == "{  }" )
 with expansion:
   "{  }" == "{  }"
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(vv) == "{ 42 }" )
 with expansion:
   "{ 42 }" == "{ 42 }"
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(vv) == "{ 42, 250 }" )
 with expansion:
   "{ 42, 250 }" == "{ 42, 250 }"
@@ -10668,20 +9582,17 @@ vector<int> -> toString
 ToStringVector.tests.cpp:<line number>
 ...............................................................................
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(vv) == "{  }" )
 with expansion:
   "{  }" == "{  }"
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(vv) == "{ 42 }" )
 with expansion:
   "{ 42 }" == "{ 42 }"
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(vv) == "{ 42, 250 }" )
 with expansion:
   "{ 42, 250 }" == "{ 42, 250 }"
@@ -10692,20 +9603,17 @@ vector<string> -> toString
 ToStringVector.tests.cpp:<line number>
 ...............................................................................
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(vv) == "{  }" )
 with expansion:
   "{  }" == "{  }"
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(vv) == "{ \"hello\" }" )
 with expansion:
   "{ "hello" }" == "{ "hello" }"
 
-ToStringVector.tests.cpp:<line number>:
-PASSED:
+ToStringVector.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(vv) == "{ \"hello\", \"world\" }" )
 with expansion:
   "{ "hello", "world" }"
@@ -10718,14 +9626,12 @@ vectors can be sized and resized
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 5 )
 with expansion:
   5 == 5
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.capacity() >= 5 )
 with expansion:
   5 >= 5
@@ -10737,14 +9643,12 @@ vectors can be sized and resized
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 10 )
 with expansion:
   10 == 10
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.capacity() >= 10 )
 with expansion:
   10 >= 10
@@ -10755,14 +9659,12 @@ vectors can be sized and resized
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 5 )
 with expansion:
   5 == 5
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.capacity() >= 5 )
 with expansion:
   5 >= 5
@@ -10774,14 +9676,12 @@ vectors can be sized and resized
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 0 )
 with expansion:
   0 == 0
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.capacity() >= 5 )
 with expansion:
   5 >= 5
@@ -10794,8 +9694,7 @@ vectors can be sized and resized
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.capacity() == 0 )
 with expansion:
   0 == 0
@@ -10806,14 +9705,12 @@ vectors can be sized and resized
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 5 )
 with expansion:
   5 == 5
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.capacity() >= 5 )
 with expansion:
   5 >= 5
@@ -10825,14 +9722,12 @@ vectors can be sized and resized
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 5 )
 with expansion:
   5 == 5
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.capacity() >= 10 )
 with expansion:
   10 >= 10
@@ -10843,14 +9738,12 @@ vectors can be sized and resized
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 5 )
 with expansion:
   5 == 5
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.capacity() >= 5 )
 with expansion:
   5 >= 5
@@ -10862,14 +9755,12 @@ vectors can be sized and resized
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.size() == 5 )
 with expansion:
   5 == 5
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( v.capacity() >= 5 )
 with expansion:
   5 >= 5
@@ -10883,8 +9774,7 @@ xmlentitycheck
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 xmlentitycheck
@@ -10893,8 +9783,7 @@ xmlentitycheck
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  216 |  150 passed |  62 failed |  4 failed as expected

--- a/projects/SelfTest/Baselines/console.swa4.approved.txt
+++ b/projects/SelfTest/Baselines/console.swa4.approved.txt
@@ -11,8 +11,7 @@ Randomness seeded to: 1
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   yay
 
@@ -23,14 +22,12 @@ with message:
 Decomposition.tests.cpp:<line number>
 ...............................................................................
 
-Decomposition.tests.cpp:<line number>:
-PASSED:
+Decomposition.tests.cpp:<line number>: PASSED:
   REQUIRE( fptr == 0 )
 with expansion:
   0 == 0
 
-Decomposition.tests.cpp:<line number>:
-PASSED:
+Decomposition.tests.cpp:<line number>: PASSED:
   REQUIRE( fptr == 0l )
 with expansion:
   0 == 0
@@ -41,14 +38,12 @@ with expansion:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( y.v == 0 )
 with expansion:
   0 == 0
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( 0 == y.v )
 with expansion:
   0 == 0
@@ -59,38 +54,32 @@ with expansion:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( t1 == t2 )
 with expansion:
   {?} == {?}
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( t1 != t2 )
 with expansion:
   {?} != {?}
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( t1 < t2 )
 with expansion:
   {?} < {?}
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( t1 > t2 )
 with expansion:
   {?} > {?}
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( t1 <= t2 )
 with expansion:
   {?} <= {?}
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( t1 >= t2 )
 with expansion:
   {?} >= {?}
@@ -101,8 +90,7 @@ with expansion:
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 #1238
@@ -110,8 +98,7 @@ PASSED:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( std::memcmp(uarr, "123", sizeof(uarr)) == 0 )
 with expansion:
   0 == 0
@@ -119,8 +106,7 @@ with messages:
   uarr := "123"
   sarr := "456"
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( std::memcmp(sarr, "456", sizeof(sarr)) == 0 )
 with expansion:
   0 == 0
@@ -134,8 +120,7 @@ with messages:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
 
 -------------------------------------------------------------------------------
 #1403
@@ -143,8 +128,7 @@ PASSED:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( h1 == h2 )
 with expansion:
   [1403 helper] == [1403 helper]
@@ -181,8 +165,7 @@ due to unexpected exception with messages:
 Exception.tests.cpp:<line number>
 ...............................................................................
 
-Exception.tests.cpp:<line number>:
-PASSED:
+Exception.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS( thisThrows() )
 with message:
   answer := 42
@@ -193,8 +176,7 @@ with message:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( 42 == f )
 with expansion:
   42 == {?}
@@ -205,38 +187,31 @@ with expansion:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( a == t )
 with expansion:
   3 == 3
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   CHECK( a == t )
 with expansion:
   3 == 3
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS( throws_int(true) )
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   CHECK_THROWS_AS( throws_int(true), int )
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( throws_int(false) )
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( "aaa", Catch::EndsWith("aaa") )
 with expansion:
   "aaa" ends with: "aaa"
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( templated_tests<int>(3) )
 with expansion:
   true
@@ -252,8 +227,7 @@ Misc.tests.cpp:<line number>: FAILED:
 with expansion:
   1 == 0
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
   REQUIRE( errno == 1 )
 with expansion:
   1 == 1
@@ -264,8 +238,7 @@ with expansion:
 Compilation.tests.cpp:<line number>
 ...............................................................................
 
-Compilation.tests.cpp:<line number>:
-PASSED:
+Compilation.tests.cpp:<line number>: PASSED:
   REQUIRE( x == 4 )
 with expansion:
   {?} == 4
@@ -279,8 +252,7 @@ with message:
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   Everything is OK
 
@@ -291,8 +263,7 @@ with message:
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   Everything is OK
 
@@ -303,8 +274,7 @@ with message:
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   Everything is OK
 
@@ -315,8 +285,7 @@ with message:
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   Everything is OK
 
@@ -327,8 +296,7 @@ with message:
 Misc.tests.cpp:<line number>
 ...............................................................................
 
-Misc.tests.cpp:<line number>:
-PASSED:
+Misc.tests.cpp:<line number>: PASSED:
 with message:
   Everything is OK
 


### PR DESCRIPTION
PASSED will now appear on the same line as filename and line number,
just like the case with FAILED message formatting

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
Minor formatting change to console reporter and unit tests output.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
Closes #360 