### PR TITLE
fix ctest output with space before name

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -109,7 +109,7 @@ function(ParseFile SourceFile TestTarget)
         # Get test type and fixture if applicable
         string(REGEX MATCH "(CATCH_)?(TEST_CASE_METHOD|SCENARIO|TEST_CASE)[ \t]*\\([^,^\"]*" TestTypeAndFixture "${TestName}")
         string(REGEX MATCH "(CATCH_)?(TEST_CASE_METHOD|SCENARIO|TEST_CASE)" TestType "${TestTypeAndFixture}")
-        string(REPLACE "${TestType}(" "" TestFixture "${TestTypeAndFixture}")
+        string(REGEX REPLACE "${TestType}\\([ \t]*" "" TestFixture "${TestTypeAndFixture}")
 
         # Get string parts of test definition
         string(REGEX MATCHALL "\"+([^\\^\"]|\\\\\")+\"+" TestStrings "${TestName}")


### PR DESCRIPTION
## Description
When PARSE_CATCH_TESTS_ADD_TARGET_IN_TEST_NAME is enabled the cmake helper script fails to extract the testcase name if a whitespace is before the name string. Use regex to consider and remove this whitespace.

## GitHub Issues
https://github.com/catchorg/Catch2/issues/1493
