### PR TITLE
Update Contents in docs #1667

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -21,8 +21,8 @@
 [Identify framework and version according to the libIdentify standard](#identify-framework-and-version-according-to-the-libidentify-standard)<br>
 [Wait for key before continuing](#wait-for-key-before-continuing)<br>
 [Specify the number of benchmark samples to collect](#specify-the-number-of-benchmark-samples-to-collect)<br>
-[Specify the number of benchmark resamples for bootstrapping](#specify-the-number-of-resamples-for-bootstrapping)<br>
-[Specify the confidence interval for bootstrapping](#specify-the-confidence-interval-for-bootstrapping)<br>
+[Specify the number of resamples for bootstrapping](#specify-the-number-of-resamples-for-bootstrapping)<br>
+[Specify the confidence-interval for bootstrapping](#specify-the-confidence-interval-for-bootstrapping)<br>
 [Disable statistical analysis of collected benchmark samples](#disable-statistical-analysis-of-collected-benchmark-samples)<br>
 [Usage](#usage)<br>
 [Specify the section to run](#specify-the-section-to-run)<br>

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,12 @@
 <a id="top"></a>
 # Contributing to Catch
 
+**Contents**<br>
+[Branches](#branches)<br>
+[Directory structure](#directory-structure)<br>
+[Testing your changes](#testing-your-changes)<br>
+[Code constructs to watch out for](#code-constructs-to-watch-out-for)<br>
+
 So you want to contribute something to Catch? That's great! Whether it's a bug fix, a new feature, support for
 additional compilers - or just a fix to the documentation - all contributions are very welcome and very much appreciated.
 Of course so are bug reports and other comments and questions.


### PR DESCRIPTION
## Description

I ran `updateDocumentToC.py` to update the Contents lists.

Only two files changed:

* docs\command-line.md: updated the names of two sections in the Contents
* docs\contributing.md: this added a missing Contents list, but did not create the `<a id="..."></a>` lines

Can I check I understand? Does the ToC script require a human to also manually add or update the `<a id="..."></a>` lines - or do they not matter, when viewing via the github website?

## GitHub Issues

This is just me seeing how the script to update the Contents lists works, and making sure I can submit PRs from my fork - before working on #1667
