### PR TITLE
Deprecated 'sudo: false' removed from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: cpp
-sudo: false
 
 branches:
   except:


### PR DESCRIPTION
Deprecated `sudo: false` removed from travis config.

## Description

Removes the now deprecated option `sudo: false` from the travis config file. This is related to the current Travis Linux infrastructure migration. 

Please see the [recent Travis announcement](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) for more information.

