### PR TITLE
Add nice error messages for unsupported && and ||

### DIFF
--- a/include/internal/catch_decomposer.h
+++ b/include/internal/catch_decomposer.h
@@ -10,6 +10,7 @@
 
 #include "catch_tostring.h"
 #include "catch_stringref.h"
+#include "catch_meta.hpp"
 
 #include <iosfwd>
 
@@ -141,6 +142,20 @@ namespace Catch {
         template<typename RhsT>
         auto operator <= ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
             return { static_cast<bool>(m_lhs <= rhs), m_lhs, "<=", rhs };
+        }
+
+        template<typename RhsT>
+        auto operator && ( RhsT const& ) -> BinaryExpr<LhsT, RhsT const&> const {
+            static_assert(always_false<RhsT>::value,
+            "operator&& is not supported inside assertions, "
+            "wrap the expression inside parentheses, or decompose it");
+        }
+
+        template<typename RhsT>
+        auto operator || ( RhsT const& ) -> BinaryExpr<LhsT, RhsT const&> const {
+            static_assert(always_false<RhsT>::value,
+            "operator|| is not supported inside assertions, "
+            "wrap the expression inside parentheses, or decompose it");
         }
 
         auto makeUnaryExpr() const -> UnaryExpr<LhsT> {

--- a/include/internal/catch_meta.hpp
+++ b/include/internal/catch_meta.hpp
@@ -9,6 +9,8 @@
 #ifndef TWOBLUECUBES_CATCH_META_HPP_INCLUDED
 #define TWOBLUECUBES_CATCH_META_HPP_INCLUDED
 
+#include <type_traits>
+
 template< typename... >
 struct TypeList{};
 
@@ -72,5 +74,8 @@ struct combine
         };
     };
 };
+
+template<typename T>
+struct always_false : std::false_type {};
 
 #endif // TWOBLUECUBES_CATCH_META_HPP_INCLUDED


### PR DESCRIPTION
## Description

As explained in issue #1273, `operator&&` and `operator||` should give
a proper compile time error on use instead of the compiler complaining
about them not being defined. This PR adds an `always_false` type in
`catch_meta.hpp` used for implementing a nice `static_assert` for both
of the abovementioned operators.


## GitHub Issues
Closes #1273 