### PR TITLE
ClockEstimate: Correct Average on Abort

### DIFF
--- a/include/internal/catch_timer.cpp
+++ b/include/internal/catch_timer.cpp
@@ -40,7 +40,7 @@ namespace Catch {
                 // is terrible and we should move on.
                 // TBD: How to signal that the measured resolution is probably wrong?
                 if (ticks > startTime + 3 * nanosecondsInSecond) {
-                    return sum / i;
+                    return sum / ( i + 1u );
                 }
             }
 


### PR DESCRIPTION
## Description
The clock estimator has a potential division by zero and the average is wrong on abort. Using `iteration + 1` would be correct for an average and is consistent with the non-aborted result which is also `sum / (max(i)+1)`.

Seen via [coverity](https://scan.coverity.com/dashboard) in a [downstream project](https://github.com/openPMD/openPMD-api).