### PR TITLE
ParseAndAddCatchTests: Ignore cmake object libraries

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -88,6 +88,11 @@ endfunction()
 
 # Worker function
 function(ParseAndAddCatchTests_ParseFile SourceFile TestTarget)
+    # If SourceFile is an object library, do not scan it (as it is not a file). Exit without giving a warning about a missing file.
+    if(SourceFile MATCHES "\\\$<TARGET_OBJECTS:.+>")
+        ParseAndAddCatchTests_PrintDebugMessage("Detected OBJECT library: ${SourceFile} this will not be scanned for tests.")
+        return()
+    endif()
     # According to CMake docs EXISTS behavior is well-defined only for full paths.
     get_filename_component(SourceFile ${SourceFile} ABSOLUTE)
     if(NOT EXISTS ${SourceFile})


### PR DESCRIPTION
## Description
This PR will make the ParseAndAddCatchTests function ignore any "files" that match `\$<TARGET_OBJECTS:.+>`, so when you use cmake object libraries the script will not try to parse that "file" for the Catch2 TEST_CASE macros.

I am putting file in quotes here because in the case of object libraries this is clearly a cmake variable and not a file.

### Why
I am using a cmake object library to compile the sources of my target binary and re-use them in my Catch2 unittests without recompiling them.

```
add_executable(mytest $<TARGET_OBJECTS:myobj> test_main.cc test1.cc test2.cc)
target_link_libraries(mytest Catch2::Catch2)

include(CTest)
include(ParseAndAddCatchTests)
ParseAndAddCatchTests(mytest)
```
This will give the following warnings (PARSE_CATCH_TESTS_VERBOSE is set during cmake configuration)
```
-- ParseAndAddCatchTests: Started parsing mytest
-- ParseAndAddCatchTests: Found the following sources: $<TARGET_OBJECTS:myobjobj>;test_main.cc;test_1.cc;test_2.cc
CMake Warning at /usr/local/lib64/cmake/Catch2/ParseAndAddCatchTests.cmake:98 (message):
  Cannot find source file:
  /home/v1tzl1/myproj/tests/$<TARGET_OBJECTS:myobj>
Call Stack (most recent call first):
  /usr/local/lib64/cmake/Catch2/ParseAndAddCatchTests.cmake:221 (ParseAndAddCatchTests_ParseFile)
  tests/CMakeLists.txt:18 (ParseAndAddCatchTests)
-- ParseAndAddCatchTests: parsing /home/v1tzl1/myproj/tests/test_main.cc
-- ParseAndAddCatchTests: parsing /home/v1tzl1/myproj/tests/test_1.cc
-- ParseAndAddCatchTests: Adding test "mytest:Test 1"
-- ParseAndAddCatchTests: parsing /home/v1tzl1/myproj/tests/test_2.cc
-- ParseAndAddCatchTests: Adding test "mytest:Test 2"
-- ParseAndAddCatchTests: Setting labels to mytest
-- ParseAndAddCatchTests: Finished parsing mytest
```
While the parser will keep working and finding all my tests, I don't want to have warnings in my cmake runs. With the proposed change the output will look like this:
```
-- ParseAndAddCatchTests: Started parsing mytest
-- ParseAndAddCatchTests: Found the following sources: $<TARGET_OBJECTS:myobjobj>;test_main.cc;test_1.cc;test_2.cc
-- ParseAndAddCatchTests: Detected OBJECT library: $<TARGET_OBJECTS:myobj> this will not be scanned for tests.
-- ParseAndAddCatchTests: parsing /home/v1tzl1/myproj/tests/test_main.cc
-- ParseAndAddCatchTests: parsing /home/v1tzl1/myproj/tests/test_1.cc
-- ParseAndAddCatchTests: Adding test "mytest:Test 1"
-- ParseAndAddCatchTests: parsing /home/v1tzl1/myproj/tests/test_2.cc
-- ParseAndAddCatchTests: Adding test "mytest:Test 2"
-- ParseAndAddCatchTests: Setting labels to mytest
-- ParseAndAddCatchTests: Finished parsing mytest
```
Note that this does not change the behaviour of Catch2. Before it ignored the "file" because it could not find it on the file system, now it skips all files that look like object library variables before checking that the remaining files are actually there. There is also an output to `ParseAndAddCatchTests_PrintDebugMessage` so the behaviour can be traced if there ever is a problem with this.

### Possible side effects
With this change, any tests defined in a file which's name matches `\$<TARGET_OBJECTS:.+>` will no longer be detected.

I have tested these changes locally with cmake 3.9.6 on Linux, but since the change is minimal there should not be much issues with other systems. For the sake of completeness I also ran the tests described in /docs/contributing.md which all passed.

Edit: removed some double copy lines from the output and fixed some typos.