### PR TITLE
Add Android implementation of writeToDebugConsole that prints to Logcat

### DIFF
--- a/include/internal/catch_debug_console.cpp
+++ b/include/internal/catch_debug_console.cpp
@@ -20,7 +20,7 @@
         }
     }
 
-#elif CATCH_PLATFORM_WINDOWS
+#elif defined(CATCH_PLATFORM_WINDOWS)
 
     namespace Catch {
         void writeToDebugConsole( std::string const& text ) {

--- a/include/internal/catch_debug_console.cpp
+++ b/include/internal/catch_debug_console.cpp
@@ -11,7 +11,16 @@
 #include "catch_platform.h"
 #include "catch_windows_h_proxy.h"
 
-#ifdef CATCH_PLATFORM_WINDOWS
+#if defined(__ANDROID__)
+#include <android/log.h>
+
+    namespace Catch {
+        void writeToDebugConsole( std::string const& text ) {
+            __android_log_print( ANDROID_LOG_DEBUG, "Catch", text.c_str() );
+        }
+    }
+
+#elif CATCH_PLATFORM_WINDOWS
 
     namespace Catch {
         void writeToDebugConsole( std::string const& text ) {


### PR DESCRIPTION
## Description
Adds an implementation of `writeToDebugConsole` for Android that logs directly to Logcat.

In my opinion, this provides a really good out-of-the-box experience for Android NDK developers.

### Notes
I refrained from adding `CATCH_PLATFORM_ANDROID` and a `catch_android_h_proxy.h` as this felt a little heavy considering that the platform is really more Linux-like and the change is very focused. Happy to make any changes suggested though 😄