### PR TITLE
Added override keyword near IntRange::describe() method

### DIFF
--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -100,7 +100,7 @@ public:
     // include any provided data (the begin/ end in this case) and
     // be written as if it were stating a fact (in the output it will be
     // preceded by the value under test).
-    virtual std::string describe() const {
+    virtual std::string describe() const override {
         std::ostringstream ss;
         ss << "is between " << m_begin << " and " << m_end;
         return ss.str();


### PR DESCRIPTION
## Description

Because `Catch::MatcherBase<T>::describe()` is virtual method, when someone copy-paste this example code for changing, typically code-analyzer produces warning about [`IntRange::describe()`](https://github.com/catchorg/Catch2/blob/master/docs/matchers.md#custom-matchers) `override`ing.
