### PR TITLE
Fix typos identified by codespell.

### DIFF
--- a/.conan/build.py
+++ b/.conan/build.py
@@ -47,7 +47,7 @@ class BuilderSettings(object):
 
     @property
     def reference(self):
-        """ Read project version from branch create Conan referece
+        """ Read project version from branch create Conan reference
         """
         return os.getenv("CONAN_REFERENCE", "Catch2/{}".format(self._version))
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ at docs/contributing.md. It will tell you how to properly test your changes.
 <!--
 Describe the what and the why of your pull request. Remember that these two
 are usually a bit different. As an example, if you have made various changes
-to decrease the number of new strings allocated, thats what. The why probably
+to decrease the number of new strings allocated, that's what. The why probably
 was that you have a large set of tests and found that this speeds them up.
 -->
 

--- a/CMake/FindGcov.cmake
+++ b/CMake/FindGcov.cmake
@@ -19,7 +19,7 @@ set(CMAKE_REQUIRED_QUIET ${codecov_FIND_QUIETLY})
 
 get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
 foreach (LANG ${ENABLED_LANGUAGES})
-	# Gcov evaluation is dependend on the used compiler. Check gcov support for
+	# Gcov evaluation is dependent on the used compiler. Check gcov support for
 	# each compiler that is used. If gcov binary was already found for this
 	# compiler, do not try to find it again.
 	if (NOT GCOV_${CMAKE_${LANG}_COMPILER_ID}_BIN)

--- a/CMake/Findcodecov.cmake
+++ b/CMake/Findcodecov.cmake
@@ -74,7 +74,7 @@ set(CMAKE_REQUIRED_QUIET ${codecov_FIND_QUIETLY})
 
 get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
 foreach (LANG ${ENABLED_LANGUAGES})
-	# Coverage flags are not dependend on language, but the used compiler. So
+	# Coverage flags are not dependent on language, but the used compiler. So
 	# instead of searching flags foreach language, search flags foreach compiler
 	# used.
 	set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -27,7 +27,7 @@
 [Override output colouring](#override-output-colouring)<br>
 
 Catch works quite nicely without any command line options at all - but for those times when you want greater control the following options are available.
-Click one of the followings links to take you straight to that option - or scroll on to browse the available options.
+Click one of the following links to take you straight to that option - or scroll on to browse the available options.
 
 <a href="#specifying-which-tests-to-run">               `    <test-spec> ...`</a><br />
 <a href="#usage">                                       `    -h, -?, --help`</a><br />

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,7 +89,7 @@ them yourself, their signatures are:
 By default, when Catch's stringification machinery has to stringify
 a type that does not specialize `StringMaker`, does not overload `operator<<`,
 is not an enumeration and is not a range, it uses `"{?}"`. This can be
-overriden by defining `CATCH_CONFIG_FALLBACK_STRINGIFIER` to name of a
+overridden by defining `CATCH_CONFIG_FALLBACK_STRINGIFIER` to name of a
 function that should perform the stringification instead.
 
 All types that do not provide `StringMaker` specialization or `operator<<`

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -85,7 +85,7 @@ Second unscoped info
 
 ## Streaming macros
 
-All these macros allow heterogenous sequences of values to be streaming using the insertion operator (```<<```) in the same way that std::ostream, std::cout, etc support it.
+All these macros allow heterogeneous sequences of values to be streaming using the insertion operator (```<<```) in the same way that std::ostream, std::cout, etc support it.
 
 E.g.:
 ```c++

--- a/docs/other-macros.md
+++ b/docs/other-macros.md
@@ -30,7 +30,7 @@ CHECKED_IF( a == b ) {
 
 `CHECK_NOFAIL( expr )` is a variant of `CHECK` that does not fail the test
 case if _expr_ evaluates to `false`. This can be useful for checking some
-assumption, that might be violated without the test neccessarily failing.
+assumption, that might be violated without the test necessarily failing.
 
 Example output:
 ```
@@ -120,7 +120,7 @@ constructor, or before Catch2's session is created in user's own main._
 `ANON_TEST_CASE` is a `TEST_CASE` replacement that will autogenerate
 unique name. The advantage of this is that you do not have to think
 of a name for the test case,`the disadvantage is that the name doesn't
-neccessarily remain stable across different links, and thus it might be
+necessarily remain stable across different links, and thus it might be
 hard to run directly.
 
 Example:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -56,7 +56,7 @@
 * Running tests will no longer open the specified output file twice (#1545)
   * This would cause trouble when the file was not a file, but rather a named pipe
   * Fixes the CLion/Resharper integration with Catch
-* Fixed `-Wunreachable-code` occuring with (old) ccache+cmake+clang combination (#1540)
+* Fixed `-Wunreachable-code` occurring with (old) ccache+cmake+clang combination (#1540)
 * Fixed `-Wdefaulted-function-deleted` warning with Clang 8 (#1537)
 * Catch2's type traits and helpers are now properly namespaced inside `Catch::` (#1548)
 * Fixed std{out,err} redirection for failing test (#1514, #1525)
@@ -738,7 +738,7 @@ Cygwin issue with `gettimeofday` - `#define` was not early enough
   * Usage of `gettimeofday` inside Catch should no longer cause compilation errors.
 * Improved `-Wparentheses` suppression for gcc (#674)
   * When compiled with gcc 4.8 or newer, the suppression is localized to assertions only
-  * Otherwise it is supressed for the whole TU
+  * Otherwise it is suppressed for the whole TU
 * Fixed test spec parser issue (with escapes in multiple names)
 
 ##### Other
@@ -821,7 +821,7 @@ Other:
 
 ##### Other:
 * Types with overloaded `&&` operator are no longer evaluated twice when used in an assertion macro.
-* The use of `__COUNTER__` is supressed when Catch is parsed by CLion
+* The use of `__COUNTER__` is suppressed when Catch is parsed by CLion
   * This change is not active when compiling a binary
 * Approval tests can now be run on Windows
 * CMake will now warn if a file is present in the `include` folder but not is not enumerated as part of the project

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -32,7 +32,7 @@ Once a release is ready, release notes need to be written. They should summarize
 
 ### Commit and push update to GitHub
 
-After version number is incremented, single-include header is regenerated and release notes are updated, changes should be commited and pushed to GitHub.
+After version number is incremented, single-include header is regenerated and release notes are updated, changes should be committed and pushed to GitHub.
 
 
 ### Release on GitHub

--- a/include/internal/catch_matchers_generic.hpp
+++ b/include/internal/catch_matchers_generic.hpp
@@ -45,7 +45,7 @@ public:
 
     // The following functions create the actual matcher objects.
     // The user has to explicitly specify type to the function, because
-    // infering std::function<bool(T const&)> is hard (but possible) and
+    // inferring std::function<bool(T const&)> is hard (but possible) and
     // requires a lot of TMP.
     template<typename T>
     Generic::PredicateMatcher<T> Predicate(std::function<bool(T const&)> const& predicate, std::string const& description = "") {

--- a/include/internal/catch_output_redirect.cpp
+++ b/include/internal/catch_output_redirect.cpp
@@ -71,7 +71,7 @@ namespace Catch {
             if (strerror_s(buffer, errno)) {
                 CATCH_RUNTIME_ERROR("Could not translate errno to a string");
             }
-            CATCH_RUNTIME_ERROR("Coul dnot open the temp file: '" << m_buffer << "' because: " << buffer);
+            CATCH_RUNTIME_ERROR("Could not open the temp file: '" << m_buffer << "' because: " << buffer);
         }
     }
 #else

--- a/include/internal/catch_test_case_info.cpp
+++ b/include/internal/catch_test_case_info.cpp
@@ -43,7 +43,7 @@ namespace Catch {
         void enforceNotReservedTag( std::string const& tag, SourceLineInfo const& _lineInfo ) {
             CATCH_ENFORCE( !isReservedTag(tag),
                           "Tag name: [" << tag << "] is not allowed.\n"
-                          << "Tag names starting with non alpha-numeric characters are reserved\n"
+                          << "Tag names starting with non alphanumeric characters are reserved\n"
                           << _lineInfo );
         }
     }

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -323,9 +323,9 @@ Matchers.tests.cpp:<line number>: passed: testStringForMatching(), Equals("this 
 Matchers.tests.cpp:<line number>: passed: testStringForMatching(), Equals("this string contains 'ABC' as a substring", Catch::CaseSensitive::No) for: "this string contains 'abc' as a substring" equals: "this string contains 'abc' as a substring" (case insensitive)
 Matchers.tests.cpp:<line number>: failed: testStringForMatching(), Equals("this string contains 'ABC' as a substring") for: "this string contains 'abc' as a substring" equals: "this string contains 'ABC' as a substring"
 Matchers.tests.cpp:<line number>: failed: testStringForMatching(), Equals("something else", Catch::CaseSensitive::No) for: "this string contains 'abc' as a substring" equals: "something else" (case insensitive)
-ToStringGeneral.tests.cpp:<line number>: passed: ::Catch::Detail::stringify(WhatException{}) == "This exception has overriden what() method" for: "This exception has overriden what() method"
+ToStringGeneral.tests.cpp:<line number>: passed: ::Catch::Detail::stringify(WhatException{}) == "This exception has overridden what() method" for: "This exception has overridden what() method"
 ==
-"This exception has overriden what() method"
+"This exception has overridden what() method"
 ToStringGeneral.tests.cpp:<line number>: passed: ::Catch::Detail::stringify(OperatorException{}) == "OperatorException" for: "OperatorException" == "OperatorException"
 ToStringGeneral.tests.cpp:<line number>: passed: ::Catch::Detail::stringify(StringMakerException{}) == "StringMakerException" for: "StringMakerException"
 ==

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -2391,11 +2391,11 @@ ToStringGeneral.tests.cpp:<line number>
 ...............................................................................
 
 ToStringGeneral.tests.cpp:<line number>: PASSED:
-  REQUIRE( ::Catch::Detail::stringify(WhatException{}) == "This exception has overriden what() method" )
+  REQUIRE( ::Catch::Detail::stringify(WhatException{}) == "This exception has overridden what() method" )
 with expansion:
-  "This exception has overriden what() method"
+  "This exception has overridden what() method"
   ==
-  "This exception has overriden what() method"
+  "This exception has overridden what() method"
 
 ToStringGeneral.tests.cpp:<line number>: PASSED:
   REQUIRE( ::Catch::Detail::stringify(OperatorException{}) == "OperatorException" )

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -2888,12 +2888,12 @@ Nor would this
     <TestCase name="Exception as a value (e.g. in REQUIRE_THROWS_MATCHES) can be stringified" tags="[exception][toString]" filename="projects/<exe-name>/UsageTests/ToStringGeneral.tests.cpp" >
       <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/ToStringGeneral.tests.cpp" >
         <Original>
-          ::Catch::Detail::stringify(WhatException{}) == "This exception has overriden what() method"
+          ::Catch::Detail::stringify(WhatException{}) == "This exception has overridden what() method"
         </Original>
         <Expanded>
-          "This exception has overriden what() method"
+          "This exception has overridden what() method"
 ==
-"This exception has overriden what() method"
+"This exception has overridden what() method"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/ToStringGeneral.tests.cpp" >

--- a/projects/SelfTest/UsageTests/ToStringGeneral.tests.cpp
+++ b/projects/SelfTest/UsageTests/ToStringGeneral.tests.cpp
@@ -132,7 +132,7 @@ namespace {
 
 struct WhatException : std::exception {
     char const* what() const noexcept override {
-        return "This exception has overriden what() method";
+        return "This exception has overridden what() method";
     }
     ~WhatException() override;
 };
@@ -170,7 +170,7 @@ StringMakerException::~StringMakerException() = default;
 
 
 TEST_CASE("Exception as a value (e.g. in REQUIRE_THROWS_MATCHES) can be stringified", "[toString][exception]") {
-    REQUIRE(::Catch::Detail::stringify(WhatException{}) == "This exception has overriden what() method");
+    REQUIRE(::Catch::Detail::stringify(WhatException{}) == "This exception has overridden what() method");
     REQUIRE(::Catch::Detail::stringify(OperatorException{}) == "OperatorException");
     REQUIRE(::Catch::Detail::stringify(StringMakerException{}) == "StringMakerException");
 }

--- a/projects/XCode/OCTest/OCTest/CatchOCTestCase.mm
+++ b/projects/XCode/OCTest/OCTest/CatchOCTestCase.mm
@@ -70,7 +70,7 @@ OC_TEST_CASE( "Matches work with OC types (NSString so far)", "[!shouldfail]" )
 {
     using namespace Catch::Matchers;
 
-    REQUIRE_THAT( @"This is a string", Equals( @"This isnt a string" ) );
+    REQUIRE_THAT( @"This is a string", Equals( @"This isn't a string" ) );
     REQUIRE_THAT( @"This is a string", Contains( @"is a" ) );
     REQUIRE_THAT( @"This is a string", StartsWith( @"This" ) );
     REQUIRE_THAT( @"This is a string", EndsWith( @"string" ) );


### PR DESCRIPTION
## Description
Fixed typos identified by Codespell in source code as well as associated test data. Done because I run codespell in CI on a project that is starting to vendor Catch2, which pointed out the typos.

Builds and tests complete successfully on Debian Buster.