### PR TITLE
Do not open the output file twice

### DIFF
--- a/include/internal/catch_session.cpp
+++ b/include/internal/catch_session.cpp
@@ -171,9 +171,9 @@ namespace Catch {
             return 1;
 
         auto result = m_cli.parse( clara::Args( argc, argv ) );
-        config();
-        getCurrentMutableContext().setConfig( m_config );
         if( !result ) {
+            config();
+            getCurrentMutableContext().setConfig(m_config);
             Catch::cerr()
                 << Colour( Colour::Red )
                 << "\nError(s) in input:\n"


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
Catch 2.6.1 broke Catch integration in ReSharper C++. R++ uses a named pipe to read the output of the test binary.  A named pipe can only be opened once, but 7f229b4f caused the output file to get opened twice.

Creating a config in `Session::applyCommandLine` is actually not necessary unless there is an error to print. After this change `Session::applyCommandLine` constructs the config only when parsing of the command line arguments has failed.

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
