### PR TITLE
Listener docs: overrides should call base class functions

### DIFF
--- a/docs/event-listeners.md
+++ b/docs/event-listeners.md
@@ -30,10 +30,12 @@ struct MyListener : Catch::TestEventListenerBase {
     using TestEventListenerBase::TestEventListenerBase; // inherit constructor
 
     void testCaseStarting( Catch::TestCaseInfo const& testInfo ) override {
+        TestEventListenerBase::testCaseStarting( testInfo );
         // Perform some setup before a test case is run
     }
     
     void testCaseEnded( Catch::TestCaseStats const& testCaseStats ) override {
+        TestEventListenerBase::testCaseEnded( testCaseStats );
         // Tear-down after a test case is run
     }
 };


### PR DESCRIPTION
## Description
Documentation change only.

Overrides in event listeners should call the base class versions of the functions.  Failing to do so can result in strange errors.

Emphasize this by including such calls in the example code.