### PR TITLE
Add `std::byte` support

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -202,6 +202,14 @@
 #endif // __has_include
 
 ////////////////////////////////////////////////////////////////////////////////
+// Check if byte is available and usable
+#if defined(__has_include)
+#  if __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
+#    define CATCH_INTERNAL_CONFIG_CPP17_BYTE
+#  endif // __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
+#endif // __has_include
+
+////////////////////////////////////////////////////////////////////////////////
 // Check if variant is available and usable
 #if defined(__has_include)
 #  if __has_include(<variant>) && defined(CATCH_CPP17_OR_GREATER)
@@ -255,6 +263,11 @@
 #if defined(CATCH_INTERNAL_CONFIG_CPP17_VARIANT) && !defined(CATCH_CONFIG_NO_CPP17_VARIANT) && !defined(CATCH_CONFIG_CPP17_VARIANT)
 #  define CATCH_CONFIG_CPP17_VARIANT
 #endif
+
+#if defined(CATCH_INTERNAL_CONFIG_CPP17_BYTE) && !defined(CATCH_CONFIG_NO_CPP17_BYTE) && !defined(CATCH_CONFIG_CPP17_BYTE)
+#  define CATCH_CONFIG_CPP17_BYTE
+#endif
+
 
 #if defined(CATCH_CONFIG_EXPERIMENTAL_REDIRECT)
 #  define CATCH_INTERNAL_CONFIG_NEW_CAPTURE

--- a/include/internal/catch_tostring.cpp
+++ b/include/internal/catch_tostring.cpp
@@ -170,6 +170,12 @@ std::string StringMaker<wchar_t *>::convert(wchar_t * str) {
 }
 #endif
 
+#if defined(CATCH_CONFIG_CPP17_BYTE)
+#include <cstddef>
+std::string StringMaker<std::byte>::convert(std::byte value) {
+    return ::Catch::Detail::stringify(std::to_integer<unsigned long long>(value));
+}
+#endif // defined(CATCH_CONFIG_CPP17_BYTE)
 
 std::string StringMaker<int>::convert(int value) {
     return ::Catch::Detail::stringify(static_cast<long long>(value));

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -211,7 +211,6 @@ namespace Catch {
     };
 
 #if defined(CATCH_CONFIG_CPP17_BYTE)
-#include <cstddef>
     template<>
     struct StringMaker<std::byte> {
         static std::string convert(std::byte value);

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -210,6 +210,13 @@ namespace Catch {
         }
     };
 
+#if defined(CATCH_CONFIG_CPP17_BYTE)
+#include <cstddef>
+    template<>
+    struct StringMaker<std::byte> {
+        static std::string convert(std::byte value);
+    };
+#endif // defined(CATCH_CONFIG_CPP17_BYTE)
     template<>
     struct StringMaker<int> {
         static std::string convert(int value);

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_SOURCES
         ${SELF_TEST_DIR}/UsageTests/Generators.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/Message.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/Misc.tests.cpp
+        ${SELF_TEST_DIR}/UsageTests/ToStringByte.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/ToStringChrono.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/ToStringGeneral.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/ToStringOptional.tests.cpp

--- a/projects/SelfTest/UsageTests/ToStringByte.tests.cpp
+++ b/projects/SelfTest/UsageTests/ToStringByte.tests.cpp
@@ -1,0 +1,15 @@
+#include "catch.hpp"
+
+#if defined(CATCH_CONFIG_CPP17_BYTE)
+
+TEST_CASE( "std::byte -> toString", "[toString][byte][approvals]" ) {
+    using type = std::byte;
+    REQUIRE( "0" == ::Catch::Detail::stringify( type{ 0 } ) );
+}
+
+TEST_CASE( "std::vector<std::byte> -> toString", "[toString][byte][approvals]" ) {
+    using type = std::vector<std::byte>;
+    REQUIRE( "{ 0, 1, 2 }" == ::Catch::Detail::stringify( type{ std::byte{0}, std::byte{1}, std::byte{2} } ) );
+}
+
+#endif // CATCH_INTERNAL_CONFIG_CPP17_BYTE


### PR DESCRIPTION
## Description
This addresses issue #1685, adding a `std::byte` specialisation for `Catch::Detail::StringMaker`, which makes `std::byte` print as an integer rather than as a character.

This has three parts:

1. **Add byte detection in Catch config**
    Following the pattern used for `std::optional`, look for the include file `cstddef` and the macro `CATCH_CPP17_OR_GREATER`. This defines `CATCH_INTERNAL_CONFIG_CPP17_BYTE`, which may then cause `CATCH_CONFIG_CPP17_BYTE` to be defined.

2. **Add a `std::byte`specialisation for Catch2::Detail::StringMaker**
    Added a declaration (gated by `CATCH_CONFIG_CPP17_BYTE`) of `struct StringMaker<std::byte>` in `catch_tostring.h`, and a definition in `catch_tostring.cpp`.

3. **Added a self-test (only compiled & executed for c++17)**
    Added new file `projects/SelfTest/UsageTests/ToStringByte.tests.cpp` and added it to the relevant place in `projects/CMakeLists.txt`
