### PR TITLE
Update m_lastAssertionInfo even if m_includeSuccessfulResults is false

### DIFF
--- a/include/internal/catch_run_context.cpp
+++ b/include/internal/catch_run_context.cpp
@@ -393,6 +393,8 @@ namespace Catch {
     ) {
         m_reporter->assertionStarting( info );
 
+        m_lastAssertionInfo = info;
+
         bool negated = isFalseTest( info.resultDisposition );
         bool result = expr.getResult() != negated;
 
@@ -415,7 +417,6 @@ namespace Catch {
             ITransientExpression const *expr,
             bool negated ) {
 
-        m_lastAssertionInfo = info;
         AssertionResultData data( resultType, LazyExpression( negated ) );
 
         AssertionResult assertionResult{ info, data };
@@ -436,7 +437,7 @@ namespace Catch {
 
         AssertionResultData data( resultType, LazyExpression( false ) );
         data.message = message;
-        AssertionResult assertionResult{ m_lastAssertionInfo, data };
+        AssertionResult assertionResult{ info, data };
         assertionEnded( assertionResult );
         if( !assertionResult.isOk() )
             populateReaction( reaction );


### PR DESCRIPTION
When looking into some SIGSEGV, I noticed that one of our reporters showed the last assertion before the sigsegv, the catch default reporter didn't. The difference was the m_includeSuccessfulResults setting. It seemed to me that this setting should not affect the report of the last assertion when encountering a signal, so here we go.

While that improves the situation (in the below screenshot, the second line number was a `109` before) I still think the output is confusing. Is it intended this way? It reports some assertion as failing, however assertion is the line of the last assertion before the signal, not about the signal itself, and that assertion might even have succeeded in fact. I can't spend more time on this, shall I open an issue for that?

![image](https://user-images.githubusercontent.com/1891915/48774466-aa544b00-ecca-11e8-9054-4f5bf80cd8a4.png)


