### PR TITLE
fix an issue where approvalTests.py cannot find selfTest.exe executable

### DIFF
--- a/scripts/scriptCommon.py
+++ b/scripts/scriptCommon.py
@@ -6,8 +6,13 @@ import subprocess
 catchPath = os.path.dirname(os.path.realpath( os.path.dirname(sys.argv[0])))
 
 def getBuildExecutable():
-    dir = os.environ.get('CATCH_DEV_OUT_DIR', "cmake-build-debug/projects/SelfTest")
-    return dir
+    if os.name == 'nt':
+        dir = os.environ.get('CATCH_DEV_OUT_DIR', "cmake-build-debug/projects/SelfTest.exe")
+        return dir
+    else:
+        dir = os.environ.get('CATCH_DEV_OUT_DIR', "cmake-build-debug/projects/SelfTest")
+        return dir
+
 
 def runAndCapture( args ):
     child = subprocess.Popen(" ".join( args ), shell=True, stdout=subprocess.PIPE)


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
Currently, the script for finding the executable is not OS aware. Specifically, it will fail to find it in Windows because the executable have .exe post-fix to its filename.
## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->

Issue #1523 
