### PR TITLE
Add setElapsed and getElapsed accessors to Chronometer

### DIFF
--- a/include/internal/benchmark/catch_chronometer.hpp
+++ b/include/internal/benchmark/catch_chronometer.hpp
@@ -20,28 +20,42 @@ namespace Catch {
     namespace Benchmark {
         namespace Detail {
             struct ChronometerConcept {
+                using DefaultClockDuration = ClockDuration<default_clock>;
+
                 virtual void start() = 0;
                 virtual void finish() = 0;
+
+                virtual DefaultClockDuration getElapsed() const = 0;
+                virtual void setElapsed(DefaultClockDuration) = 0;
+
                 virtual ~ChronometerConcept() = default;
             };
             template <typename Clock>
             struct ChronometerModel final : public ChronometerConcept {
                 void start() override { started = Clock::now(); }
-                void finish() override { finished = Clock::now(); }
+                void finish() override { elapsed = Clock::now() - started; }
 
-                ClockDuration<Clock> elapsed() const { return finished - started; }
+                DefaultClockDuration getElapsed() const override { return elapsed; }
+                void setElapsed(DefaultClockDuration _elapsed) override {
+                    elapsed = _elapsed;
+                }
 
                 TimePoint<Clock> started;
-                TimePoint<Clock> finished;
+                ClockDuration<Clock> elapsed;
             };
         } // namespace Detail
 
         struct Chronometer {
         public:
+            using DefaultClockDuration = Detail::ChronometerConcept::DefaultClockDuration;
+
             template <typename Fun>
             void measure(Fun&& fun) { measure(std::forward<Fun>(fun), is_callable<Fun(int)>()); }
 
             int runs() const { return k; }
+
+            DefaultClockDuration getElapsed() const { return impl->getElapsed(); }
+            void setElapsed(DefaultClockDuration elapsed) { impl->setElapsed(elapsed); }
 
             Chronometer(Detail::ChronometerConcept& meter, int k)
                 : impl(&meter)

--- a/include/internal/benchmark/catch_execution_plan.hpp
+++ b/include/internal/benchmark/catch_execution_plan.hpp
@@ -45,7 +45,7 @@ namespace Catch {
                 std::generate_n(std::back_inserter(times), cfg.benchmarkSamples(), [this, env] {
                     Detail::ChronometerModel<Clock> model;
                     this->benchmark(Chronometer(model, iterations_per_sample));
-                    auto sample_time = model.elapsed() - env.clock_cost.mean;
+                    auto sample_time = model.elapsed - env.clock_cost.mean;
                     if (sample_time < FloatDuration<Clock>::zero()) sample_time = FloatDuration<Clock>::zero();
                     return sample_time / iterations_per_sample;
                 });

--- a/include/internal/benchmark/detail/catch_run_for_at_least.hpp
+++ b/include/internal/benchmark/detail/catch_run_for_at_least.hpp
@@ -33,7 +33,7 @@ namespace Catch {
                 Detail::ChronometerModel<Clock> meter;
                 auto&& result = Detail::complete_invoke(fun, Chronometer(meter, iters));
 
-                return { meter.elapsed(), std::move(result), iters };
+                return { meter.elapsed, std::move(result), iters };
             }
 
             template <typename Clock, typename Fun>


### PR DESCRIPTION
## Description

Add `setElapsed` and `getElapsed` accessors to Chronometer so a benchmark program can modify the measured time.

## Notes

This is needed for benchmarking multi-process MPI routines, for example, where load imbalance might cause a different number of iterations of the estimation phase to run, causing deadlocks. By taking some aggregate of the time, this will provide a consistent time across all processes, and so a consistent number of calls.

The Chronometer could probably do with another member saying whether it's in the estimation phase or not. Again, for MPI, the user might decide to aggregate values across processes for the estimation phase, but allow variations in the measurement phase. Any thoughts?

## GitHub Issues
Related: #1690 . If the estimation phase and the measurement phase are exposed to the user, the elapsed value could be left alone during estimation to ensure good measurement, and divided by the sample rate during the measurement phase to provide nice results.