### PR TITLE
Use correct filename in CMake integration docs

### DIFF
--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -48,7 +48,7 @@ If Catch2 has been installed in system, both of these can be used after
 doing `find_package(Catch2 REQUIRED)`. Otherwise you need to add them
 to your CMake module path.
 
-### `Catch.cmake` and `AddCatchTests.cmake`
+### `Catch.cmake` and `CatchAddTests.cmake`
 
 `Catch.cmake` provides function `catch_discover_tests` to get tests from
 a target. This function works by running the resulting executable with


### PR DESCRIPTION
The header at https://github.com/catchorg/Catch2/blob/master/docs/cmake-integration.md#catchcmake-and-addcatchtestscmake should be naming https://github.com/catchorg/Catch2/blob/master/contrib/CatchAddTests.cmake