### PR TITLE
Docs: missing hyphens and full-stops added

### DIFF
--- a/docs/opensource-users.md
+++ b/docs/opensource-users.md
@@ -18,28 +18,28 @@ Listing a project here does not imply endorsement and the plan is to keep these 
 ## Libraries & Frameworks
 
 ### [Azmq](https://github.com/zeromq/azmq)
-Boost Asio style bindings for ZeroMQ
+Boost Asio style bindings for ZeroMQ.
 
 ### [ChakraCore](https://github.com/Microsoft/ChakraCore)
-The core part of the Chakra JavaScript engine that powers Microsoft Edge
+The core part of the Chakra JavaScript engine that powers Microsoft Edge.
 
 ### [ChaiScript](https://github.com/ChaiScript/ChaiScript)
-A, header-only, embedded scripting language designed from the ground up to directly target C++ and take advantage of modern C++ development techniques
+A, header-only, embedded scripting language designed from the ground up to directly target C++ and take advantage of modern C++ development techniques.
 
 ### [Clara](https://github.com/philsquared/Clara)
 A, single-header-only, type-safe, command line parser - which also prints formatted usage strings.
 
 ### [Couchbase-lite-core](https://github.com/couchbase/couchbase-lite-core)
-The next-generation core storage and query engine for Couchbase Lite
+The next-generation core storage and query engine for Couchbase Lite.
 
 ### [cppcodec](https://github.com/tplgy/cppcodec)
 Header-only C++11 library to encode/decode base64, base64url, base32, base32hex and hex (a.k.a. base16) as specified in RFC 4648, plus Crockford's base32.
 
 ### [DtCraft](https://github.com/twhuang-uiuc/DtCraft)
-A High-performance Cluster Computing Engine
+A High-performance Cluster Computing Engine.
 
 ### [forest](https://github.com/xorz57/forest)
-Template Library of Tree Data Structures
+Template Library of Tree Data Structures.
 
 ### [Fuxedo](https://github.com/fuxedo/fuxedo)
 Open source Oracle Tuxedo-like XATMI middleware for C and C++.
@@ -63,25 +63,25 @@ A small C++ library wrapper for the native C ODBC API.
 A header-only framework for benchmarking small snippets of C++ code.
 
 ### [SOCI](https://github.com/SOCI/soci)
-The C++ Database Access Library
+The C++ Database Access Library.
 
 ### [polymorphic_value](https://github.com/jbcoe/polymorphic_value)
-A polymorphic value-type for C++
+A polymorphic value-type for C++.
 
 ### [Ppconsul](https://github.com/oliora/ppconsul)
-A C++ client library for Consul. Consul is a distributed tool for discovering and configuring services in your infrastructure
+A C++ client library for Consul. Consul is a distributed tool for discovering and configuring services in your infrastructure.
 
 ### [Reactive-Extensions/ RxCpp](https://github.com/Reactive-Extensions/RxCpp)
-A library of algorithms for values-distributed-in-time
+A library of algorithms for values-distributed-in-time.
 
 ### [thor](https://github.com/xorz57/thor)
-Wrapper Library for CUDA
+Wrapper Library for CUDA.
 
 ### [TextFlowCpp](https://github.com/philsquared/textflowcpp)
-A small, single-header-only, library for wrapping and composing columns of text
+A small, single-header-only, library for wrapping and composing columns of text.
 
 ### [Trompeloeil](https://github.com/rollbear/trompeloeil)
-A thread safe header only mocking framework for C++14
+A thread-safe header-only mocking framework for C++14.
 
 ### [args](https://github.com/Taywee/args)
 A simple header-only C++ argument parser library.
@@ -95,7 +95,7 @@ ArangoDB is a native multi-model database with flexible data models for document
 Minimal, open-source and cross-platform audio tool for live music production.
 
 ### [MAME](https://github.com/mamedev/mame)
-MAME originally stood for Multiple Arcade Machine Emulator
+MAME originally stood for Multiple Arcade Machine Emulator.
 
 ### [Newsbeuter](https://github.com/akrennmair/newsbeuter)
 Newsbeuter is an open-source RSS/Atom feed reader for text terminals.
@@ -104,7 +104,7 @@ Newsbeuter is an open-source RSS/Atom feed reader for text terminals.
 SpECTRE is a code for multi-scale, multi-physics problems in astrophysics and gravitational physics.
 
 ### [Standardese](https://github.com/foonathan/standardese)
-Standardese aims to be a nextgen Doxygen
+Standardese aims to be a nextgen Doxygen.
 
 ---
 


### PR DESCRIPTION
## Description
In the docs I noticed some missing hyphens, so I added them. Then I noticed that some project descriptions had full-stops and others didn't. I decided to add them where missing rather than remove them if present.

## GitHub Issues
N/A
