### PR TITLE
Remove semicolon causing GCC to complain

### DIFF
--- a/projects/SelfTest/UsageTests/EnumToString.tests.cpp
+++ b/projects/SelfTest/UsageTests/EnumToString.tests.cpp
@@ -90,7 +90,7 @@ namespace Bikeshed {
 CATCH_REGISTER_ENUM( Bikeshed::Colours,
                      Bikeshed::Colours::Red,
                      Bikeshed::Colours::Green,
-                     Bikeshed::Colours::Blue );
+                     Bikeshed::Colours::Blue )
 
 TEST_CASE( "Enums in namespaces can quickly have stringification enabled using REGISTER_ENUM" ) {
     using Catch::Detail::stringify;


### PR DESCRIPTION
Travis fails on master because of this.

Fixes #1613.
