### PR TITLE
Add standard deviation to benchmarking

### DIFF
--- a/include/internal/catch_benchmark.cpp
+++ b/include/internal/catch_benchmark.cpp
@@ -55,7 +55,7 @@ namespace Catch {
         double sigma = 0.0;
         for (auto v: m_timeStamps)
             sigma += (v - mean) * (v - mean);
-        sigma = sqrt(sigma / (double)(m_timeStamps.size() - 1));
+        sigma = std::sqrt(sigma / (double)(m_timeStamps.size() - 1));
 
         getResultCapture().benchmarkEnded( { { m_name }, m_count, elapsed, (uint64_t)sigma } );
     }

--- a/include/internal/catch_benchmark.cpp
+++ b/include/internal/catch_benchmark.cpp
@@ -39,7 +39,7 @@ namespace Catch {
         stddev /= totalIterations;
         stddev = std::sqrt(stddev);
 
-        getResultCapture().benchmarkEnded({ { m_name, m_minSamples }, totalIterations, m_timeStamps.size(), totalNs, static_cast<uint64_t>(stddev) });
+        getResultCapture().benchmarkEnded({ { m_name, m_minSamples }, static_cast<size_t>( totalIterations ), m_timeStamps.size(), totalNs, static_cast<uint64_t>(stddev) });
     }
 
 } // end namespace Catch

--- a/include/internal/catch_benchmark.cpp
+++ b/include/internal/catch_benchmark.cpp
@@ -10,6 +10,7 @@
 #include "catch_capture.hpp"
 #include "catch_interfaces_reporter.h"
 #include "catch_context.h"
+#include <cmath>
 
 namespace Catch {
 

--- a/include/internal/catch_benchmark.h
+++ b/include/internal/catch_benchmark.h
@@ -27,7 +27,6 @@ namespace Catch {
         std::string m_name;
         std::size_t m_count = 0;
         std::size_t m_iterationsToRun = 1;
-        std::size_t m_samples = 0;
         std::size_t m_minSamples;
         uint64_t m_resolution;
         std::vector<MeasurementRecord> m_timeStamps;

--- a/include/internal/catch_benchmark.h
+++ b/include/internal/catch_benchmark.h
@@ -31,8 +31,8 @@ namespace Catch {
         // Keep most of this inline as it's on the code path that is being timed
         BenchmarkLooper( StringRef name, size_t minSamples = 10 )
         :   m_name( name ),
-            m_resolution( getResolution() ),
-            m_minSamples( minSamples )
+            m_minSamples(minSamples),
+            m_resolution( getResolution() )
         {
             reportStart();
             m_timer.start();

--- a/include/internal/catch_benchmark.h
+++ b/include/internal/catch_benchmark.h
@@ -22,15 +22,17 @@ namespace Catch {
         std::string m_name;
         std::size_t m_count = 0;
         std::size_t m_iterationsToRun = 1;
+        std::size_t m_minSamples;
         uint64_t m_resolution;
         Timer m_timer;
 
         static auto getResolution() -> uint64_t;
     public:
         // Keep most of this inline as it's on the code path that is being timed
-        BenchmarkLooper( StringRef name )
+        BenchmarkLooper( StringRef name, size_t minSamples = 10 )
         :   m_name( name ),
-            m_resolution( getResolution() )
+            m_resolution( getResolution() ),
+            m_minSamples( minSamples )
         {
             reportStart();
             m_timer.start();
@@ -93,9 +95,7 @@ namespace Catch {
 
 } // end namespace Catch
 
-#define BENCHMARK( name ) \
-    for( Catch::BenchmarkLooper looper( name ); looper; looper.increment() )
-#define BENCHMARK_DEVIATION( name, timeStampsToSample ) \
-    for( Catch::BenchmarkDeviationLooper looper( name, timeStampsToSample ); looper; looper.increment() )
+#define BENCHMARK( ... ) \
+    for( Catch::BenchmarkLooper looper( __VA_ARGS__ ); looper; looper.increment() )
 
 #endif // TWOBLUECUBES_CATCH_BENCHMARK_H_INCLUDED

--- a/include/internal/catch_benchmark.h
+++ b/include/internal/catch_benchmark.h
@@ -24,15 +24,13 @@ namespace Catch {
         std::size_t m_iterationsToRun = 1;
         uint64_t m_resolution;
         Timer m_timer;
-        std::vector<uint64_t> timeStamps;
 
         static auto getResolution() -> uint64_t;
     public:
         // Keep most of this inline as it's on the code path that is being timed
-        BenchmarkLooper( StringRef name, size_t timeStampsToSample = 1 )
+        BenchmarkLooper( StringRef name )
         :   m_name( name ),
-            m_resolution( getResolution() ),
-            timeStamps( timeStampsToSample )
+            m_resolution( getResolution() )
         {
             reportStart();
             m_timer.start();

--- a/include/internal/catch_interfaces_reporter.h
+++ b/include/internal/catch_interfaces_reporter.h
@@ -166,6 +166,7 @@ namespace Catch {
         BenchmarkInfo info;
         std::size_t iterations;
         uint64_t elapsedTimeInNanoseconds;
+        uint64_t sigmaInNanoseconds;
     };
 
     struct IStreamingReporter {

--- a/include/internal/catch_interfaces_reporter.h
+++ b/include/internal/catch_interfaces_reporter.h
@@ -161,10 +161,12 @@ namespace Catch {
 
     struct BenchmarkInfo {
         std::string name;
+        std::size_t samples;
     };
     struct BenchmarkStats {
         BenchmarkInfo info;
         std::size_t iterations;
+        std::size_t samples;
         uint64_t elapsedTimeInNanoseconds;
         uint64_t sigmaInNanoseconds;
     };

--- a/include/reporters/catch_reporter_console.cpp
+++ b/include/reporters/catch_reporter_console.cpp
@@ -339,10 +339,12 @@ ConsoleReporter::ConsoleReporter(ReporterConfig const& config)
     : StreamingReporterBase(config),
     m_tablePrinter(new TablePrinter(config.stream(),
     {
-        { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 32, ColumnInfo::Left },
+        { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left },
         { "iters", 8, ColumnInfo::Right },
         { "elapsed ns", 14, ColumnInfo::Right },
-        { "average", 14, ColumnInfo::Right }
+        { "average", 14, ColumnInfo::Right },
+        { "sigma", 12, ColumnInfo::Right }
+
     })) {}
 ConsoleReporter::~ConsoleReporter() = default;
 
@@ -406,7 +408,7 @@ void ConsoleReporter::benchmarkStarting(BenchmarkInfo const& info) {
     bool firstLine = true;
     for (auto line : nameCol) {
         if (!firstLine)
-            (*m_tablePrinter) << ColumnBreak() << ColumnBreak() << ColumnBreak();
+            (*m_tablePrinter) << ColumnBreak() << ColumnBreak() << ColumnBreak() << ColumnBreak();
         else
             firstLine = false;
 
@@ -415,10 +417,12 @@ void ConsoleReporter::benchmarkStarting(BenchmarkInfo const& info) {
 }
 void ConsoleReporter::benchmarkEnded(BenchmarkStats const& stats) {
     Duration average(stats.elapsedTimeInNanoseconds / stats.iterations);
+    Duration sigma(stats.sigmaInNanoseconds);
     (*m_tablePrinter)
         << stats.iterations << ColumnBreak()
         << stats.elapsedTimeInNanoseconds << ColumnBreak()
-        << average << ColumnBreak();
+        << average << ColumnBreak()
+        << sigma << ColumnBreak();
 }
 
 void ConsoleReporter::testCaseEnded(TestCaseStats const& _testCaseStats) {

--- a/projects/SelfTest/UsageTests/Benchmark.tests.cpp
+++ b/projects/SelfTest/UsageTests/Benchmark.tests.cpp
@@ -16,7 +16,7 @@ TEST_CASE( "benchmarked", "[!benchmark]" ) {
     }
     REQUIRE( v.size() == size );
 
-    BENCHMARK( "Load up a map" ) {
+    BENCHMARK_DEVIATION( "Load up a map", 256 ) {
         m = std::map<int, int>();
         for(int i =0; i < size; ++i )
             m.insert( { i, i+1 } );

--- a/projects/SelfTest/UsageTests/Benchmark.tests.cpp
+++ b/projects/SelfTest/UsageTests/Benchmark.tests.cpp
@@ -8,7 +8,7 @@ TEST_CASE( "benchmarked", "[!benchmark]" ) {
 
     std::vector<int> v;
     std::map<int, int> m;
-
+    // Plain benchmarking will take a preset number of measurements
     BENCHMARK( "Load up a vector" ) {
         v = std::vector<int>();
         for(int i =0; i < size; ++i )
@@ -16,14 +16,14 @@ TEST_CASE( "benchmarked", "[!benchmark]" ) {
     }
     REQUIRE( v.size() == size );
 
-    BENCHMARK_DEVIATION( "Load up a map", 256 ) {
+    BENCHMARK( "Load up a map") {
         m = std::map<int, int>();
         for(int i =0; i < size; ++i )
             m.insert( { i, i+1 } );
     }
     REQUIRE( m.size() == size );
-
-    BENCHMARK( "Reserved vector" ) {
+    // You can also manually provide the number of measurements you want to take
+    BENCHMARK( "Reserved vector", 256 ) {
         v = std::vector<int>();
         v.reserve(size);
         for(int i =0; i < size; ++i )

--- a/projects/SelfTest/UsageTests/Benchmark.tests.cpp
+++ b/projects/SelfTest/UsageTests/Benchmark.tests.cpp
@@ -9,7 +9,7 @@ TEST_CASE( "benchmarked", "[!benchmark]" ) {
     std::vector<int> v;
     std::map<int, int> m;
     // Plain benchmarking will take a preset number of measurements
-    BENCHMARK( "Load up a vector" ) {
+    BENCHMARK( "Load up a vector", 256 ) {
         v = std::vector<int>();
         for(int i =0; i < size; ++i )
             v.push_back( i );


### PR DESCRIPTION
## Description
This PR adds standard deviation calculation to benchmark feature.
Deviation is useful when benchmarking OS dependent things: for example how long it takes to create a thread. Normal benchmark will only return a mean value like 100 us, but deviation will return a sigma, for example 20 us. Via [68–95–99.7 rule](https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule) we can conclude that 95% of threads creations will be completed in [100 - 2 * 20, 100 + 2 * 20] = [60, 140] us.

Please let me know how can I improve it :)