### PR TITLE
Support for printing test filters

### DIFF
--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -82,7 +82,7 @@ namespace Catch {
         std::string getProcessName() const;
         std::string const& getReporterName() const;
 
-        std::vector<std::string> const& getTestsOrTags() const;
+        std::vector<std::string> const& getTestsOrTags() const override;
         std::vector<std::string> const& getSectionsToRun() const override;
 
         virtual TestSpec const& testSpec() const override;

--- a/include/internal/catch_interfaces_config.h
+++ b/include/internal/catch_interfaces_config.h
@@ -69,6 +69,7 @@ namespace Catch {
         virtual ShowDurations::OrNot showDurations() const = 0;
         virtual TestSpec const& testSpec() const = 0;
         virtual bool hasTestFilters() const = 0;
+        virtual std::vector<std::string> const& getTestsOrTags() const = 0;
         virtual RunTests::InWhatOrder runOrder() const = 0;
         virtual unsigned int rngSeed() const = 0;
         virtual int benchmarkResolutionMultiple() const = 0;

--- a/include/reporters/catch_reporter_bases.cpp
+++ b/include/reporters/catch_reporter_bases.cpp
@@ -41,6 +41,20 @@ namespace Catch {
         return std::string(buffer);
     }
 
+    std::string serializeFilters( std::vector<std::string> const& container ) {
+        ReusableStringStream oss;
+        bool first = true;
+        for (auto&& filter : container)
+        {
+            if (!first)
+                oss << ' ';
+            else
+                first = false;
+
+            oss << filter;
+        }
+        return oss.str();
+    }
 
     TestEventListenerBase::TestEventListenerBase(ReporterConfig const & _config)
         :StreamingReporterBase(_config) {}

--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -25,6 +25,8 @@ namespace Catch {
     // Returns double formatted as %.3f (format expected on output)
     std::string getFormattedDuration( double duration );
 
+    std::string serializeFilters( std::vector<std::string> const& container );
+
     template<typename DerivedT>
     struct StreamingReporterBase : IStreamingReporter {
 
@@ -52,6 +54,7 @@ namespace Catch {
         void testRunStarting(TestRunInfo const& _testRunInfo) override {
             currentTestRunInfo = _testRunInfo;
         }
+
         void testGroupStarting(GroupInfo const& _groupInfo) override {
             currentGroupInfo = _groupInfo;
         }

--- a/include/reporters/catch_reporter_console.cpp
+++ b/include/reporters/catch_reporter_console.cpp
@@ -441,6 +441,10 @@ void ConsoleReporter::testRunEnded(TestRunStats const& _testRunStats) {
     stream << std::endl;
     StreamingReporterBase::testRunEnded(_testRunStats);
 }
+void ConsoleReporter::testRunStarting(TestRunInfo const& _testInfo) {
+    StreamingReporterBase::testRunStarting(_testInfo);
+    printTestFilters();
+}
 
 void ConsoleReporter::lazyPrint() {
 
@@ -620,6 +624,11 @@ void ConsoleReporter::printTotalsDivider(Totals const& totals) {
 }
 void ConsoleReporter::printSummaryDivider() {
     stream << getLineOfChars<'-'>() << '\n';
+}
+
+void ConsoleReporter::printTestFilters() {
+    if (m_config->testSpec().hasFilters())
+        stream << Colour(Colour::BrightYellow) << "Filters: " << serializeFilters( m_config->getTestsOrTags() ) << '\n';
 }
 
 CATCH_REGISTER_REPORTER("console", ConsoleReporter)

--- a/include/reporters/catch_reporter_console.h
+++ b/include/reporters/catch_reporter_console.h
@@ -46,7 +46,7 @@ namespace Catch {
         void testCaseEnded(TestCaseStats const& _testCaseStats) override;
         void testGroupEnded(TestGroupStats const& _testGroupStats) override;
         void testRunEnded(TestRunStats const& _testRunStats) override;
-
+        void testRunStarting(TestRunInfo const& _testRunInfo) override;
     private:
 
         void lazyPrint();
@@ -69,6 +69,7 @@ namespace Catch {
 
         void printTotalsDivider(Totals const& totals);
         void printSummaryDivider();
+        void printTestFilters();
 
     private:
         bool m_headerPrinted = false;

--- a/include/reporters/catch_reporter_junit.cpp
+++ b/include/reporters/catch_reporter_junit.cpp
@@ -76,8 +76,17 @@ namespace Catch {
     void JunitReporter::testRunStarting( TestRunInfo const& runInfo )  {
         CumulativeReporterBase::testRunStarting( runInfo );
         xml.startElement( "testsuites" );
+
+        if ( m_config->hasTestFilters() || m_config->rngSeed() != 0 ) 
+            xml.startElement("properties");
+
+        if ( m_config->hasTestFilters() ) {
+            xml.scopedElement( "property" )
+                .writeAttribute( "name" , "filters" )
+                .writeAttribute( "value" , serializeFilters( m_config->getTestsOrTags() ) );
+        }
+        
         if( m_config->rngSeed() != 0 ) {
-            xml.startElement( "properties" );
             xml.scopedElement( "property" )
                 .writeAttribute( "name", "random-seed" )
                 .writeAttribute( "value", m_config->rngSeed() );

--- a/include/reporters/catch_reporter_xml.cpp
+++ b/include/reporters/catch_reporter_xml.cpp
@@ -55,6 +55,8 @@ namespace Catch {
         m_xml.startElement( "Catch" );
         if( !m_config->name().empty() )
             m_xml.writeAttribute( "name", m_config->name() );
+        if (m_config->testSpec().hasFilters())
+            m_xml.writeAttribute( "filters", serializeFilters( m_config->getTestsOrTags() ) );
         if( m_config->rngSeed() != 0 )
             m_xml.scopedElement( "Randomness" )
                 .writeAttribute( "seed", m_config->rngSeed() );

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -1,3 +1,4 @@
+Filters: ~[!nonportable]~[!benchmark]~[approvals]
 This would not be caught previously
 Nor would this
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -1,3 +1,4 @@
+Filters: ~[!nonportable]~[!benchmark]~[approvals]
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <exe-name> is a <version> host application.

--- a/projects/SelfTest/Baselines/console.swa4.approved.txt
+++ b/projects/SelfTest/Baselines/console.swa4.approved.txt
@@ -1,3 +1,4 @@
+Filters: ~[!nonportable]~[!benchmark]~[approvals]
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <exe-name> is a <version> host application.

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <properties>
+    <property name="filters" value="~[!nonportable]~[!benchmark]~[approvals]"/>
     <property name="random-seed" value="1"/>
   </properties>
 loose text artifact

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Catch name="<exe-name>">
+<Catch name="<exe-name>" filters="~[!nonportable]~[!benchmark]~[approvals]">
   <Randomness seed="1"/>
   <Group name="<exe-name>">
     <TestCase name="# A test name that starts with a #" filename="projects/<exe-name>/UsageTests/Misc.tests.cpp" >


### PR DESCRIPTION
## Description
### What?
Adding printing of the filters being used by the tests as part of the report.

Example Console Reporter:
![image](https://user-images.githubusercontent.com/22654243/55235493-b931a800-523e-11e9-9657-cce954b79429.png)

Example XML Reporter:
![image](https://user-images.githubusercontent.com/22654243/55235554-dfefde80-523e-11e9-9c5d-52e3661c846e.png)

Example JUnit Reporter:
![image](https://user-images.githubusercontent.com/22654243/55253569-c9f61400-5266-11e9-9b12-a85f20f4ad09.png)


### Why?
When running the tests from a non terminal interface like any IDE, the arguments passed to main are hidden under a pile of GUI and usually you don't look at them before running the executable.
If you forger that you've added a filter to the tests, you might think that all your test have passed and commit new changes, but some of the tests did not even run, and you can miss it in case the number of tests that have passed is close enough to the total number of tests/assertions (or you simply don't know how many assertions should pass). 

Having a bright yellow indication of filters that were in use makes the report more complete and also helps users avoid scenarios like the one depicted above.


## GitHub Issues
Implementation of suggestion in issue #1550.

## To do list:
 - ~~Console Reporter~~
 - ~~XML Reporter~~
 - ~~JunitReporter~~
 - TeamCity reporter 
 - AutoMake and TAP reporters: 🤷‍♂️
 - ~~AprovalTest~~
- CTest