### PR TITLE
Add to string for std::optional

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -184,6 +184,14 @@
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
+// Check if optional is available and usable
+#if defined(__has_include)
+#  if __has_include(<optional>) && defined(CATCH_CPP17_OR_GREATER)
+#    define CATCH_INTERNAL_CONFIG_CPP17_OPTIONAL
+#  endif // __has_include(<optional>) && defined(CATCH_CPP17_OR_GREATER)
+#endif // __has_include
+
+////////////////////////////////////////////////////////////////////////////////
 // Check if variant is available and usable
 #if defined(__has_include)
 #  if __has_include(<variant>) && defined(CATCH_CPP17_OR_GREATER)
@@ -220,6 +228,10 @@
 
 #if !defined(CATCH_INTERNAL_CONFIG_NO_CPP11_TO_STRING) && !defined(CATCH_CONFIG_NO_CPP11_TO_STRING) && !defined(CATCH_CONFIG_CPP11_TO_STRING)
 #    define CATCH_CONFIG_CPP11_TO_STRING
+#endif
+
+#if defined(CATCH_INTERNAL_CONFIG_CPP17_OPTIONAL) && !defined(CATCH_CONFIG_NO_CPP17_OPTIONAL) && !defined(CATCH_CONFIG_CPP17_OPTIONAL)
+#  define CATCH_CONFIG_CPP17_OPTIONAL
 #endif
 
 #if defined(CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS) && !defined(CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS) && !defined(CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -348,6 +348,7 @@ namespace Catch {
 #  define CATCH_CONFIG_ENABLE_TUPLE_STRINGMAKER
 #  define CATCH_CONFIG_ENABLE_VARIANT_STRINGMAKER
 #  define CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER
+#  define CATCH_CONFIG_ENABLE_OPTIONAL_STRINGMAKER
 #endif
 
 // Separate std::pair specialization
@@ -368,6 +369,24 @@ namespace Catch {
     };
 }
 #endif // CATCH_CONFIG_ENABLE_PAIR_STRINGMAKER
+
+#if defined(CATCH_CONFIG_ENABLE_OPTIONAL_STRINGMAKER) && defined(CATCH_CONFIG_CPP17_OPTIONAL)
+#include <optional>
+namespace Catch {
+    template<typename T>
+    struct StringMaker<std::optional<T> > {
+        static std::string convert(const std::optional<T>& optional) {
+            ReusableStringStream rss;
+            if (optional.has_value()) {
+                rss << ::Catch::Detail::stringify(*optional);
+            } else {
+                rss << "{ }";
+            }
+            return rss.str();
+        }
+    };
+}
+#endif // CATCH_CONFIG_ENABLE_OPTIONAL_STRINGMAKER
 
 // Separate std::tuple specialization
 #if defined(CATCH_CONFIG_ENABLE_TUPLE_STRINGMAKER)

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_SOURCES
         ${SELF_TEST_DIR}/UsageTests/Misc.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/ToStringChrono.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/ToStringGeneral.tests.cpp
+        ${SELF_TEST_DIR}/UsageTests/ToStringOptional.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/ToStringPair.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/ToStringTuple.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/ToStringVariant.tests.cpp

--- a/projects/SelfTest/UsageTests/ToStringOptional.tests.cpp
+++ b/projects/SelfTest/UsageTests/ToStringOptional.tests.cpp
@@ -1,0 +1,23 @@
+#define CATCH_CONFIG_ENABLE_OPTIONAL_STRINGMAKER
+#include "catch.hpp"
+
+#if defined(CATCH_CONFIG_CPP17_OPTIONAL)
+
+TEST_CASE( "std::optional<int> -> toString", "[toString][optional][approvals]" ) {
+    using type = std::optional<int>;
+    REQUIRE( "{ }" == ::Catch::Detail::stringify( type{} ) );
+    REQUIRE( "0" == ::Catch::Detail::stringify( type{ 0 } ) );
+}
+
+TEST_CASE( "std::optional<std::string> -> toString", "[toString][optional][approvals]" ) {
+    using type = std::optional<std::string>;
+    REQUIRE( "{ }" == ::Catch::Detail::stringify( type{} ) );
+    REQUIRE( "\"abc\"" == ::Catch::Detail::stringify( type{ "abc" } ) );
+}
+
+TEST_CASE( "std::vector<std::optional<int> > -> toString", "[toString][optional][approvals]" ) {
+    using type = std::vector<std::optional<int> >;
+    REQUIRE( "{ 0, { }, 2 }" == ::Catch::Detail::stringify( type{ 0, {}, 2 } ) );
+}
+
+#endif // CATCH_INTERNAL_CONFIG_CPP17_OPTIONAL


### PR DESCRIPTION
This commit add stringification for c++17 `std::optional`.

I used the same style than `std::variant<std::monostate>` for empty optionals (`{ }`), and no curly bracket around valid object (example: `0` or `"abc"`). See the added unit tests.

Given that this is a feature conditionally activated (if C++17 is available), then I don't know if the files modified by the script `misc/CMakeLists.txt` should be added.