### PR TITLE
use gmtime_r instead of gmtime

### DIFF
--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -602,7 +602,8 @@ struct ratio_string<std::milli> {
             std::tm timeInfo = {};
             gmtime_s(&timeInfo, &converted);
 #else
-            std::tm* timeInfo = std::gmtime(&converted);
+            struct tm_instance;
+            std::tm* timeInfo = std::gmtime_r(&converted, &tm_instance);
 #endif
 
             auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");

--- a/include/reporters/catch_reporter_junit.cpp
+++ b/include/reporters/catch_reporter_junit.cpp
@@ -33,7 +33,8 @@ namespace Catch {
             gmtime_s(&timeInfo, &rawtime);
 #else
             std::tm* timeInfo;
-            timeInfo = std::gmtime(&rawtime);
+            struct tm tm_instance;
+            timeInfo = std::gmtime_r(&rawtime, &tm_instance);
 #endif
 
             char timeStamp[timeStampSize];


### PR DESCRIPTION
Browsing alerts on [lgtm.com](https://lgtm.com/projects/g/catchorg/Catch2/alerts/?mode=list), I noticed that `gmtime` is being used.

Switching to `gmtime_r` prevents spurious results.