### PR TITLE
Allow 'make package' to create an installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,9 +205,7 @@ if (NOT_SUBPROJECT)
         ${PKGCONFIG_INSTALL_DIR}
     )
 
-    if(EXISTS "/etc/debian_version")
-        set(DEBIAN TRUE CACHE BOOL "Enable debian specific options: .deb generation")
-    endif()
+    set(DEBIAN FALSE CACHE BOOL "Enable debian specific options: .deb generation")
 
     set(CPACK_PACKAGE_NAME "catch2")
     set(CPACK_PACKAGE_CONTACT "https://discord.gg/4CWS9zD")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,4 +205,17 @@ if (NOT_SUBPROJECT)
         ${PKGCONFIG_INSTALL_DIR}
     )
 
+    if(EXISTS "/etc/debian_version")
+        set(DEBIAN TRUE CACHE BOOL "Enable debian specific options: .deb generation")
+    endif()
+
+    set(CPACK_PACKAGE_NAME "catch2")
+    set(CPACK_PACKAGE_CONTACT "https://discord.gg/4CWS9zD")
+    if(DEBIAN)
+        set( CPACK_SOURCE_GENERATOR "DEB" )
+        set( CPACK_GENERATOR "DEB" )
+    endif(DEBIAN)
+
+    include( CPack )
+
 endif(NOT_SUBPROJECT)


### PR DESCRIPTION
I'd like to be able to generate a .deb package from the latest source.
This allows me to both install and uninstall the package in a consistent way.

This change adds the CPack statements to allow 'make package' to generate a .deb on debian systems.
