### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/include/internal/catch_context.h
+++ b/include/internal/catch_context.h
@@ -44,7 +44,7 @@ namespace Catch {
 
     inline IMutableContext& getCurrentMutableContext()
     {
-        if( !IMutableContext::currentContext )
+        while( !IMutableContext::currentContext )
             IMutableContext::createContext();
         return *IMutableContext::currentContext;
     }


### PR DESCRIPTION
Clang-tidy gives a warning like this:
/usr/local/include/catch2/catch.hpp:5444:9: warning: Returning null reference [clang-analyzer-core.uninitialized.UndefReturn]
        return *IMutableContext::currentContext;

This simple change fixes the warning and the overhead is minimal.