### PR TITLE
Update catch_suppress_warnings.h

### DIFF
--- a/include/internal/catch_suppress_warnings.h
+++ b/include/internal/catch_suppress_warnings.h
@@ -19,8 +19,8 @@
      // GCC likes to warn on REQUIREs, and we cannot suppress them
      // locally because g++'s support for _Pragma is lacking in older,
      // still supported, versions
-#    pragma GCC diagnostic ignored "-Wparentheses"
 #    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wparentheses"
 #    pragma GCC diagnostic ignored "-Wunused-variable"
 #    pragma GCC diagnostic ignored "-Wpadded"
 #endif

--- a/projects/SelfTest/UsageTests/Class.tests.cpp
+++ b/projects/SelfTest/UsageTests/Class.tests.cpp
@@ -8,6 +8,10 @@
 
 #include "catch.hpp"
 
+#if defined __GNUC__
+#    pragma GCC diagnostic ignored "-Wparentheses"
+#endif
+
 namespace{ namespace ClassTests {
 
 #ifndef CLASS_TEST_HELPERS_INCLUDED // Don't compile this more than once per TU

--- a/projects/SelfTest/UsageTests/Compilation.tests.cpp
+++ b/projects/SelfTest/UsageTests/Compilation.tests.cpp
@@ -19,6 +19,7 @@ namespace foo {
 
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wmissing-declarations"
+#pragma GCC diagnostic ignored "-Wparentheses"
 #endif
 std::ostream& operator<<(std::ostream& out, foo::helper_1403 const&) {
     return out << "[1403 helper]";

--- a/projects/SelfTest/UsageTests/Misc.tests.cpp
+++ b/projects/SelfTest/UsageTests/Misc.tests.cpp
@@ -11,6 +11,8 @@
 #ifdef __clang__
 #   pragma clang diagnostic ignored "-Wc++98-compat"
 #   pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
+#elif defined __GNUC__
+#   pragma GCC diagnostic ignored "-Wparentheses"
 #endif
 
 


### PR DESCRIPTION
fixed "pragma GCC diagnostic push" after "pragma GCC diagnostic ignored"

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
I found unusual gcc warnings pattern in catch_suppress_warnings.h that obviosly a bug added by someone who doesn't familar with diagnostic push-ignored-pop pattern.
```
#    pragma GCC diagnostic ignored "-Wparentheses"
#    pragma GCC diagnostic push
#    pragma GCC diagnostic ignored "-Wunused-variable"
#    pragma GCC diagnostic ignored "-Wpadded"
```
So I just moved "push" before first "ignored"

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->