### PR TITLE
fixing issue #1507 by using FSM

### DIFF
--- a/include/internal/catch_approx.h
+++ b/include/internal/catch_approx.h
@@ -110,10 +110,15 @@ namespace Detail {
         std::string toString() const;
 
     private:
+
+        enum calculation_type{
+            DEFAULT, MARGIN, EPSILON
+        };
         double m_epsilon;
         double m_margin;
         double m_scale;
         double m_value;
+        calculation_type current_calculation_type;
     };
 } // end namespace Detail
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

**WHAT**
This PR attempts to fix Issue #1507 by introducing a finite state machine (FSM) to determine the type of approximation that the user wants to perform. The default is using both and then OR'ing them.

**WHY**
As per Issue #1507 the inequality check will fail even though it is obviously correct. More simply, the equality is supposed to be wrong but Catch2 is reporting them as correct, because we performed an OR of epsilon_check and margin_check.

The problem seems to occur when the margin that is set by the user is smaller than the default epsilon, therefore, while margin_check will fail, epsilon_check will not.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
Closes #1507 