### PR TITLE
Minor RNG improvements

### DIFF
--- a/include/internal/catch_commandline.cpp
+++ b/include/internal/catch_commandline.cpp
@@ -15,6 +15,7 @@
 
 #include <fstream>
 #include <ctime>
+#include <random>
 
 namespace Catch {
 
@@ -68,7 +69,7 @@ namespace Catch {
         auto const setRngSeed = [&]( std::string const& seed ) {
                 if( seed != "time" )
                     return clara::detail::convertInto( seed, config.rngSeed );
-                config.rngSeed = static_cast<unsigned int>( std::time(nullptr) );
+                config.rngSeed = static_cast<std::mt19937::result_type>( std::time(nullptr) );
                 return ParserResult::ok( ParseResultType::Matched );
             };
         auto const setColourUsage = [&]( std::string const& useColour ) {

--- a/include/internal/catch_config.cpp
+++ b/include/internal/catch_config.cpp
@@ -56,7 +56,7 @@ namespace Catch {
     bool Config::warnAboutNoTests() const              { return !!(m_data.warnings & WarnAbout::NoTests); }
     ShowDurations::OrNot Config::showDurations() const { return m_data.showDurations; }
     RunTests::InWhatOrder Config::runOrder() const     { return m_data.runOrder; }
-    unsigned int Config::rngSeed() const               { return m_data.rngSeed; }
+    std::mt19937::result_type Config::rngSeed() const  { return m_data.rngSeed; }
     int Config::benchmarkResolutionMultiple() const    { return m_data.benchmarkResolutionMultiple; }
     UseColour::YesOrNo Config::useColour() const       { return m_data.useColour; }
     bool Config::shouldDebugBreak() const              { return m_data.shouldDebugBreak; }

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <vector>
+#include <random>
 #include <string>
 
 #ifndef CATCH_CONFIG_CONSOLE_WIDTH
@@ -41,7 +42,7 @@ namespace Catch {
         bool libIdentify = false;
 
         int abortAfter = -1;
-        unsigned int rngSeed = 0;
+        std::mt19937::result_type rngSeed = 0;
         int benchmarkResolutionMultiple = 100;
 
         Verbosity verbosity = Verbosity::Normal;
@@ -99,7 +100,7 @@ namespace Catch {
         bool warnAboutNoTests() const override;
         ShowDurations::OrNot showDurations() const override;
         RunTests::InWhatOrder runOrder() const override;
-        unsigned int rngSeed() const override;
+        std::mt19937::result_type rngSeed() const override;
         int benchmarkResolutionMultiple() const override;
         UseColour::YesOrNo useColour() const override;
         bool shouldDebugBreak() const override;

--- a/include/internal/catch_interfaces_config.h
+++ b/include/internal/catch_interfaces_config.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <random>
 
 namespace Catch {
 
@@ -70,7 +71,7 @@ namespace Catch {
         virtual TestSpec const& testSpec() const = 0;
         virtual bool hasTestFilters() const = 0;
         virtual RunTests::InWhatOrder runOrder() const = 0;
-        virtual unsigned int rngSeed() const = 0;
+        virtual std::mt19937::result_type rngSeed() const = 0;
         virtual int benchmarkResolutionMultiple() const = 0;
         virtual UseColour::YesOrNo useColour() const = 0;
         virtual std::vector<std::string> const& getSectionsToRun() const = 0;

--- a/include/internal/catch_random_number_generator.cpp
+++ b/include/internal/catch_random_number_generator.cpp
@@ -12,18 +12,17 @@
 namespace Catch {
 
     std::mt19937& rng() {
-        static std::mt19937 s_rng;
+        thread_local static std::mt19937 s_rng;
         return s_rng;
     }
 
     void seedRng( IConfig const& config ) {
         if( config.rngSeed() != 0 ) {
-            std::srand( config.rngSeed() );
             rng().seed( config.rngSeed() );
         }
     }
 
-    unsigned int rngSeed() {
+    std::mt19937::result_type rngSeed() {
         return getCurrentContext().getConfig()->rngSeed();
     }
 }

--- a/include/internal/catch_random_number_generator.h
+++ b/include/internal/catch_random_number_generator.h
@@ -16,7 +16,7 @@ namespace Catch {
 
     std::mt19937& rng();
     void seedRng( IConfig const& config );
-    unsigned int rngSeed();
+    std::mt19937::result_type rngSeed();
 
 }
 

--- a/include/internal/catch_user_interfaces.h
+++ b/include/internal/catch_user_interfaces.h
@@ -11,8 +11,10 @@
 #ifndef TWOBLUECUBES_CATCH_USER_INTERFACES_H_INCLUDED
 #define TWOBLUECUBES_CATCH_USER_INTERFACES_H_INCLUDED
 
+#include <random>
+
 namespace Catch {
-    unsigned int rngSeed();
+    std::mt19937::result_type rngSeed();
 }
 
 #endif // TWOBLUECUBES_CATCH_USER_INTERFACES_H_INCLUDED


### PR DESCRIPTION
## Description
- use thread_local instead of just static, which has the benefit of having one RNG instance per thread, which is useful in multithreaded situations (see [this article](https://web.archive.org/web/20150202012421/http://cpp.indi.frih.net/blog/2014/12/the-bell-has-tolled-for-rand/) for more info)

- remove std::srand since that only applies to std::rand

- use std::mt19937::result_type which is strictly more correct and less limiting
than unsigned int. Using unsigned int may truncate and pessismize larger values,
so we match the signature of std::mt19937.seed

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
