### PR TITLE
Fixed a bug where the application would die due to a null-ptr of platformColourInstance

### DIFF
--- a/include/internal/catch_console_colour.cpp
+++ b/include/internal/catch_console_colour.cpp
@@ -222,7 +222,13 @@ namespace Catch {
 
     void Colour::use( Code _colourCode ) {
         static IColourImpl* impl = platformColourInstance();
-        impl->use( _colourCode );
+        // Strictly speaking, this cannot possibly happen.
+        // However, under some conditions it does happen (see #1626),
+        // and this change is small enough that we can let practicality
+        // triumph over purity in this case.
+        if (impl != NULL) {
+            impl->use( _colourCode );
+        }
     }
 
     std::ostream& operator << ( std::ostream& os, Colour const& ) {


### PR DESCRIPTION
## Description
On different windows virtual machines test executables with Catch2 would crash with a segmentation fault.
The reason is that the `platfomColourInstance()` in `Colour::use()` would return a null-ptr. This will not be checked and thus a c000000005 will happen.
I created this simple PR to check for the null-ptr and avoid calling `impl->use( _colourCode );`
The result is that the tests won't crash anymore, but the downside is that the console output is not coloured anymore. So it is just a workaround.

## GitHub Issues
Probably related: #1626 