### PR TITLE
Fix typo in 2.7.1 release notes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -88,7 +88,7 @@
 
 ### Improvements
 * Reporters now print out the filters applied to test cases (#1550, #1585)
-* Added `GENERATE_COPY` and `GENERATE_VAR` macros that can use variables inside the generator expression
+* Added `GENERATE_COPY` and `GENERATE_REF` macros that can use variables inside the generator expression
   * Because of the significant danger of lifetime issues, the default `GENERATE` macro still does not allow variables
 * The `map` generator helper now deduces the mapped return type (#1576)
 


### PR DESCRIPTION
Hi, there was a trivial typo in the notes for 2.7.1 release, which this fixes:

GENERATE_VAR -> GENERATE_REF

This removes the only instance in code of that typo.

Is it possible to make the same edit here:

https://github.com/catchorg/Catch2/releases/tag/v2.7.1
