### PR TITLE
Remove std::ios_base::Init

### DIFF
--- a/include/internal/catch_test_case_registry_impl.h
+++ b/include/internal/catch_test_case_registry_impl.h
@@ -44,7 +44,6 @@ namespace Catch {
         mutable RunTests::InWhatOrder m_currentSortOrder = RunTests::InDeclarationOrder;
         mutable std::vector<TestCase> m_sortedFunctions;
         std::size_t m_unnamedCount = 0;
-        std::ios_base::Init m_ostreamInit; // Forces cout/ cerr to be initialised
     };
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
One test executable in our project was consistently crashing on shutdown due to a nullptr access when destructing that `std::ios_base::Init` instance. I haven't figured out why that happens, but removing this member fixed the crash. 

This was introduced in https://github.com/catchorg/Catch2/issues/461. It should not be necessary since C++11.

I was using visual studio 15.7.6.

