### PR TITLE
Fix CTest command issue with square brackets

### DIFF
--- a/contrib/CatchAddTests.cmake
+++ b/contrib/CatchAddTests.cmake
@@ -51,8 +51,11 @@ string(REPLACE "\n" ";" output "${output}")
 # Parse output
 foreach(line ${output})
   set(test ${line})
-  # use escape commas to handle properly test cases with commans inside the name
-  string(REPLACE "," "\\," test_name ${test})
+  # Escape characters in test case names that would be parsed by Catch2
+  set(test_name ${test})
+  foreach(char , [ ])
+    string(REPLACE ${char} "\\${char}" test_name ${test_name})
+  endforeach(char)
   # ...and add to script
   add_command(add_test
     "${prefix}${test}${suffix}"


### PR DESCRIPTION
## Description
The issue was that square brackets are in principle legal in the name of a test case, but CatchAddTests was passing them directly to the test executable, which interprets them as a tag. It now escapes these brackets along with commas in test case names.

## GitHub Issues
Fixes #1634.
