### PR TITLE
raspigcd - opensource-users

### DIFF
--- a/docs/opensource-users.md
+++ b/docs/opensource-users.md
@@ -103,6 +103,9 @@ MAME originally stood for Multiple Arcade Machine Emulator.
 ### [Newsbeuter](https://github.com/akrennmair/newsbeuter)
 Newsbeuter is an open-source RSS/Atom feed reader for text terminals.
 
+### [raspigcd](https://github.com/pantadeusz/raspigcd)
+Low level CLI app and library for execution of GCODE on Raspberry Pi without any additional microcontrolers (just RPi + Stepsticks).
+
 ### [SpECTRE](https://github.com/sxs-collaboration/spectre)
 SpECTRE is a code for multi-scale, multi-physics problems in astrophysics and gravitational physics.
 


### PR DESCRIPTION
Added raspigcd to the opensource-users that uses Catch2 for tests

## Description

I would like to include my little project (described here https://hackaday.com/2018/05/15/direct-cnc-control-with-the-raspberry-pi/) in the list of usages of Your awesome test lib. Raspigcd uses older version of Catch. The new version (not yet mentioned here) will use Catch2.
