### PR TITLE
Fix catch_discover_tests() from breaking on long test names

### DIFF
--- a/contrib/CatchAddTests.cmake
+++ b/contrib/CatchAddTests.cmake
@@ -22,39 +22,6 @@ function(add_command NAME)
   set(script "${script}${NAME}(${_args})\n" PARENT_SCOPE)
 endfunction()
 
-macro(_add_catch_test_labels LINE)
-  # convert to list of tags
-  string(REPLACE "][" "]\\;[" tags ${line})
-
-  add_command(
-    set_tests_properties "${prefix}${test}${suffix}"
-      PROPERTIES
-        LABELS "${tags}"
-  )
-endmacro()
-
-macro(_add_catch_test LINE)
-  set(test ${line})
-  # use escape commas to handle properly test cases with commans inside the name
-  string(REPLACE "," "\\," test_name ${test})
-  # ...and add to script
-  add_command(
-    add_test "${prefix}${test}${suffix}"
-      ${TEST_EXECUTOR}
-       "${TEST_EXECUTABLE}"
-       "${test_name}"
-       ${extra_args}
-     )
-
-  add_command(
-    set_tests_properties "${prefix}${test}${suffix}"
-      PROPERTIES
-        WORKING_DIRECTORY "${TEST_WORKING_DIR}"
-        ${properties}
-  )
-  list(APPEND tests "${prefix}${test}${suffix}")
-endmacro()
-
 # Run test executable to get list of available tests
 if(NOT EXISTS "${TEST_EXECUTABLE}")
   message(FATAL_ERROR
@@ -62,7 +29,7 @@ if(NOT EXISTS "${TEST_EXECUTABLE}")
   )
 endif()
 execute_process(
-  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-tests
+  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-test-names-only
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
 )
@@ -80,22 +47,27 @@ elseif(${result} LESS 0)
 endif()
 
 string(REPLACE "\n" ";" output "${output}")
-set(test)
-set(tags_regex "(\\[([^\\[]*)\\])+$")
 
 # Parse output
 foreach(line ${output})
-  # lines without leading whitespaces are catch output not tests
-  if(${line} MATCHES "^[ \t]+")
-    # strip leading spaces and tabs
-    string(REGEX REPLACE "^[ \t]+" "" line ${line})
-
-    if(${line} MATCHES "${tags_regex}")
-      _add_catch_test_labels(${line})
-    else()
-      _add_catch_test(${line})
-    endif()
-  endif()
+  set(test ${line})
+  # use escape commas to handle properly test cases with commans inside the name
+  string(REPLACE "," "\\," test_name ${test})
+  # ...and add to script
+  add_command(add_test
+    "${prefix}${test}${suffix}"
+    ${TEST_EXECUTOR}
+    "${TEST_EXECUTABLE}"
+    "${test_name}"
+    ${extra_args}
+  )
+  add_command(set_tests_properties
+    "${prefix}${test}${suffix}"
+    PROPERTIES
+    WORKING_DIRECTORY "${TEST_WORKING_DIR}"
+    ${properties}
+  )
+  list(APPEND tests "${prefix}${test}${suffix}")
 endforeach()
 
 # Create a list of all discovered tests, which users may use to e.g. set


### PR DESCRIPTION
Fixes #1645 by rolling back d4eec016a9df54a560d82e5ee12aef42822525e7 ; reopens #1590 .

Parsing `--list-tests` is broken, as Catch automatically line wraps the line when it gets too long, stripping any whitespace in the process. This means that it's impossible to reproduce the exact name of the
test if the test's name is long enough to line-wrap.

Furthermore, overwriting the `LABELS` property with the discovered labels breaks users who manually added custom ctest labels. However, this seems to not actually overwrite the labels due to buggy handling of our strange test names by CMake.

Rolling back to using `--list-test-names-only` for now, as it does not wrap lines even on very long test names.

We may be able parse the output of `--list-tags` to produce the ctest labels. However, the straightforward way of doing this is to use CMake's `get_property(TEST ...)` and `set_property(TEST ... APPEND ...)`, which don't work if the test name has spaces or other special characters. Such test names may be illegal test names anyway&mdash;the [documentation](https://cmake.org/cmake/help/latest/command/add_test.html) doesn't state whether it's allowed or disallowed for the variant of `add_test(...)` we are using&mdash;although they appear to work.

Upstream CMake issue on allowing custom strings as test names, or at least custom test descriptions: https://gitlab.kitware.com/cmake/cmake/issues/19391
