### PR TITLE
use "std" namespace for "sprintf"

### DIFF
--- a/include/reporters/catch_reporter_bases.cpp
+++ b/include/reporters/catch_reporter_bases.cpp
@@ -36,7 +36,7 @@ namespace Catch {
 #ifdef _MSC_VER
         sprintf_s(buffer, "%.3f", duration);
 #else
-        sprintf(buffer, "%.3f", duration);
+        std::sprintf(buffer, "%.3f", duration);
 #endif
         return std::string(buffer);
     }


### PR DESCRIPTION
Some compilers don't export C compatibility functions in `::`. Using
`std::sprintf` should work for those (and all other compilers).

Reference: https://en.cppreference.com/w/cpp/header#C_compatibility_headers