### PR TITLE
Fix TAP protocol reporter

### DIFF
--- a/include/reporters/catch_reporter_tap.hpp
+++ b/include/reporters/catch_reporter_tap.hpp
@@ -42,9 +42,9 @@ namespace Catch {
         bool assertionEnded( AssertionStats const& _assertionStats ) override {
             ++counter;
 
+            stream << "# " << currentTestCaseInfo->name << std::endl;
             AssertionPrinter printer( stream, _assertionStats, counter );
             printer.print();
-            stream << " # " << currentTestCaseInfo->name ;
 
             stream << std::endl;
             return true;


### PR DESCRIPTION
According to TAP protocol version 13, the comments after the test name
only may contain Directives - # TODO or # SKIP. We should put
the comment (aka suite name) on a separate line before the test.

See http://testanything.org/tap-version-13-specification.html#directives