### PR TITLE
TrackerContext: Remove misleading instance static method.

### DIFF
--- a/include/internal/catch_test_case_tracker.cpp
+++ b/include/internal/catch_test_case_tracker.cpp
@@ -32,11 +32,6 @@ namespace TestCaseTracking {
     ITracker::~ITracker() = default;
 
 
-    TrackerContext& TrackerContext::instance() {
-        static TrackerContext s_instance;
-        return s_instance;
-    }
-
     ITracker& TrackerContext::startRun() {
         m_rootTracker = std::make_shared<SectionTracker>( NameAndLocation( "{root}", CATCH_INTERNAL_LINEINFO ), *this, nullptr );
         m_currentTracker = nullptr;

--- a/include/internal/catch_test_case_tracker.h
+++ b/include/internal/catch_test_case_tracker.h
@@ -71,8 +71,6 @@ namespace TestCaseTracking {
 
     public:
 
-        static TrackerContext& instance();
-
         ITracker& startRun();
         void endRun();
 

--- a/projects/SelfTest/IntrospectiveTests/PartTracker.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/PartTracker.tests.cpp
@@ -8,21 +8,6 @@
 #include "internal/catch_suppress_warnings.h"
 #include "internal/catch_test_case_tracker.h"
 
-
-namespace Catch
-{
-    class LocalContext {
-
-    public:
-        TrackerContext& operator()() const {
-            return TrackerContext::instance();
-        }
-    };
-
-} // namespace Catch
-
-// -------------------
-
 #include "catch.hpp"
 
 using namespace Catch;


### PR DESCRIPTION
TrackerContext is not used as singleton, so just remove this misleading method.

While working on an prove of concept for something in catch, I was confused by this no longer needed method leading me to think that TrackerContext was a singleton. But it's not.