### PR TITLE
Fix xml reporter crashing when a benchmark failed.

### DIFF
--- a/include/reporters/catch_reporter_xml.cpp
+++ b/include/reporters/catch_reporter_xml.cpp
@@ -220,10 +220,13 @@ namespace Catch {
     }
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-    void XmlReporter::benchmarkStarting(BenchmarkInfo const &info) {
+    void XmlReporter::benchmarkPreparing(std::string const& name) {
         m_xml.startElement("BenchmarkResults")
-            .writeAttribute("name", info.name)
-            .writeAttribute("samples", info.samples)
+            .writeAttribute("name", name);
+    }
+
+    void XmlReporter::benchmarkStarting(BenchmarkInfo const &info) {
+        m_xml.writeAttribute("samples", info.samples)
             .writeAttribute("resamples", info.resamples)
             .writeAttribute("iterations", info.iterations)
             .writeAttribute("clockResolution", static_cast<uint64_t>(info.clockResolution))

--- a/include/reporters/catch_reporter_xml.h
+++ b/include/reporters/catch_reporter_xml.h
@@ -51,6 +51,7 @@ namespace Catch {
         void testRunEnded(TestRunStats const& testRunStats) override;
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
+        void benchmarkPreparing(std::string const& name) override;
         void benchmarkStarting(BenchmarkInfo const&) override;
         void benchmarkEnded(BenchmarkStats<> const&) override;
         void benchmarkFailed(std::string const&) override;


### PR DESCRIPTION
## Description
When running a benchmark, that throws an exception or a optimized away exception is thrown, the xml reporter closes the wrong tag.
This was fixed by opening a BenchmarkResults tag on the preparing message. This way it is also reproducible, which benchmark failed.
