### PR TITLE
StreamingReporterBase: add Verbosity::Quiet and Verbosity::High

### DIFF
--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -42,7 +42,7 @@ namespace Catch {
         }
 
         static std::set<Verbosity> getSupportedVerbosities() {
-            return { Verbosity::Normal };
+            return { Verbosity::Quiet, Verbosity::Normal, Verbosity::High };
         }
 
         ~StreamingReporterBase() override = default;


### PR DESCRIPTION
adding also other verbosities to static method getSupportedVerbosities

It will allow custom reporters and listeners to be used with these
verbosities from commandline.

Closes #1426

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
