### PR TITLE
Support for printing test filters

### DIFF
--- a/include/internal/catch_test_spec.cpp
+++ b/include/internal/catch_test_spec.cpp
@@ -26,6 +26,11 @@ namespace Catch {
     bool TestSpec::NamePattern::matches( TestCaseInfo const& testCase ) const {
         return m_wildcardPattern.matches( toLower( testCase.name ) );
     }
+	 
+	PatternDescription TestSpec::NamePattern::description() const
+	{
+		return PatternDescription{ "Names" , m_wildcardPattern.getPattern() };
+	}
 
     TestSpec::TagPattern::TagPattern( std::string const& tag ) : m_tag( toLower( tag ) ) {}
     bool TestSpec::TagPattern::matches( TestCaseInfo const& testCase ) const {
@@ -34,8 +39,18 @@ namespace Catch {
                          m_tag) != end(testCase.lcaseTags);
     }
 
+	PatternDescription TestSpec::TagPattern::description() const
+	{
+		return PatternDescription{ "Tags" ,m_tag };
+	}
+
     TestSpec::ExcludedPattern::ExcludedPattern( PatternPtr const& underlyingPattern ) : m_underlyingPattern( underlyingPattern ) {}
     bool TestSpec::ExcludedPattern::matches( TestCaseInfo const& testCase ) const { return !m_underlyingPattern->matches( testCase ); }
+
+	PatternDescription TestSpec::ExcludedPattern::description() const
+	{
+		return PatternDescription{ "Excluded" , m_underlyingPattern->description().pattern };
+	}
 
     bool TestSpec::Filter::matches( TestCaseInfo const& testCase ) const {
         // All patterns in a filter must match for the filter to be a match
@@ -56,4 +71,14 @@ namespace Catch {
                 return true;
         return false;
     }
+	std::vector<PatternDescription> TestSpec::filters() const {
+		std::vector<PatternDescription> filters;
+		filters.reserve(m_filters.size());
+		for (auto&& filter : m_filters) {
+			for (auto&& pattern : filter.m_patterns) {
+				filters.emplace_back(pattern->description());
+			}
+		}
+		return filters;
+	}
 }

--- a/include/internal/catch_test_spec.h
+++ b/include/internal/catch_test_spec.h
@@ -22,10 +22,16 @@
 
 namespace Catch {
 
+	struct PatternDescription {
+		std::string name;
+		std::string pattern;
+	};
+
     class TestSpec {
         struct Pattern {
             virtual ~Pattern();
-            virtual bool matches( TestCaseInfo const& testCase ) const = 0;
+			virtual bool matches(TestCaseInfo const& testCase) const = 0;
+			virtual PatternDescription description() const = 0;
         };
         using PatternPtr = std::shared_ptr<Pattern>;
 
@@ -34,7 +40,8 @@ namespace Catch {
             NamePattern( std::string const& name );
             virtual ~NamePattern();
             virtual bool matches( TestCaseInfo const& testCase ) const override;
-        private:
+			virtual PatternDescription description() const override;
+		private:
             WildcardPattern m_wildcardPattern;
         };
 
@@ -43,7 +50,8 @@ namespace Catch {
             TagPattern( std::string const& tag );
             virtual ~TagPattern();
             virtual bool matches( TestCaseInfo const& testCase ) const override;
-        private:
+			virtual PatternDescription description() const override;
+		private:
             std::string m_tag;
         };
 
@@ -52,7 +60,8 @@ namespace Catch {
             ExcludedPattern( PatternPtr const& underlyingPattern );
             virtual ~ExcludedPattern();
             virtual bool matches( TestCaseInfo const& testCase ) const override;
-        private:
+			virtual PatternDescription description() const override;
+		private:
             PatternPtr m_underlyingPattern;
         };
 
@@ -65,7 +74,7 @@ namespace Catch {
     public:
         bool hasFilters() const;
         bool matches( TestCaseInfo const& testCase ) const;
-
+		std::vector<PatternDescription> filters() const;
     private:
         std::vector<Filter> m_filters;
 

--- a/include/internal/catch_wildcard_pattern.cpp
+++ b/include/internal/catch_wildcard_pattern.cpp
@@ -43,6 +43,22 @@ namespace Catch {
         }
     }
 
+	std::string WildcardPattern::getPattern() const
+	{
+		switch (m_wildcard) {
+		case NoWildcard:
+			return m_pattern;
+		case WildcardAtStart:
+			return "*" + m_pattern;
+		case WildcardAtEnd:
+			return m_pattern + "*";
+		case WildcardAtBothEnds:
+			return "*" + m_pattern + "*";
+		default:
+			CATCH_INTERNAL_ERROR("Unknown enum");
+		}
+	}
+
     std::string WildcardPattern::adjustCase( std::string const& str ) const {
         return m_caseSensitivity == CaseSensitive::No ? toLower( str ) : str;
     }

--- a/include/internal/catch_wildcard_pattern.h
+++ b/include/internal/catch_wildcard_pattern.h
@@ -26,7 +26,7 @@ namespace Catch
         WildcardPattern( std::string const& pattern, CaseSensitive::Choice caseSensitivity );
         virtual ~WildcardPattern() = default;
         virtual bool matches( std::string const& str ) const;
-
+		virtual std::string getPattern() const;
     private:
         std::string adjustCase( std::string const& str ) const;
         CaseSensitive::Choice m_caseSensitivity;

--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -83,6 +83,22 @@ namespace Catch {
             // It can optionally be overridden in the derived class.
         }
 
+		std::string filtersToString() const
+		{
+			std::ostringstream oss;
+			bool first = true;
+			for (auto&& pattern : m_config->testSpec().filters())
+			{
+				if (!first)
+				{
+					oss << ", ";
+				}
+				oss << pattern.pattern;
+				first = false;
+			}
+			return oss.str();
+		}
+
         IConfigPtr m_config;
         std::ostream& stream;
 

--- a/include/reporters/catch_reporter_console.cpp
+++ b/include/reporters/catch_reporter_console.cpp
@@ -436,10 +436,14 @@ void ConsoleReporter::testGroupEnded(TestGroupStats const& _testGroupStats) {
     StreamingReporterBase::testGroupEnded(_testGroupStats);
 }
 void ConsoleReporter::testRunEnded(TestRunStats const& _testRunStats) {
+	//printTestFilters(_testRunStats.totals);
     printTotalsDivider(_testRunStats.totals);
     printTotals(_testRunStats.totals);
     stream << std::endl;
     StreamingReporterBase::testRunEnded(_testRunStats);
+}
+void ConsoleReporter::testRunStarting(TestRunInfo const&) {
+	printTestFilters();
 }
 
 void ConsoleReporter::lazyPrint() {
@@ -620,6 +624,13 @@ void ConsoleReporter::printTotalsDivider(Totals const& totals) {
 }
 void ConsoleReporter::printSummaryDivider() {
     stream << getLineOfChars<'-'>() << '\n';
+}
+
+void ConsoleReporter::printTestFilters() {
+	if (m_config->testSpec().hasFilters())
+	{
+		stream << Colour(Colour::BrightYellow) << "Filters used: [" << filtersToString() << "]\n";
+	}
 }
 
 CATCH_REGISTER_REPORTER("console", ConsoleReporter)

--- a/include/reporters/catch_reporter_console.h
+++ b/include/reporters/catch_reporter_console.h
@@ -46,7 +46,7 @@ namespace Catch {
         void testCaseEnded(TestCaseStats const& _testCaseStats) override;
         void testGroupEnded(TestGroupStats const& _testGroupStats) override;
         void testRunEnded(TestRunStats const& _testRunStats) override;
-
+		void testRunStarting(TestRunInfo const& _testRunInfo) override;
     private:
 
         void lazyPrint();
@@ -69,6 +69,7 @@ namespace Catch {
 
         void printTotalsDivider(Totals const& totals);
         void printSummaryDivider();
+		void printTestFilters();
 
     private:
         bool m_headerPrinted = false;

--- a/include/reporters/catch_reporter_xml.cpp
+++ b/include/reporters/catch_reporter_xml.cpp
@@ -53,6 +53,8 @@ namespace Catch {
         if( !stylesheetRef.empty() )
             m_xml.writeStylesheetRef( stylesheetRef );
         m_xml.startElement( "Catch" );
+		if (m_config->testSpec().hasFilters())
+			m_xml.writeAttribute("Filters", filtersToString());
         if( !m_config->name().empty() )
             m_xml.writeAttribute( "name", m_config->name() );
         if( m_config->rngSeed() != 0 )


### PR DESCRIPTION
## Description
### What?
Adding printing of the filters being used by the tests as part of the report.

### Why?
When running the tests from a non terminal interface like any IDE, the arguments passed to main are hidden under a pile of GUI and usually you don't look at them before running the executable.
If you forger that you've added a filter to the tests, you might think that all your test have passed and commit new changes, but some of the tests did not even run, and you can miss it in case the number of tests that have passed is close enough to the total number of tests/assertions (or you simply don't know how many assertions should pass). 

Having a bright yellow indication of filters that were in use makes the report more complete and also helps users avoid scenarios like the one depicted above.


## GitHub Issues
Implementation of suggestion in issue #1550.
