### PR TITLE
enfore the suggestion that expressions should not be overly complex b…

### DIFF
--- a/include/internal/catch_decomposer.h
+++ b/include/internal/catch_decomposer.h
@@ -142,7 +142,17 @@ namespace Catch {
         auto operator <= ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
             return { static_cast<bool>(m_lhs <= rhs), m_lhs, "<=", rhs };
         }
+        
+        template<typename RhsT>
+        void operator&&( RhsT const&) = delete;
 
+        void operator&&(bool) = delete;
+        
+        template<typename RhsT>
+        void operator||( RhsT const&) = delete;
+
+        void operator||(bool) = delete;
+        
         auto makeUnaryExpr() const -> UnaryExpr<LhsT> {
             return UnaryExpr<LhsT>{ m_lhs };
         }


### PR DESCRIPTION
…y deleting operator&& and operator|| from ExprLhs

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
**WHAT**
Delete the `operator&&` and `operator||` from `ExprLhs`

**WHY**
According to the documentation, specifically [here](https://github.com/catchorg/Catch2/blob/master/docs/assertions.md#natural-expressions), expressions cannot include || or && to prevent them from being overly complex.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
I think this issue is quite common. This is just the latest one I found: https://github.com/catchorg/Catch2/issues/1471 .
