### PR TITLE
Suppress warning caused by ntstatus.h inclusion

### DIFF
--- a/include/internal/catch_fatal_condition.cpp
+++ b/include/internal/catch_fatal_condition.cpp
@@ -37,10 +37,10 @@ namespace Catch {
     // Windows can easily distinguish between SO and SigSegV,
     // but SigInt, SigTerm, etc are handled differently.
     static SignalDefs signalDefs[] = {
-        { EXCEPTION_ILLEGAL_INSTRUCTION,  "SIGILL - Illegal instruction signal" },
-        { EXCEPTION_STACK_OVERFLOW, "SIGSEGV - Stack overflow" },
-        { EXCEPTION_ACCESS_VIOLATION, "SIGSEGV - Segmentation violation signal" },
-        { EXCEPTION_INT_DIVIDE_BY_ZERO, "Divide by zero error" },
+        { static_cast<DWORD>(EXCEPTION_ILLEGAL_INSTRUCTION),  "SIGILL - Illegal instruction signal" },
+        { static_cast<DWORD>(EXCEPTION_STACK_OVERFLOW), "SIGSEGV - Stack overflow" },
+        { static_cast<DWORD>(EXCEPTION_ACCESS_VIOLATION), "SIGSEGV - Segmentation violation signal" },
+        { static_cast<DWORD>(EXCEPTION_INT_DIVIDE_BY_ZERO), "Divide by zero error" },
     };
 
     LONG CALLBACK FatalConditionHandler::handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {


### PR DESCRIPTION
*Windows-specific*

EXCEPTION_* codes are typically mapped to corresponding STATUS_* codes, e.g.
`#define EXCEPTION_INT_DIVIDE_BY_ZERO        STATUS_INTEGER_DIVIDE_BY_ZERO`

STATUS_* codes are *typically* defined in winnt.h:
`#define STATUS_INTEGER_DIVIDE_BY_ZERO    ((DWORD   )0xC0000094L)`

However, winnt.h defines only a limited subset of them, and sometimes it might be desirable to access the full set from ntstatus.h. A simple inclusion of ntstatus.h causes a lot of warnings because these constants are now defined twice. The conventional approach is to definine `WIN32_NO_STATUS` before including windows.h and undefine it before including ntstatus.h.

For some reason in ntstatus.h these constants are defined in a slightly different way:
`#define STATUS_INTEGER_DIVIDE_BY_ZERO    ((NTSTATUS)0xC0000094L)    // winnt`
where `NTSTATUS` is the same as `LONG` and the same as `long`.

There is a place in catch.hpp where EXCEPTION_* codes are stored in DWORD (`unsigned long`) variables.
Usually it works just fine (because usually they are also DWORDs), but in the case described above they are suddenly NTSTATUSes and `warning C4838: conversion from 'NTSTATUS' to 'DWORD' requires a narrowing conversion` is generated.

[Compiler Explorer demo](https://godbolt.org/z/islBCf)

The fix is a simple explicit cast.

Alternatively, something like this should work as well:
```diff
- struct SignalDefs { DWORD id; const char* name; };
+ struct SignalDefs { decltype(EXCEPTION_ILLEGAL_INSTRUCTION) id; const char* name; };
```