### PR TITLE
ParseAndAddCatchTests: Add PARSE_CATCH_TESTS_HIDDEN_TESTS_DISABLED option

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -32,6 +32,8 @@
 #    -- enables debug messages                                                                     #
 #    PARSE_CATCH_TESTS_NO_HIDDEN_TESTS (Default OFF)                                               #
 #    -- excludes tests marked with [!hide], [.] or [.foo] tags                                     #
+#    PARSE_CATCH_TESTS_HIDDEN_TESTS_DISABLED (Default OFF)                                         #
+#    -- if not excluded, mark tests with [!hide], [.] or [.foo] tags as DISABLED                   #
 #    PARSE_CATCH_TESTS_ADD_FIXTURE_IN_TEST_NAME (Default ON)                                       #
 #    -- adds fixture class name to the test name                                                   #
 #    PARSE_CATCH_TESTS_ADD_TARGET_IN_TEST_NAME (Default ON)                                        #
@@ -50,6 +52,7 @@ cmake_minimum_required(VERSION 2.8.8)
 
 option(PARSE_CATCH_TESTS_VERBOSE "Print Catch to CTest parser debug messages" OFF)
 option(PARSE_CATCH_TESTS_NO_HIDDEN_TESTS "Exclude tests with [!hide], [.] or [.foo] tags" OFF)
+option(PARSE_CATCH_TESTS_HIDDEN_TESTS_DISABLED "If not excluded, mark tests with [!hide], [.] or [.foo] tags as DISABLED" OFF)
 option(PARSE_CATCH_TESTS_ADD_FIXTURE_IN_TEST_NAME "Add fixture class name to the test name" ON)
 option(PARSE_CATCH_TESTS_ADD_TARGET_IN_TEST_NAME "Add target name to the test name" ON)
 option(PARSE_CATCH_TESTS_ADD_TO_CONFIGURE_DEPENDS "Add test file to CMAKE_CONFIGURE_DEPENDS property" OFF)
@@ -174,8 +177,13 @@ function(ParseFile SourceFile TestTarget)
 
             # Add the test and set its properties
             add_test(NAME "\"${CTestName}\"" COMMAND ${OptionalCatchTestLauncher} ${TestTarget} ${Name} ${AdditionalCatchParameters})
-            set_tests_properties("\"${CTestName}\"" PROPERTIES FAIL_REGULAR_EXPRESSION "No tests ran"
-                                                    LABELS "${Labels}")
+            if(PARSE_CATCH_TESTS_HIDDEN_TESTS_DISABLED AND ${HiddenTagFound})
+                PrintDebugMessage("Setting DISABLED test property")
+                set_tests_properties("\"${CTestName}\"" PROPERTIES DISABLED ON)
+            else()
+                set_tests_properties("\"${CTestName}\"" PROPERTIES FAIL_REGULAR_EXPRESSION "No tests ran"
+                                                        LABELS "${Labels}")
+            endif()
         endif()
 
     endforeach()


### PR DESCRIPTION
This PR adds the `PARSE_CATCH_TESTS_HIDDEN_TESTS_DISABLED` option to `ParseAndAddCatchTests`.

If this option is enabled and `PARSE_CATCH_TESTS_NO_HIDDEN_TESTS` option is disabled, the test is be added, but the [`DISABLED`](https://cmake.org/cmake/help/latest/prop_test/DISABLED.html) property is set, therefore CTest shows it as `Not Run (Disabled)` instead of `Passed`.

The tests that are not executed do not count in the number of executed tests.

I think this would probably be a good option to have enabled by default, but it is set it to `OFF` instead, since this would change current behaviour, and since it the option does not exist before CMake 3.9