### PR TITLE
hexEscapeChar: restore stream

### DIFF
--- a/include/internal/catch_xmlwriter.cpp
+++ b/include/internal/catch_xmlwriter.cpp
@@ -44,9 +44,11 @@ namespace {
     }
 
     void hexEscapeChar(std::ostream& os, unsigned char c) {
+        std::ios_base::fmtflags f(os.flags());
         os << "\\x"
             << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
             << static_cast<int>(c);
+        os.flags(f);
     }
 
 } // anonymous namespace


### PR DESCRIPTION
## Description

The ostream passed as reference to `hexEscapeChar` is manipulated and its original state not restored. This is an unexpected side effect and now fixed.

Seen via [coverity](https://scan.coverity.com/dashboard) in a [downstream project](https://github.com/openPMD/openPMD-api).