### PR TITLE
Fix the first linebreak of messages that aborts printing #1455

### DIFF
--- a/include/external/clara.hpp
+++ b/include/external/clara.hpp
@@ -111,7 +111,10 @@ public:
 			m_suffix = false;
 			auto width = m_column.m_width - indent();
 			m_end = m_pos;
+            if(!line().empty() && line()[m_pos] == '\n')
+                ++m_end;
 			while (m_end < line().size() && line()[m_end] != '\n')
+            // while (m_end < line().size())
 				++m_end;
 
 			if (m_end < m_pos + width) {

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -453,6 +453,9 @@ Approx.tests.cpp:<line number>: passed: d >= Approx( 1.23 ) for: 1.23 >= Approx(
 Approx.tests.cpp:<line number>: passed: !(d >= Approx( 1.24 )) for: !(1.23 >= Approx( 1.24 ))
 Approx.tests.cpp:<line number>: passed: d >= Approx( 1.24 ).epsilon(0.1) for: 1.23 >= Approx( 1.24 )
 Message.tests.cpp:<line number>: warning: 'this is a message' with 1 message: 'this is a warning'
+Message.tests.cpp:<line number>: warning: '
+this is a message start with a linebreak' with 1 message: '
+this is a warning start with a linebreak'
 Message.tests.cpp:<line number>: failed: a == 1 for: 2 == 1 with 2 messages: 'this message should be logged' and 'so should this'
 Message.tests.cpp:<line number>: passed: a == 2 for: 2 == 2 with 1 message: 'this message may be logged later'
 Message.tests.cpp:<line number>: failed: a == 1 for: 2 == 1 with 2 messages: 'this message may be logged later' and 'this message should be logged'
@@ -1389,5 +1392,5 @@ Misc.tests.cpp:<line number>: passed: v.size() == 5 for: 5 == 5
 Misc.tests.cpp:<line number>: passed: v.capacity() >= 5 for: 5 >= 5
 Misc.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: passed:
-Failed 65 test cases, failed 125 assertions.
+Failed 66 test cases, failed 126 assertions.
 

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -438,6 +438,16 @@ Message.tests.cpp:<line number>: warning:
   this is a warning
 
 -------------------------------------------------------------------------------
+INFO and WARN start with a linebreak
+-------------------------------------------------------------------------------
+Message.tests.cpp:<line number>
+...............................................................................
+
+Message.tests.cpp:<line number>: warning:
+
+this is a warning start with a linebreak
+
+-------------------------------------------------------------------------------
 INFO gets logged on failure
 -------------------------------------------------------------------------------
 Message.tests.cpp:<line number>
@@ -1126,6 +1136,6 @@ due to unexpected exception with message:
   Why would you throw a std::string?
 
 ===============================================================================
-test cases:  228 |  172 passed |  52 failed |  4 failed as expected
+test cases:  229 |  173 passed |  52 failed |  4 failed as expected
 assertions: 1310 | 1178 passed | 111 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -3669,6 +3669,21 @@ Message.tests.cpp:<line number>: warning:
 No assertions in test case 'INFO and WARN do not abort tests'
 
 -------------------------------------------------------------------------------
+INFO and WARN start with a linebreak
+-------------------------------------------------------------------------------
+Message.tests.cpp:<line number>
+...............................................................................
+
+Message.tests.cpp:<line number>: warning:
+
+this is a message start with a linebreak
+
+this is a warning start with a linebreak
+
+
+No assertions in test case 'INFO and WARN start with a linebreak'
+
+-------------------------------------------------------------------------------
 INFO gets logged on failure
 -------------------------------------------------------------------------------
 Message.tests.cpp:<line number>
@@ -10464,6 +10479,6 @@ Misc.tests.cpp:<line number>
 Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
-test cases:  228 |  159 passed |  65 failed |  4 failed as expected
-assertions: 1324 | 1178 passed | 125 failed | 21 failed as expected
+test cases:  229 |  159 passed |  66 failed |  4 failed as expected
+assertions: 1325 | 1178 passed | 126 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="109" tests="1325" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="110" tests="1326" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <testcase classname="<exe-name>.global" name="# A test name that starts with a #" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1005: Comparing pointer to int and long (NULL can be either on various systems)" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1027" time="{duration}"/>
@@ -321,6 +321,7 @@ Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Generators impl/type erasure" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Greater-than inequalities with different epsilons" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="INFO and WARN do not abort tests" time="{duration}"/>
+    <testcase classname="<exe-name>.global" name="INFO and WARN start with a linebreak" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="INFO gets logged on failure" time="{duration}">
       <failure message="2 == 1" type="REQUIRE">
 this message should be logged

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -3980,6 +3980,17 @@
       </Warning>
       <OverallResult success="false"/>
     </TestCase>
+    <TestCase name="INFO and WARN start with a linebreak" tags="[.][messages]" filename="projects/<exe-name>/UsageTests/Message.tests.cpp" >
+      <Info>
+
+this is a message start with a linebreak
+      </Info>
+      <Warning>
+
+this is a warning start with a linebreak
+      </Warning>
+      <OverallResult success="false"/>
+    </TestCase>
     <TestCase name="INFO gets logged on failure" tags="[.][failing][messages]" filename="projects/<exe-name>/UsageTests/Message.tests.cpp" >
       <Info>
         this message should be logged
@@ -12099,7 +12110,7 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="1178" failures="126" expectedFailures="21"/>
+    <OverallResults successes="1178" failures="127" expectedFailures="21"/>
   </Group>
-  <OverallResults successes="1178" failures="125" expectedFailures="21"/>
+  <OverallResults successes="1178" failures="126" expectedFailures="21"/>
 </Catch>

--- a/projects/SelfTest/UsageTests/Message.tests.cpp
+++ b/projects/SelfTest/UsageTests/Message.tests.cpp
@@ -14,6 +14,11 @@ TEST_CASE( "INFO and WARN do not abort tests", "[messages][.]" ) {
     WARN( "this is a " << "warning" );    // This should always output the message but then continue
 }
 
+TEST_CASE( "INFO and WARN start with a linebreak", "[messages][.]" ) {
+    INFO( "\nthis is a " << "message start with a linebreak" );
+    WARN( "\nthis is a " << "warning start with a linebreak" );
+}
+
 TEST_CASE( "SUCCEED counts as a test pass", "[messages]" ) {
     SUCCEED( "this is a " << "success" );
 }


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

To handle something like this

```cpp
TEST_CASE( "INFO and WARN start with a linebreak", "[messages][.]" ) {
    INFO( "\nthis is a " << "message start with a linebreak" );
    WARN( "\nthis is a " << "warning start with a linebreak" );
}
```

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
#1455 