### PR TITLE
Deducing return type of map generator helper

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -57,7 +57,7 @@ type, making their usage much nicer. These are
 * `filter(predicate, GeneratorWrapper<T>&&)` for `FilterGenerator<T, Predicate>`
 * `take(count, GeneratorWrapper<T>&&)` for `TakeGenerator<T>`
 * `repeat(repeats, GeneratorWrapper<T>&&)` for `RepeatGenerator<T>`
-* `map(func, GeneratorWrapper<T>&&)` for `MapGenerator<T, T, Func>` (map `T` to `T`)
+* `map(func, GeneratorWrapper<T>&&)` for `MapGenerator<T, U, Func>` (map `U` to `T`, deduced from `Func`)
 * `map<T>(func, GeneratorWrapper<U>&&)` for `MapGenerator<T, U, Func>` (map `U` to `T`)
 * `chunk(chunk-size, GeneratorWrapper<T>&&)` for `ChunkGenerator<T>`
 * `random(IntegerOrFloat a, IntegerOrFloat b)` for `RandomIntegerGenerator` or `RandomFloatGenerator`

--- a/include/internal/catch_generators.hpp
+++ b/include/internal/catch_generators.hpp
@@ -17,6 +17,7 @@
 
 #include <utility>
 #include <exception>
+#include <functional>
 
 namespace Catch {
 

--- a/include/internal/catch_generators.hpp
+++ b/include/internal/catch_generators.hpp
@@ -17,7 +17,6 @@
 
 #include <utility>
 #include <exception>
-#include <functional>
 
 namespace Catch {
 

--- a/include/internal/catch_generators_generic.hpp
+++ b/include/internal/catch_generators_generic.hpp
@@ -169,26 +169,23 @@ namespace Generators {
         }
     };
 
-    template <
-        typename Func, typename U,
-        typename T = typename std::remove_reference<typename std::remove_cv<
-            typename std::result_of<Func(U)>::type>::type>::type,
-        typename = typename std::enable_if<std::is_constructible<
-            std::function<T(U)>,
-            std::reference_wrapper<
-                typename std::remove_reference<Func>::type>>::value>::type>
+    template <typename Func, typename U>
+    using MapFunctionReturnType = typename std::remove_reference<typename std::remove_cv<typename std::result_of<Func(U)>::type>::type>::type;
+
+    template <typename Func, typename U, typename T>
+    using IsMapFunctionCallable = typename std::is_constructible<std::function<T(U)>, std::reference_wrapper<typename std::remove_reference<Func>::type>>;
+
+    template <typename Func, typename U, typename T = MapFunctionReturnType<Func, U>>
     GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
+        static_assert(IsMapFunctionCallable<Func, U, T>::value, "Map function must take only one parameter of same type with the output of the generator");
         return GeneratorWrapper<T>(
             pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
         );
     }
 
-    template <typename T, typename U, typename Func,
-              typename = typename std::enable_if<std::is_constructible<
-                  std::function<T(U)>,
-                  std::reference_wrapper<typename std::remove_reference<
-                      Func>::type>>::value>::type>
+    template <typename T, typename U, typename Func>
     GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
+        static_assert(IsMapFunctionCallable<Func, U, T>::value, "Map function must take only one parameter of same type with the output of the generator");
         return GeneratorWrapper<T>(
             pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
         );

--- a/include/internal/catch_generators_generic.hpp
+++ b/include/internal/catch_generators_generic.hpp
@@ -169,16 +169,28 @@ namespace Generators {
         }
     };
 
-    template <typename T, typename U, typename Func>
+    template <
+        typename Func, typename U,
+        typename T = typename std::remove_reference<typename std::remove_cv<
+            typename std::result_of<Func(U)>::type>::type>::type,
+        typename = typename std::enable_if<std::is_constructible<
+            std::function<T(U)>,
+            std::reference_wrapper<
+                typename std::remove_reference<Func>::type>>::value>::type>
     GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
         return GeneratorWrapper<T>(
             pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
         );
     }
-    template <typename T, typename Func>
-    GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<T>&& generator) {
+
+    template <typename T, typename U, typename Func,
+              typename = typename std::enable_if<std::is_constructible<
+                  std::function<T(U)>,
+                  std::reference_wrapper<typename std::remove_reference<
+                      Func>::type>>::value>::type>
+    GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
         return GeneratorWrapper<T>(
-            pf::make_unique<MapGenerator<T, T, Func>>(std::forward<Func>(function), std::move(generator))
+            pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
         );
     }
 

--- a/include/internal/catch_generators_generic.hpp
+++ b/include/internal/catch_generators_generic.hpp
@@ -180,13 +180,8 @@ namespace Generators {
     using MapFunctionReturnType = typename std::remove_reference<typename std::remove_cv<typename std::result_of<Func(U)>::type>::type>::type;
 #endif
 
-    // TODO: Remove this and use std::invocable_r instead with C++17
-    template <typename Func, typename U, typename T>
-    using IsMapFunctionCallable = typename std::is_constructible<std::function<T(U)>, std::reference_wrapper<typename std::remove_reference<Func>::type>>;
-
     template <typename Func, typename U, typename T = MapFunctionReturnType<Func, U>>
     GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
-        static_assert(IsMapFunctionCallable<Func, U, T>::value, "Map function must take only one parameter of same type with the output of the generator");
         return GeneratorWrapper<T>(
             pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
         );
@@ -194,7 +189,6 @@ namespace Generators {
 
     template <typename T, typename U, typename Func>
     GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
-        static_assert(IsMapFunctionCallable<Func, U, T>::value, "Map function must take only one parameter of same type with the output of the generator");
         return GeneratorWrapper<T>(
             pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
         );

--- a/include/internal/catch_generators_generic.hpp
+++ b/include/internal/catch_generators_generic.hpp
@@ -169,9 +169,18 @@ namespace Generators {
         }
     };
 
+#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703
+    // std::result_of is deprecated in C++17 and removed in C++20. Hence, it is
+    // replaced with std::invoke_result here. Also *_t format is preferred over
+    // typename *::type format.
+    template <typename Func, typename U>
+    using MapFunctionReturnType = std::remove_reference_t<std::remove_cv_t<std::invoke_result_t<Func, U>>>;
+#else
     template <typename Func, typename U>
     using MapFunctionReturnType = typename std::remove_reference<typename std::remove_cv<typename std::result_of<Func(U)>::type>::type>::type;
+#endif
 
+    // TODO: Remove this and use std::invocable_r instead with C++17
     template <typename Func, typename U, typename T>
     using IsMapFunctionCallable = typename std::is_constructible<std::function<T(U)>, std::reference_wrapper<typename std::remove_reference<Func>::type>>;
 

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -416,6 +416,9 @@ Generators.tests.cpp:<line number>: passed: i % 2 == 0 for: 0 == 0
 Generators.tests.cpp:<line number>: passed: i.size() == 1 for: 1 == 1
 Generators.tests.cpp:<line number>: passed: i.size() == 1 for: 1 == 1
 Generators.tests.cpp:<line number>: passed: i.size() == 1 for: 1 == 1
+Generators.tests.cpp:<line number>: passed: i.size() == 1 for: 1 == 1
+Generators.tests.cpp:<line number>: passed: i.size() == 1 for: 1 == 1
+Generators.tests.cpp:<line number>: passed: i.size() == 1 for: 1 == 1
 Generators.tests.cpp:<line number>: passed: j > 0 for: 1 > 0
 Generators.tests.cpp:<line number>: passed: j > 0 for: 2 > 0
 Generators.tests.cpp:<line number>: passed: j > 0 for: 3 > 0
@@ -488,6 +491,12 @@ GeneratorsImpl.tests.cpp:<line number>: passed: gen.next() for: true
 GeneratorsImpl.tests.cpp:<line number>: passed: gen.get() == 2 for: 2 == 2
 GeneratorsImpl.tests.cpp:<line number>: passed: !(gen.next()) for: !false
 GeneratorsImpl.tests.cpp:<line number>: passed: gen.get() == 1 for: 1 == 1
+GeneratorsImpl.tests.cpp:<line number>: passed: !(gen.next()) for: !false
+GeneratorsImpl.tests.cpp:<line number>: passed: gen.get() == 2.0 for: 2.0 == 2.0
+GeneratorsImpl.tests.cpp:<line number>: passed: gen.next() for: true
+GeneratorsImpl.tests.cpp:<line number>: passed: gen.get() == 4.0 for: 4.0 == 4.0
+GeneratorsImpl.tests.cpp:<line number>: passed: gen.next() for: true
+GeneratorsImpl.tests.cpp:<line number>: passed: gen.get() == 6.0 for: 6.0 == 6.0
 GeneratorsImpl.tests.cpp:<line number>: passed: !(gen.next()) for: !false
 GeneratorsImpl.tests.cpp:<line number>: passed: gen.get() == 2.0 for: 2.0 == 2.0
 GeneratorsImpl.tests.cpp:<line number>: passed: gen.next() for: true

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -1265,5 +1265,5 @@ due to unexpected exception with message:
 
 ===============================================================================
 test cases:  255 |  189 passed |  62 failed |  4 failed as expected
-assertions: 1393 | 1250 passed | 122 failed | 21 failed as expected
+assertions: 1402 | 1259 passed | 122 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -3047,6 +3047,45 @@ with expansion:
 
 -------------------------------------------------------------------------------
 Generators -- adapters
+  Transforming elements
+  Different deduced type
+-------------------------------------------------------------------------------
+Generators.tests.cpp:<line number>
+...............................................................................
+
+Generators.tests.cpp:<line number>: PASSED:
+  REQUIRE( i.size() == 1 )
+with expansion:
+  1 == 1
+
+-------------------------------------------------------------------------------
+Generators -- adapters
+  Transforming elements
+  Different deduced type
+-------------------------------------------------------------------------------
+Generators.tests.cpp:<line number>
+...............................................................................
+
+Generators.tests.cpp:<line number>: PASSED:
+  REQUIRE( i.size() == 1 )
+with expansion:
+  1 == 1
+
+-------------------------------------------------------------------------------
+Generators -- adapters
+  Transforming elements
+  Different deduced type
+-------------------------------------------------------------------------------
+Generators.tests.cpp:<line number>
+...............................................................................
+
+Generators.tests.cpp:<line number>: PASSED:
+  REQUIRE( i.size() == 1 )
+with expansion:
+  1 == 1
+
+-------------------------------------------------------------------------------
+Generators -- adapters
   Repeating a generator
 -------------------------------------------------------------------------------
 Generators.tests.cpp:<line number>
@@ -3675,7 +3714,44 @@ with expansion:
 
 -------------------------------------------------------------------------------
 Generators internals
-  Map
+  Map with explicit return type
+-------------------------------------------------------------------------------
+GeneratorsImpl.tests.cpp:<line number>
+...............................................................................
+
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
+  REQUIRE( gen.get() == 2.0 )
+with expansion:
+  2.0 == 2.0
+
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
+  REQUIRE( gen.next() )
+with expansion:
+  true
+
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
+  REQUIRE( gen.get() == 4.0 )
+with expansion:
+  4.0 == 4.0
+
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
+  REQUIRE( gen.next() )
+with expansion:
+  true
+
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
+  REQUIRE( gen.get() == 6.0 )
+with expansion:
+  6.0 == 6.0
+
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
+  REQUIRE_FALSE( gen.next() )
+with expansion:
+  !false
+
+-------------------------------------------------------------------------------
+Generators internals
+  Map with deduced return type
 -------------------------------------------------------------------------------
 GeneratorsImpl.tests.cpp:<line number>
 ...............................................................................
@@ -10850,5 +10926,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  255 |  174 passed |  77 failed |  4 failed as expected
-assertions: 1409 | 1250 passed | 138 failed | 21 failed as expected
+assertions: 1418 | 1259 passed | 138 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -4,7 +4,7 @@
     <property name="random-seed" value="1"/>
   </properties>
 loose text artifact
-  <testsuite name="<exe-name>" errors="17" failures="122" tests="1410" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="122" tests="1419" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <testcase classname="<exe-name>.global" name="# A test name that starts with a #" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1005: Comparing pointer to int and long (NULL can be either on various systems)" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1027" time="{duration}"/>
@@ -360,6 +360,7 @@ Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Generators -- adapters/Shortening a range" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Generators -- adapters/Transforming elements/Same type" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Generators -- adapters/Transforming elements/Different type" time="{duration}"/>
+    <testcase classname="<exe-name>.global" name="Generators -- adapters/Transforming elements/Different deduced type" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Generators -- adapters/Repeating a generator" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Generators -- adapters/Chunking a generator into sized pieces/Number of elements in source is divisible by chunk size" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Generators -- adapters/Chunking a generator into sized pieces/Number of elements in source is not divisible by chunk size" time="{duration}"/>
@@ -373,7 +374,8 @@ Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Generators internals/Filter generator" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Generators internals/Take generator/Take less" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Generators internals/Take generator/Take more" time="{duration}"/>
-    <testcase classname="<exe-name>.global" name="Generators internals/Map" time="{duration}"/>
+    <testcase classname="<exe-name>.global" name="Generators internals/Map with explicit return type" time="{duration}"/>
+    <testcase classname="<exe-name>.global" name="Generators internals/Map with deduced return type" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Generators internals/Repeat/Singular repeat" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Generators internals/Repeat/Actual repeat" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Generators internals/Range/Positive auto step/Integer" time="{duration}"/>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -3736,6 +3736,48 @@ Nor would this
         </Section>
         <OverallResults successes="1" failures="0" expectedFailures="0"/>
       </Section>
+      <Section name="Transforming elements" filename="projects/<exe-name>/UsageTests/Generators.tests.cpp" >
+        <Section name="Different deduced type" filename="projects/<exe-name>/UsageTests/Generators.tests.cpp" >
+          <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Generators.tests.cpp" >
+            <Original>
+              i.size() == 1
+            </Original>
+            <Expanded>
+              1 == 1
+            </Expanded>
+          </Expression>
+          <OverallResults successes="1" failures="0" expectedFailures="0"/>
+        </Section>
+        <OverallResults successes="1" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="Transforming elements" filename="projects/<exe-name>/UsageTests/Generators.tests.cpp" >
+        <Section name="Different deduced type" filename="projects/<exe-name>/UsageTests/Generators.tests.cpp" >
+          <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Generators.tests.cpp" >
+            <Original>
+              i.size() == 1
+            </Original>
+            <Expanded>
+              1 == 1
+            </Expanded>
+          </Expression>
+          <OverallResults successes="1" failures="0" expectedFailures="0"/>
+        </Section>
+        <OverallResults successes="1" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="Transforming elements" filename="projects/<exe-name>/UsageTests/Generators.tests.cpp" >
+        <Section name="Different deduced type" filename="projects/<exe-name>/UsageTests/Generators.tests.cpp" >
+          <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Generators.tests.cpp" >
+            <Original>
+              i.size() == 1
+            </Original>
+            <Expanded>
+              1 == 1
+            </Expanded>
+          </Expression>
+          <OverallResults successes="1" failures="0" expectedFailures="0"/>
+        </Section>
+        <OverallResults successes="1" failures="0" expectedFailures="0"/>
+      </Section>
       <Section name="Repeating a generator" filename="projects/<exe-name>/UsageTests/Generators.tests.cpp" >
         <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Generators.tests.cpp" >
           <Original>
@@ -4461,7 +4503,58 @@ Nor would this
         </Section>
         <OverallResults successes="2" failures="0" expectedFailures="0"/>
       </Section>
-      <Section name="Map" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
+      <Section name="Map with explicit return type" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
+        <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
+          <Original>
+            gen.get() == 2.0
+          </Original>
+          <Expanded>
+            2.0 == 2.0
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
+          <Original>
+            gen.next()
+          </Original>
+          <Expanded>
+            true
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
+          <Original>
+            gen.get() == 4.0
+          </Original>
+          <Expanded>
+            4.0 == 4.0
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
+          <Original>
+            gen.next()
+          </Original>
+          <Expanded>
+            true
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
+          <Original>
+            gen.get() == 6.0
+          </Original>
+          <Expanded>
+            6.0 == 6.0
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE_FALSE" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
+          <Original>
+            !(gen.next())
+          </Original>
+          <Expanded>
+            !false
+          </Expanded>
+        </Expression>
+        <OverallResults successes="6" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="Map with deduced return type" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
         <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
           <Original>
             gen.get() == 2.0
@@ -13153,7 +13246,7 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="1250" failures="139" expectedFailures="21"/>
+    <OverallResults successes="1259" failures="139" expectedFailures="21"/>
   </Group>
-  <OverallResults successes="1250" failures="138" expectedFailures="21"/>
+  <OverallResults successes="1259" failures="138" expectedFailures="21"/>
 </Catch>

--- a/projects/SelfTest/IntrospectiveTests/GeneratorsImpl.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/GeneratorsImpl.tests.cpp
@@ -68,8 +68,17 @@ TEST_CASE("Generators internals", "[generators][internals]") {
             REQUIRE_FALSE(gen.next());
         }
     }
-    SECTION("Map") {
+    SECTION("Map with explicit return type") {
         auto gen = map<double>([] (int i) {return 2.0 * i; }, values({ 1, 2, 3 }));
+        REQUIRE(gen.get() == 2.0);
+        REQUIRE(gen.next());
+        REQUIRE(gen.get() == 4.0);
+        REQUIRE(gen.next());
+        REQUIRE(gen.get() == 6.0);
+        REQUIRE_FALSE(gen.next());
+    }
+    SECTION("Map with deduced return type") {
+        auto gen = map([] (int i) {return 2.0 * i; }, values({ 1, 2, 3 }));
         REQUIRE(gen.get() == 2.0);
         REQUIRE(gen.next());
         REQUIRE(gen.get() == 4.0);

--- a/projects/SelfTest/UsageTests/Generators.tests.cpp
+++ b/projects/SelfTest/UsageTests/Generators.tests.cpp
@@ -144,6 +144,11 @@ TEST_CASE("Generators -- adapters", "[generators][generic]") {
             auto i = GENERATE(map<std::string>([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })));
             REQUIRE(i.size() == 1);
         }
+        SECTION("Different deduced type") {
+            // This takes a generator that returns ints and maps them into strings
+            auto i = GENERATE(map([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })));
+            REQUIRE(i.size() == 1);
+        }
     }
     SECTION("Repeating a generator") {
         // This will return values [1, 2, 3, 1, 2, 3]


### PR DESCRIPTION
## Description
`map` generator helper function requires its return type to be given explicitly if it is different from the type produced by the generator argument. This patch enables deducing the return type from the return type of given lambda function. Example: 

This:

```c++
auto val = GENERATE(map<std::tuple<int, std::string>>([](int val) {
  return std::make_tuple(val, std::to_string(val));
}, range(-5, 5));
```
can be optionally written as:
```c++
auto val = GENERATE(map([](int val) {
  return std::make_tuple(val, std::to_string(val));
}, range(-5, 5));
```