### PR TITLE
fix "code will never be executed" under clang + ccache

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -48,7 +48,7 @@
             CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
         } INTERNAL_CATCH_CATCH( catchAssertionHandler ) \
         INTERNAL_CATCH_REACT( catchAssertionHandler ) \
-    } while( (void)0, false && static_cast<bool>( !!(__VA_ARGS__) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
+    } while( (void)0, (false) && static_cast<bool>( !!(__VA_ARGS__) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
     // The double negation silences MSVC's C4800 warning, the static_cast forces short-circuit evaluation if the type has overloaded &&.
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

The issue, for some otherworldly reason, only seems to appear when using ccache, with the `-c` flag (see [relevant issue](https://github.com/ccache/ccache/issues/354)).

When compiling any test such as:
```cpp
#define CATCH_CONFIG_MAIN
#include "catch.hpp"

TEST_CASE("foo", "[bar]")
{
    double a = 2.0;
    double b = 10.0;
    CHECK(a * 5.0/3.0  == b / 3.0);
}
```

Compiling it (*with ccache*):
```bash
ccache /usr/bin/clang++     -Wunreachable-code   -std=gnu++11 -c /absolute/path/test.cpp
/absolute/path/test.cpp:8:161: warning: code will never be executed [-Wunreachable-code]
 } catch(...) { catchAssertionHandler.handleUnexpectedInflightException(); } catchAssertionHandler.complete(); } while( (void)0, false && static_cast<bool>( !!(a * 5.0/3.0 == b / 3.0) ) );
                                                                                                                                                                ^
/absolute/path/test.cpp:8:130: note: silence by adding parentheses to mark code as explicitly dead
 } catch(...) { catchAssertionHandler.handleUnexpectedInflightException(); } catchAssertionHandler.complete(); } while( (void)0, false && static_cast<bool>( !!(a * 5.0/3.0 == b / 3.0) ) );
```

Why it is worth fixing:

1. It creates *very* noisy warnings, and cannot really be avoided because...
2. CMake always compiles objects separately by default (therefore with the `-c` flag)
3. ... and even if it didn't, since we should compile Catch2's main separately, we'd still need to compile the objects separately

