### PR TITLE
operator<< works from the global namespace

### DIFF
--- a/docs/tostring.md
+++ b/docs/tostring.md
@@ -23,7 +23,7 @@ std::ostream& operator << ( std::ostream& os, T const& value ) {
 
 (where ```T``` is your type and ```convertMyTypeToString``` is where you'll write whatever code is necessary to make your type printable - it doesn't have to be in another function).
 
-You should put this function in the same namespace as your type and have it declared before including Catch's header.
+You should put this function in the same namespace as your type, or the global namespace, and have it declared before including Catch's header.
 
 ## Catch::StringMaker specialisation
 If you don't want to provide an ```operator <<``` overload, or you want to convert your type differently for testing purposes, you can provide a specialization for `Catch::StringMaker<T>`:


### PR DESCRIPTION
Since https://github.com/catchorg/Catch2/pull/1405 was merged and propagated to the single-include declaring a user operator<< in the global namespace makes it available to Catch2 string converters.

## Description
Many times it is not practical or legal to add overloads in the namespace of a type, for example, the namespace `std`.  However, the user may want Catch2 to be able to use their `operator<<` overloads in the global namespace.  Since the fix mentioned in pull request 1405 these overloads are available and the documentation should reflect that.
