### PR TITLE
Force to install Conan 1.10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -276,7 +276,7 @@ matrix:
         - "3.7"
       dist: xenial
       install:
-        - pip install conan conan-package-tools
+        - pip install conan==1.10.2 conan-package-tools
       env:
         - CONAN_GCC_VERSIONS=8
         - CONAN_DOCKER_IMAGE=conanio/gcc8


### PR DESCRIPTION
## Description

As pointed in job https://travis-ci.org/catchorg/Catch2/jobs/473406174, Conan Package Tools requires Conan <1.11, however, the latest version is 1.11.1.

This PR is a hotfix to support Conan + CPT until the next release. 

/cc @horenmar 