### PR TITLE
generators.md: fix extraneous back tick in doc

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -61,7 +61,7 @@ type, making their usage much nicer. These are
 * `map<T>(func, GeneratorWrapper<U>&&)` for `MapGenerator<T, U, Func>` (map `U` to `T`)
 * `chunk(chunk-size, GeneratorWrapper<T>&&)` for `ChunkGenerator<T>`
 * `random(IntegerOrFloat a, IntegerOrFloat b)` for `RandomIntegerGenerator` or `RandomFloatGenerator`
-* `range(start, end)` for `RangeGenerator<T>` with a step size of `1` 
+* `range(start, end)` for `RangeGenerator<T>` with a step size of `1`
 * `range(start, end, step)` for `RangeGenerator<T>` with a custom step size
 
 
@@ -98,7 +98,7 @@ if you want them to come out as `std::string`:
 
 ```cpp
 TEST_CASE("type conversion", "[generators]") {
-    auto str = GENERATE(as<std::string>{}, "a", "bb", "ccc");`
+    auto str = GENERATE(as<std::string>{}, "a", "bb", "ccc");
     REQUIRE(str.size() > 0);
 }
 ```


### PR DESCRIPTION
## Description
This is a trivial change to remove an extraneous back tick character in [generators.md](https://github.com/catchorg/Catch2/blob/master/docs/generators.md). 

This is present in (Data Generators / Provided generators / For safety reasons, ...). See the code block with `TEST_CASE("type conversion"`, end of line 2.
