### PR TITLE
Missing <type_traits> include

### DIFF
--- a/include/internal/catch_type_traits.hpp
+++ b/include/internal/catch_type_traits.hpp
@@ -9,6 +9,8 @@
 #ifndef TWOBLUECUBES_CATCH_TYPE_TRAITS_HPP_INCLUDED
 #define TWOBLUECUBES_CATCH_TYPE_TRAITS_HPP_INCLUDED
 
+#include <type_traits>
+
 namespace Catch{
 
 #ifdef CATCH_CPP17_OR_GREATER


### PR DESCRIPTION
## Description
Missing `<type_traits>` include in `include/internal/catch_type_traits.hpp` is causing a compile error on Clang 6 on Ubuntu.

## GitHub Issues
Issue not created
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
