### PR TITLE
Add support for capturing lambdas in GENERATE()

### DIFF
--- a/include/internal/catch_generators.hpp
+++ b/include/internal/catch_generators.hpp
@@ -201,7 +201,7 @@ namespace Generators {
 } // namespace Catch
 
 #define GENERATE( ... ) \
-    Catch::Generators::generate( CATCH_INTERNAL_LINEINFO, []{ using namespace Catch::Generators; return makeGenerators( __VA_ARGS__ ); } )
+    Catch::Generators::generate( CATCH_INTERNAL_LINEINFO, [&]{ using namespace Catch::Generators; return makeGenerators( __VA_ARGS__ ); } )
 
 
 #endif // TWOBLUECUBES_CATCH_GENERATORS_HPP_INCLUDED

--- a/projects/SelfTest/UsageTests/Generators.tests.cpp
+++ b/projects/SelfTest/UsageTests/Generators.tests.cpp
@@ -111,6 +111,51 @@ SCENARIO("Eating cucumbers", "[generators][approvals]") {
         REQUIRE( eatCucumbers( start, eat ) == left );
     }
 }
+
+SCENARIO("capturing lambda", "[generators]") {
+
+    class SomeStateMachine {
+    public:
+        void doA() { i++; }
+        void doB() { i += 2; }
+        bool checkSomeProperty() { return (i & 1); }
+
+    private:
+        int i{};
+    };
+
+    GIVEN("some instance") {
+        SomeStateMachine instance;
+
+        auto[seqId, inputSequence, expectedProperty] =
+            GENERATE(table<std::string, std::function<void()>, bool>({
+                {
+                    "AA",
+                    [&]() {
+                        instance.doA();
+                        instance.doA();
+                    },
+                    false
+                },
+                {
+                    "AB",
+                    [&]() {
+                        instance.doA();
+                        instance.doB();
+                    },
+                    true
+                },
+            }));
+
+        WHEN("the input sequence " << seqId << " is applied") {
+            inputSequence();
+
+            THEN("the expected property value is met") {
+                REQUIRE(instance.checkSomeProperty() == expectedProperty);
+            }
+        }
+    }
+}
 #endif
 
 // There are also some generic generator manipulators


### PR DESCRIPTION
## Description
It is already allowed to use non-capturing lambdas in the argument table of a GENERATE(). This simple fix allows to use capturing lambdas as-well, now.

Since the GENERATE() macro-magic contains a (non-capturing) lambda, we end up in a lambda-in-lambda situation when lambdas are supplied as arguments in the table. Since the inner lambdas can only capture if the outer lambda has a default capture, a capture by reference is added here. This still allows the inner lambdas to capture by value if necessary or to capture not at all.

An example test scenario is added as well, which hopefully shows that capturing lambdas can be quite useful in conjunction with generators.

## GitHub Issues
Also see #850