### PR TITLE
RunContext: Uninit Member

### DIFF
--- a/include/internal/catch_run_context.h
+++ b/include/internal/catch_run_context.h
@@ -128,7 +128,7 @@ namespace Catch {
         TestRunInfo m_runInfo;
         IMutableContext& m_context;
         TestCase const* m_activeTestCase = nullptr;
-        ITracker* m_testCaseTracker;
+        ITracker* m_testCaseTracker = nullptr;
         Option<AssertionResult> m_lastResult;
 
         IConfigPtr m_config;


### PR DESCRIPTION
## Description

Fix an uninitialized member in `RunContext`.

Seen via [coverity](https://scan.coverity.com/dashboard) in a [downstream project](https://github.com/openPMD/openPMD-api).PR itself, so that maintainers can decide.
-->
