### PR TITLE
CatchAddTests now adds tags as labels for ctest

### DIFF
--- a/contrib/CatchAddTests.cmake
+++ b/contrib/CatchAddTests.cmake
@@ -22,6 +22,39 @@ function(add_command NAME)
   set(script "${script}${NAME}(${_args})\n" PARENT_SCOPE)
 endfunction()
 
+macro(_add_catch_test_labels LINE)
+  # convert to list of tags
+  string(REPLACE "][" "]\\;[" tags ${line})
+
+  add_command(
+    set_tests_properties "${prefix}${test}${suffix}"
+      PROPERTIES
+        LABELS "${tags}"
+  )
+endmacro()
+
+macro(_add_catch_test LINE)
+  set(test ${line})
+  # use escape commas to handle properly test cases with commans inside the name
+  string(REPLACE "," "\\," test_name ${test})
+  # ...and add to script
+  add_command(
+    add_test "${prefix}${test}${suffix}"
+      ${TEST_EXECUTOR}
+       "${TEST_EXECUTABLE}"
+       "${test_name}"
+       ${extra_args}
+     )
+
+  add_command(
+    set_tests_properties "${prefix}${test}${suffix}"
+      PROPERTIES
+        WORKING_DIRECTORY "${TEST_WORKING_DIR}"
+        ${properties}
+  )
+  list(APPEND tests "${prefix}${test}${suffix}")
+endmacro()
+
 # Run test executable to get list of available tests
 if(NOT EXISTS "${TEST_EXECUTABLE}")
   message(FATAL_ERROR
@@ -29,7 +62,7 @@ if(NOT EXISTS "${TEST_EXECUTABLE}")
   )
 endif()
 execute_process(
-  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-test-names-only
+  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-tests
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
 )
@@ -47,27 +80,22 @@ elseif(${result} LESS 0)
 endif()
 
 string(REPLACE "\n" ";" output "${output}")
+set(test)
+set(tags_regex "(\\[([^\\[]*)\\])+$")
 
 # Parse output
 foreach(line ${output})
-  set(test ${line})
-  # use escape commas to handle properly test cases with commans inside the name
-  string(REPLACE "," "\\," test_name ${test})
-  # ...and add to script
-  add_command(add_test
-    "${prefix}${test}${suffix}"
-    ${TEST_EXECUTOR}
-    "${TEST_EXECUTABLE}"
-    "${test_name}"
-    ${extra_args}
-  )
-  add_command(set_tests_properties
-    "${prefix}${test}${suffix}"
-    PROPERTIES
-    WORKING_DIRECTORY "${TEST_WORKING_DIR}"
-    ${properties}
-  )
-  list(APPEND tests "${prefix}${test}${suffix}")
+  # lines without leading whitespaces are catch output not tests
+  if(${line} MATCHES "^[ \t]+")
+    # strip leading spaces and tabs
+    string(REGEX REPLACE "^[ \t]+" "" line ${line})
+
+    if(${line} MATCHES "${tags_regex}")
+      _add_catch_test_labels(${line})
+    else()
+      _add_catch_test(${line})
+    endif()
+  endif()
 endforeach()
 
 # Create a list of all discovered tests, which users may use to e.g. set


### PR DESCRIPTION
- `ctest --print-labels` now will show list of available labels
- `ctest -L <regex>` will allow to run tests with given labels(tags)

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
Having an executable with given list of tests:
```
> exercises/ut/exercisesTests --list-tests
All available test cases:
  Life, the universe and everything
  Having fun with lambdas
      [cpp11][lambdas]
  Delegating constructors
      [constructor][cpp11][delegation]
  User-defined literals functionality
  Class modifications introduces in C++11
      [cpp11][default][delete][final][override]
5 test cases
```
`catch_discover_tests` now discovers correctly:
```
ctest -N
Test project /home/mpatro/projects/clion/self_learn_repo/cmake-build-debug
  Test #1: Life, the universe and everything
  Test #2: Having fun with lambdas
  Test #3: Delegating constructors
  Test #4: User-defined literals functionality
  Test #5: Class modifications introduces in C++11

Total Tests: 5
```
also adding tags as labels and enabling running labels
```
> ctest -L lambdas --verbose
...
test 2
    Start 2: Having fun with lambdas

2: Test command: /home/mpatro/projects/clion/self_learn_repo/cmake-build-debug/exercises/ut/exercisesTests "Having fun with lambdas"
2: Test timeout computed to be: 10000000
2: ===============================================================================
2: All tests passed (11 assertions in 1 test case)
2: 
1/1 Test #2: Having fun with lambdas ..........   Passed    0.01 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
[cpp11]      =   0.01 sec*proc (1 test)
[lambdas]    =   0.01 sec*proc (1 test)

Total Test time (real) =   0.03 sec
```
## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
#1590 