### PR TITLE
Fix warnings generated with -Wshadow

### DIFF
--- a/include/internal/catch_approx.cpp
+++ b/include/internal/catch_approx.cpp
@@ -55,18 +55,18 @@ namespace Detail {
         return marginComparison(m_value, other, m_margin) || marginComparison(m_value, other, m_epsilon * (m_scale + std::fabs(m_value)));
     }
 
-    void Approx::setMargin(double margin) {
-        CATCH_ENFORCE(margin >= 0,
-            "Invalid Approx::margin: " << margin << '.'
+    void Approx::setMargin(double newMargin) {
+        CATCH_ENFORCE(newMargin >= 0,
+            "Invalid Approx::margin: " << newMargin << '.'
             << " Approx::Margin has to be non-negative.");
-        m_margin = margin;
+        m_margin = newMargin;
     }
 
-    void Approx::setEpsilon(double epsilon) {
-        CATCH_ENFORCE(epsilon >= 0 && epsilon <= 1.0,
-            "Invalid Approx::epsilon: " << epsilon << '.'
+    void Approx::setEpsilon(double newEpsilon) {
+        CATCH_ENFORCE(newEpsilon >= 0 && newEpsilon <= 1.0,
+            "Invalid Approx::epsilon: " << newEpsilon << '.'
             << " Approx::epsilon has to be in [0, 1]");
-        m_epsilon = epsilon;
+        m_epsilon = newEpsilon;
     }
 
 } // end namespace Detail

--- a/projects/SelfTest/UsageTests/Message.tests.cpp
+++ b/projects/SelfTest/UsageTests/Message.tests.cpp
@@ -155,9 +155,9 @@ TEST_CASE( "CAPTURE can deal with complex expressions", "[messages][capture]" ) 
 
 template <typename T1, typename T2>
 struct helper_1436 {
-    helper_1436(T1 t1, T2 t2):
-        t1{ t1 },
-        t2{ t2 }
+    helper_1436(T1 t1_, T2 t2_):
+        t1{ t1_ },
+        t2{ t2_ }
     {}
     T1 t1;
     T2 t2;


### PR DESCRIPTION
## Description
I was playing with Catch2 locally and my default set of cxxflags caused build errors, specifically `-Wshadow` (tested with gcc-7.3.0).  This change just renames a few function parameters to avoid the shadowing.

## Testing
```
[/tmp/catch2/build] cmake ../source/ '-DCMAKE_CXX_FLAGS=-Wall -Wextra -Wshadow -pedantic' -GNinja
-- The CXX compiler identification is GNU 7.3.0
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PythonInterp: /usr/bin/python (found version "3.6.5") 
-- Enabling C++11
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/catch2/build
[/tmp/catch2/build] ninja
[107/107] Linking CXX executable projects/SelfTest
[/tmp/catch2/build] ninja test
[0/1] Running tests...
Test project /tmp/catch2/build
    Start 1: RunTests
1/8 Test #1: RunTests .........................   Passed    0.02 sec
    Start 2: ListTests
2/8 Test #2: ListTests ........................   Passed    0.00 sec
    Start 3: ListTags
3/8 Test #3: ListTags .........................   Passed    0.00 sec
    Start 4: ListReporters
4/8 Test #4: ListReporters ....................   Passed    0.00 sec
    Start 5: ListTestNamesOnly
5/8 Test #5: ListTestNamesOnly ................   Passed    0.00 sec
    Start 6: NoAssertions
6/8 Test #6: NoAssertions .....................   Passed    0.02 sec
    Start 7: NoTest
7/8 Test #7: NoTest ...........................   Passed    0.00 sec
    Start 8: ApprovalTests
8/8 Test #8: ApprovalTests ....................   Passed    0.60 sec

100% tests passed, 0 tests failed out of 8

Total Test time (real) =   0.67 sec
```

I didn't test upstream code with any other compilers (gcc-7.3.0 is my default system compiler), but I ran my changes through gcc-8.2.0 and clang-7.0.1; both compiled cleanly and `ninja test` reported 100% passing tests.