### PR TITLE
Improve JUnit failure report

### DIFF
--- a/include/reporters/catch_reporter_junit.cpp
+++ b/include/reporters/catch_reporter_junit.cpp
@@ -12,6 +12,7 @@
 
 #include "../internal/catch_tostring.h"
 #include "../internal/catch_reporter_registrars.hpp"
+#include "../internal/catch_text.h"
 
 #include <cassert>
 #include <sstream>
@@ -244,10 +245,25 @@ namespace Catch {
 
             XmlWriter::ScopedElement e = xml.scopedElement( elementName );
 
-            xml.writeAttribute( "message", result.getExpandedExpression() );
+            xml.writeAttribute( "message", result.getExpression() );
             xml.writeAttribute( "type", result.getTestMacroName() );
 
             ReusableStringStream rss;
+            if (stats.totals.assertions.total() > 0) {
+                rss << "FAILED" << ":\n";
+                if (result.hasExpression()) {
+                    rss << "  ";
+                    rss << result.getExpressionInMacro();
+                    rss << '\n';
+                }
+                if (result.hasExpandedExpression()) {
+                    rss << "with expansion:\n";
+                    rss << Column(result.getExpandedExpression()).indent(2) << '\n';
+                }
+            } else {
+                rss << '\n';
+            }
+
             if( !result.getMessage().empty() )
                 rss << result.getMessage() << '\n';
             for( auto const& msg : stats.infoMessages )

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -18,6 +18,7 @@
     <testcase classname="<exe-name>.global" name="#1455 - INFO and WARN can start with a linebreak" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1514: stderr/stdout is not captured in tests aborted by an exception" time="{duration}">
       <failure type="FAIL">
+FAILED:
 1514
 Tricky.tests.cpp:<line number>
       </failure>
@@ -31,6 +32,7 @@ Nor would this
     <testcase classname="<exe-name>.global" name="#1548" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#748 - captures with unexpected exceptions/outside assertions" time="{duration}">
       <error type="TEST_CASE">
+FAILED:
 expected exception
 answer := 42
 Exception.tests.cpp:<line number>
@@ -38,6 +40,8 @@ Exception.tests.cpp:<line number>
     </testcase>
     <testcase classname="<exe-name>.global" name="#748 - captures with unexpected exceptions/inside REQUIRE_NOTHROW" time="{duration}">
       <error message="thisThrows()" type="REQUIRE_NOTHROW">
+FAILED:
+  REQUIRE_NOTHROW( thisThrows() )
 expected exception
 answer := 42
 Exception.tests.cpp:<line number>
@@ -47,7 +51,11 @@ Exception.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="#809" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#833" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#835 -- errno should not be touched by Catch" time="{duration}">
-      <failure message="1 == 0" type="CHECK">
+      <failure message="f() == 0" type="CHECK">
+FAILED:
+  CHECK( f() == 0 )
+with expansion:
+  1 == 0
 Misc.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -59,27 +67,53 @@ Misc.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="#961 -- Dynamically created sections should all be reported/Looped section 4" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="'Not' checks that should fail" time="{duration}">
       <failure message="false != false" type="CHECK">
+FAILED:
+  CHECK( false != false )
 Condition.tests.cpp:<line number>
       </failure>
       <failure message="true != true" type="CHECK">
+FAILED:
+  CHECK( true != true )
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="false" type="CHECK">
+      <failure message="!true" type="CHECK">
+FAILED:
+  CHECK( !true )
+with expansion:
+  false
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="!true" type="CHECK_FALSE">
+      <failure message="!(true)" type="CHECK_FALSE">
+FAILED:
+  CHECK_FALSE( true )
+with expansion:
+  !true
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="false" type="CHECK">
+      <failure message="!trueValue" type="CHECK">
+FAILED:
+  CHECK( !trueValue )
+with expansion:
+  false
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="!true" type="CHECK_FALSE">
+      <failure message="!(trueValue)" type="CHECK_FALSE">
+FAILED:
+  CHECK_FALSE( trueValue )
+with expansion:
+  !true
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="false" type="CHECK">
+      <failure message="!(1 == 1)" type="CHECK">
+FAILED:
+  CHECK( !(1 == 1) )
+with expansion:
+  false
 Condition.tests.cpp:<line number>
       </failure>
       <failure message="!(1 == 1)" type="CHECK_FALSE">
+FAILED:
+  CHECK_FALSE( 1 == 1 )
 Condition.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -91,28 +125,48 @@ Condition.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="(unimplemented) static bools can be evaluated/direct" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="3x3x3 ints" time="{duration}"/>
     <testcase classname="<exe-name>.TestClass" name="A METHOD_AS_TEST_CASE based test run that fails" time="{duration}">
-      <failure message="&quot;hello&quot; == &quot;world&quot;" type="REQUIRE">
+      <failure message="s == &quot;world&quot;" type="REQUIRE">
+FAILED:
+  REQUIRE( s == "world" )
+with expansion:
+  "hello" == "world"
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.TestClass" name="A METHOD_AS_TEST_CASE based test run that succeeds" time="{duration}"/>
     <testcase classname="<exe-name>.Template_Fixture_2" name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - Template_Foo&lt;float>" time="{duration}">
-      <failure message="0 == 1" type="REQUIRE">
+      <failure message="Template_Fixture_2&lt;TestType>::m_a.size() == 1" type="REQUIRE">
+FAILED:
+  REQUIRE( Template_Fixture_2&lt;TestType>::m_a.size() == 1 )
+with expansion:
+  0 == 1
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.Template_Fixture_2" name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - Template_Foo&lt;int>" time="{duration}">
-      <failure message="0 == 1" type="REQUIRE">
+      <failure message="Template_Fixture_2&lt;TestType>::m_a.size() == 1" type="REQUIRE">
+FAILED:
+  REQUIRE( Template_Fixture_2&lt;TestType>::m_a.size() == 1 )
+with expansion:
+  0 == 1
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.Template_Fixture_2" name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - std::vector&lt;float>" time="{duration}">
-      <failure message="0 == 1" type="REQUIRE">
+      <failure message="Template_Fixture_2&lt;TestType>::m_a.size() == 1" type="REQUIRE">
+FAILED:
+  REQUIRE( Template_Fixture_2&lt;TestType>::m_a.size() == 1 )
+with expansion:
+  0 == 1
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.Template_Fixture_2" name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - std::vector&lt;int>" time="{duration}">
-      <failure message="0 == 1" type="REQUIRE">
+      <failure message="Template_Fixture_2&lt;TestType>::m_a.size() == 1" type="REQUIRE">
+FAILED:
+  REQUIRE( Template_Fixture_2&lt;TestType>::m_a.size() == 1 )
+with expansion:
+  0 == 1
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -121,22 +175,38 @@ Class.tests.cpp:<line number>
     <testcase classname="<exe-name>.Template_Fixture_2" name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - std::vector&lt;float>" time="{duration}"/>
     <testcase classname="<exe-name>.Template_Fixture_2" name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - std::vector&lt;int>" time="{duration}"/>
     <testcase classname="<exe-name>.Template_Fixture_2" name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - Template_Foo_2&lt;float, 6>" time="{duration}">
-      <failure message="6 &lt; 2" type="REQUIRE">
+      <failure message="Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2" type="REQUIRE">
+FAILED:
+  REQUIRE( Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2 )
+with expansion:
+  6 &lt; 2
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.Template_Fixture_2" name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - Template_Foo_2&lt;int, 2>" time="{duration}">
-      <failure message="2 &lt; 2" type="REQUIRE">
+      <failure message="Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2" type="REQUIRE">
+FAILED:
+  REQUIRE( Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2 )
+with expansion:
+  2 &lt; 2
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.Template_Fixture_2" name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - std::array&lt;float, 6>" time="{duration}">
-      <failure message="6 &lt; 2" type="REQUIRE">
+      <failure message="Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2" type="REQUIRE">
+FAILED:
+  REQUIRE( Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2 )
+with expansion:
+  6 &lt; 2
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.Template_Fixture_2" name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - std::array&lt;int, 2>" time="{duration}">
-      <failure message="2 &lt; 2" type="REQUIRE">
+      <failure message="Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2" type="REQUIRE">
+FAILED:
+  REQUIRE( Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2 )
+with expansion:
+  2 &lt; 2
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -145,17 +215,29 @@ Class.tests.cpp:<line number>
     <testcase classname="<exe-name>.Template_Fixture_2" name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - std::array&lt;float,6>" time="{duration}"/>
     <testcase classname="<exe-name>.Template_Fixture_2" name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - std::array&lt;int,2>" time="{duration}"/>
     <testcase classname="<exe-name>.Template_Fixture" name="A TEMPLATE_TEST_CASE_METHOD based test run that fails - double" time="{duration}">
-      <failure message="1.0 == 2" type="REQUIRE">
+      <failure message="Template_Fixture&lt;TestType>::m_a == 2" type="REQUIRE">
+FAILED:
+  REQUIRE( Template_Fixture&lt;TestType>::m_a == 2 )
+with expansion:
+  1.0 == 2
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.Template_Fixture" name="A TEMPLATE_TEST_CASE_METHOD based test run that fails - float" time="{duration}">
-      <failure message="1.0f == 2" type="REQUIRE">
+      <failure message="Template_Fixture&lt;TestType>::m_a == 2" type="REQUIRE">
+FAILED:
+  REQUIRE( Template_Fixture&lt;TestType>::m_a == 2 )
+with expansion:
+  1.0f == 2
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.Template_Fixture" name="A TEMPLATE_TEST_CASE_METHOD based test run that fails - int" time="{duration}">
-      <failure message="1 == 2" type="REQUIRE">
+      <failure message="Template_Fixture&lt;TestType>::m_a == 2" type="REQUIRE">
+FAILED:
+  REQUIRE( Template_Fixture&lt;TestType>::m_a == 2 )
+with expansion:
+  1 == 2
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -163,17 +245,29 @@ Class.tests.cpp:<line number>
     <testcase classname="<exe-name>.Template_Fixture" name="A TEMPLATE_TEST_CASE_METHOD based test run that succeeds - float" time="{duration}"/>
     <testcase classname="<exe-name>.Template_Fixture" name="A TEMPLATE_TEST_CASE_METHOD based test run that succeeds - int" time="{duration}"/>
     <testcase classname="<exe-name>.Nttp_Fixture" name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that fails - 1" time="{duration}">
-      <failure message="1 == 0" type="REQUIRE">
+      <failure message="Nttp_Fixture&lt;V>::value == 0" type="REQUIRE">
+FAILED:
+  REQUIRE( Nttp_Fixture&lt;V>::value == 0 )
+with expansion:
+  1 == 0
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.Nttp_Fixture" name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that fails - 3" time="{duration}">
-      <failure message="3 == 0" type="REQUIRE">
+      <failure message="Nttp_Fixture&lt;V>::value == 0" type="REQUIRE">
+FAILED:
+  REQUIRE( Nttp_Fixture&lt;V>::value == 0 )
+with expansion:
+  3 == 0
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.Nttp_Fixture" name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that fails - 6" time="{duration}">
-      <failure message="6 == 0" type="REQUIRE">
+      <failure message="Nttp_Fixture&lt;V>::value == 0" type="REQUIRE">
+FAILED:
+  REQUIRE( Nttp_Fixture&lt;V>::value == 0 )
+with expansion:
+  6 == 0
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -181,7 +275,11 @@ Class.tests.cpp:<line number>
     <testcase classname="<exe-name>.Nttp_Fixture" name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds - 3" time="{duration}"/>
     <testcase classname="<exe-name>.Nttp_Fixture" name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds - 6" time="{duration}"/>
     <testcase classname="<exe-name>.Fixture" name="A TEST_CASE_METHOD based test run that fails" time="{duration}">
-      <failure message="1 == 2" type="REQUIRE">
+      <failure message="m_a == 2" type="REQUIRE">
+FAILED:
+  REQUIRE( m_a == 2 )
+with expansion:
+  1 == 2
 Class.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -197,16 +295,25 @@ Class.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="A comparison that uses literals instead of the normal constructor" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="A couple of nested sections followed by a failure" time="{duration}">
       <failure type="FAIL">
+FAILED:
 to infinity and beyond
 Misc.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="A couple of nested sections followed by a failure/Outer/Inner" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="A failing expression with a non streamable type is still captured" time="{duration}">
-      <failure message="0x<hex digits> == 0x<hex digits>" type="CHECK">
+      <failure message="&amp;o1 == &amp;o2" type="CHECK">
+FAILED:
+  CHECK( &amp;o1 == &amp;o2 )
+with expansion:
+  0x<hex digits> == 0x<hex digits>
 Tricky.tests.cpp:<line number>
       </failure>
-      <failure message="{?} == {?}" type="CHECK">
+      <failure message="o1 == o2" type="CHECK">
+FAILED:
+  CHECK( o1 == o2 )
+with expansion:
+  {?} == {?}
 Tricky.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -214,6 +321,8 @@ Tricky.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="An expression with side-effects should only be evaluated once" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="An unchecked exception reports the line of the last assertion" time="{duration}">
       <error message="{Unknown expression after the reported line}">
+FAILED:
+  {Unknown expression after the reported line}
 unexpected exception
 Exception.tests.cpp:<line number>
       </error>
@@ -248,10 +357,19 @@ Exception.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Comparisons between unsigned ints and negative signed ints match c++ standard behaviour" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Comparisons with int literals don't warn when mixing signed/ unsigned" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Contains string matcher" time="{duration}">
-      <failure message="&quot;this string contains 'abc' as a substring&quot; contains: &quot;not there&quot; (case insensitive)" type="CHECK_THAT">
+      <failure message="testStringForMatching(), Contains(&quot;not there&quot;, Catch::CaseSensitive::No)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), Contains("not there", Catch::CaseSensitive::No) )
+with expansion:
+  "this string contains 'abc' as a substring" contains: "not there" (case
+  insensitive)
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;this string contains 'abc' as a substring&quot; contains: &quot;STRING&quot;" type="CHECK_THAT">
+      <failure message="testStringForMatching(), Contains(&quot;STRING&quot;)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), Contains("STRING") )
+with expansion:
+  "this string contains 'abc' as a substring" contains: "STRING"
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -260,18 +378,23 @@ Matchers.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Copy and then generate a range/Final validation" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Custom exceptions can be translated when testing for nothrow" time="{duration}">
       <error message="throwCustom()" type="REQUIRE_NOTHROW">
+FAILED:
+  REQUIRE_NOTHROW( throwCustom() )
 custom exception - not std
 Exception.tests.cpp:<line number>
       </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="Custom exceptions can be translated when testing for throwing as something else" time="{duration}">
       <error message="throwCustom(), std::exception" type="REQUIRE_THROWS_AS">
+FAILED:
+  REQUIRE_THROWS_AS( throwCustom(), std::exception )
 custom exception - not std
 Exception.tests.cpp:<line number>
       </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="Custom std-exceptions can be custom translated" time="{duration}">
       <error type="TEST_CASE">
+FAILED:
 custom std exception
 Exception.tests.cpp:<line number>
       </error>
@@ -279,10 +402,19 @@ Exception.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Default scale is invisible to comparison" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Directly creating an EnumInfo" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="EndsWith string matcher" time="{duration}">
-      <failure message="&quot;this string contains 'abc' as a substring&quot; ends with: &quot;Substring&quot;" type="CHECK_THAT">
+      <failure message="testStringForMatching(), EndsWith(&quot;Substring&quot;)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), EndsWith("Substring") )
+with expansion:
+  "this string contains 'abc' as a substring" ends with: "Substring"
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;this string contains 'abc' as a substring&quot; ends with: &quot;this&quot; (case insensitive)" type="CHECK_THAT">
+      <failure message="testStringForMatching(), EndsWith(&quot;this&quot;, Catch::CaseSensitive::No)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), EndsWith("this", Catch::CaseSensitive::No) )
+with expansion:
+  "this string contains 'abc' as a substring" ends with: "this" (case
+  insensitive)
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -290,80 +422,158 @@ Matchers.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Enums in namespaces can quickly have stringification enabled using REGISTER_ENUM" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Epsilon only applies to Approx's value" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Equality checks that should fail" time="{duration}">
-      <failure message="7 == 6" type="CHECK">
+      <failure message="data.int_seven == 6" type="CHECK">
+FAILED:
+  CHECK( data.int_seven == 6 )
+with expansion:
+  7 == 6
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="7 == 8" type="CHECK">
+      <failure message="data.int_seven == 8" type="CHECK">
+FAILED:
+  CHECK( data.int_seven == 8 )
+with expansion:
+  7 == 8
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="7 == 0" type="CHECK">
+      <failure message="data.int_seven == 0" type="CHECK">
+FAILED:
+  CHECK( data.int_seven == 0 )
+with expansion:
+  7 == 0
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="9.1f == Approx( 9.1099996567 )" type="CHECK">
+      <failure message="data.float_nine_point_one == Approx( 9.11f )" type="CHECK">
+FAILED:
+  CHECK( data.float_nine_point_one == Approx( 9.11f ) )
+with expansion:
+  9.1f == Approx( 9.1099996567 )
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="9.1f == Approx( 9.0 )" type="CHECK">
+      <failure message="data.float_nine_point_one == Approx( 9.0f )" type="CHECK">
+FAILED:
+  CHECK( data.float_nine_point_one == Approx( 9.0f ) )
+with expansion:
+  9.1f == Approx( 9.0 )
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="9.1f == Approx( 1.0 )" type="CHECK">
+      <failure message="data.float_nine_point_one == Approx( 1 )" type="CHECK">
+FAILED:
+  CHECK( data.float_nine_point_one == Approx( 1 ) )
+with expansion:
+  9.1f == Approx( 1.0 )
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="9.1f == Approx( 0.0 )" type="CHECK">
+      <failure message="data.float_nine_point_one == Approx( 0 )" type="CHECK">
+FAILED:
+  CHECK( data.float_nine_point_one == Approx( 0 ) )
+with expansion:
+  9.1f == Approx( 0.0 )
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="3.1415926535 == Approx( 3.1415 )" type="CHECK">
+      <failure message="data.double_pi == Approx( 3.1415 )" type="CHECK">
+FAILED:
+  CHECK( data.double_pi == Approx( 3.1415 ) )
+with expansion:
+  3.1415926535 == Approx( 3.1415 )
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;hello&quot; == &quot;goodbye&quot;" type="CHECK">
+      <failure message="data.str_hello == &quot;goodbye&quot;" type="CHECK">
+FAILED:
+  CHECK( data.str_hello == "goodbye" )
+with expansion:
+  "hello" == "goodbye"
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;hello&quot; == &quot;hell&quot;" type="CHECK">
+      <failure message="data.str_hello == &quot;hell&quot;" type="CHECK">
+FAILED:
+  CHECK( data.str_hello == "hell" )
+with expansion:
+  "hello" == "hell"
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;hello&quot; == &quot;hello1&quot;" type="CHECK">
+      <failure message="data.str_hello == &quot;hello1&quot;" type="CHECK">
+FAILED:
+  CHECK( data.str_hello == "hello1" )
+with expansion:
+  "hello" == "hello1"
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="5 == 6" type="CHECK">
+      <failure message="data.str_hello.size() == 6" type="CHECK">
+FAILED:
+  CHECK( data.str_hello.size() == 6 )
+with expansion:
+  5 == 6
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="1.3 == Approx( 1.301 )" type="CHECK">
+      <failure message="x == Approx( 1.301 )" type="CHECK">
+FAILED:
+  CHECK( x == Approx( 1.301 ) )
+with expansion:
+  1.3 == Approx( 1.301 )
 Condition.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Equality checks that should succeed" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Equals" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Equals string matcher" time="{duration}">
-      <failure message="&quot;this string contains 'abc' as a substring&quot; equals: &quot;this string contains 'ABC' as a substring&quot;" type="CHECK_THAT">
+      <failure message="testStringForMatching(), Equals(&quot;this string contains 'ABC' as a substring&quot;)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), Equals("this string contains 'ABC' as a substring") )
+with expansion:
+  "this string contains 'abc' as a substring" equals: "this string contains
+  'ABC' as a substring"
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;this string contains 'abc' as a substring&quot; equals: &quot;something else&quot; (case insensitive)" type="CHECK_THAT">
+      <failure message="testStringForMatching(), Equals(&quot;something else&quot;, Catch::CaseSensitive::No)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), Equals("something else", Catch::CaseSensitive::No) )
+with expansion:
+  "this string contains 'abc' as a substring" equals: "something else" (case
+  insensitive)
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Exception as a value (e.g. in REQUIRE_THROWS_MATCHES) can be stringified" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Exception matchers that fail/No exception" time="{duration}">
       <failure message="doesNotThrow(), SpecialException, ExceptionMatcher{1}" type="CHECK_THROWS_MATCHES">
+FAILED:
+  CHECK_THROWS_MATCHES( doesNotThrow(), SpecialException, ExceptionMatcher{1} )
 Matchers.tests.cpp:<line number>
       </failure>
       <failure message="doesNotThrow(), SpecialException, ExceptionMatcher{1}" type="REQUIRE_THROWS_MATCHES">
+FAILED:
+  REQUIRE_THROWS_MATCHES( doesNotThrow(), SpecialException, ExceptionMatcher{1} )
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Exception matchers that fail/Type mismatch" time="{duration}">
       <error message="throwsAsInt(1), SpecialException, ExceptionMatcher{1}" type="CHECK_THROWS_MATCHES">
+FAILED:
+  CHECK_THROWS_MATCHES( throwsAsInt(1), SpecialException, ExceptionMatcher{1} )
 Unknown exception
 Matchers.tests.cpp:<line number>
       </error>
       <error message="throwsAsInt(1), SpecialException, ExceptionMatcher{1}" type="REQUIRE_THROWS_MATCHES">
+FAILED:
+  REQUIRE_THROWS_MATCHES( throwsAsInt(1), SpecialException, ExceptionMatcher{1} )
 Unknown exception
 Matchers.tests.cpp:<line number>
       </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="Exception matchers that fail/Contents are wrong" time="{duration}">
-      <failure message="SpecialException::what special exception has value of 1" type="CHECK_THROWS_MATCHES">
+      <failure message="throwsSpecialException(3), SpecialException, ExceptionMatcher{1}" type="CHECK_THROWS_MATCHES">
+FAILED:
+  CHECK_THROWS_MATCHES( throwsSpecialException(3), SpecialException, ExceptionMatcher{1} )
+with expansion:
+  SpecialException::what special exception has value of 1
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="SpecialException::what special exception has value of 1" type="REQUIRE_THROWS_MATCHES">
+      <failure message="throwsSpecialException(4), SpecialException, ExceptionMatcher{1}" type="REQUIRE_THROWS_MATCHES">
+FAILED:
+  REQUIRE_THROWS_MATCHES( throwsSpecialException(4), SpecialException, ExceptionMatcher{1} )
+with expansion:
+  SpecialException::what special exception has value of 1
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -374,30 +584,39 @@ Matchers.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Exceptions matchers" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Expected exceptions that don't throw or unexpected exceptions fail the test" time="{duration}">
       <error message="thisThrows(), std::string" type="CHECK_THROWS_AS">
+FAILED:
+  CHECK_THROWS_AS( thisThrows(), std::string )
 expected exception
 Exception.tests.cpp:<line number>
       </error>
       <failure message="thisDoesntThrow(), std::domain_error" type="CHECK_THROWS_AS">
+FAILED:
+  CHECK_THROWS_AS( thisDoesntThrow(), std::domain_error )
 Exception.tests.cpp:<line number>
       </failure>
       <error message="thisThrows()" type="CHECK_NOTHROW">
+FAILED:
+  CHECK_NOTHROW( thisThrows() )
 expected exception
 Exception.tests.cpp:<line number>
       </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="FAIL aborts the test" time="{duration}">
       <failure type="FAIL">
+FAILED:
 This is a failure
 Message.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="FAIL does not require an argument" time="{duration}">
       <failure type="FAIL">
+FAILED:
 Message.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="FAIL_CHECK does not abort the test" time="{duration}">
       <failure type="FAIL_CHECK">
+FAILED:
 This is a failure
 Message.tests.cpp:<line number>
       </failure>
@@ -453,19 +672,31 @@ Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Greater-than inequalities with different epsilons" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="INFO and WARN do not abort tests" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="INFO gets logged on failure" time="{duration}">
-      <failure message="2 == 1" type="REQUIRE">
+      <failure message="a == 1" type="REQUIRE">
+FAILED:
+  REQUIRE( a == 1 )
+with expansion:
+  2 == 1
 this message should be logged
 so should this
 Message.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="INFO gets logged on failure, even if captured before successful assertions" time="{duration}">
-      <failure message="2 == 1" type="CHECK">
+      <failure message="a == 1" type="CHECK">
+FAILED:
+  CHECK( a == 1 )
+with expansion:
+  2 == 1
 this message may be logged later
 this message should be logged
 Message.tests.cpp:<line number>
       </failure>
-      <failure message="2 == 0" type="CHECK">
+      <failure message="a == 0" type="CHECK">
+FAILED:
+  CHECK( a == 0 )
+with expansion:
+  2 == 0
 this message may be logged later
 this message should be logged
 and this, but later
@@ -473,26 +704,50 @@ Message.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="INFO is reset for each loop" time="{duration}">
-      <failure message="10 &lt; 10" type="REQUIRE">
+      <failure message="i &lt; 10" type="REQUIRE">
+FAILED:
+  REQUIRE( i &lt; 10 )
+with expansion:
+  10 &lt; 10
 current counter 10
 i := 10
 Message.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Inequality checks that should fail" time="{duration}">
-      <failure message="7 != 7" type="CHECK">
+      <failure message="data.int_seven != 7" type="CHECK">
+FAILED:
+  CHECK( data.int_seven != 7 )
+with expansion:
+  7 != 7
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="9.1f != Approx( 9.1000003815 )" type="CHECK">
+      <failure message="data.float_nine_point_one != Approx( 9.1f )" type="CHECK">
+FAILED:
+  CHECK( data.float_nine_point_one != Approx( 9.1f ) )
+with expansion:
+  9.1f != Approx( 9.1000003815 )
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="3.1415926535 != Approx( 3.1415926535 )" type="CHECK">
+      <failure message="data.double_pi != Approx( 3.1415926535 )" type="CHECK">
+FAILED:
+  CHECK( data.double_pi != Approx( 3.1415926535 ) )
+with expansion:
+  3.1415926535 != Approx( 3.1415926535 )
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;hello&quot; != &quot;hello&quot;" type="CHECK">
+      <failure message="data.str_hello != &quot;hello&quot;" type="CHECK">
+FAILED:
+  CHECK( data.str_hello != "hello" )
+with expansion:
+  "hello" != "hello"
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="5 != 5" type="CHECK">
+      <failure message="data.str_hello.size() != 5" type="CHECK">
+FAILED:
+  CHECK( data.str_hello.size() != 5 )
+with expansion:
+  5 != 5
 Condition.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -503,18 +758,31 @@ Condition.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Matchers can be (AnyOf) composed with the || operator" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Matchers can be composed with both &amp;&amp; and ||" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Matchers can be composed with both &amp;&amp; and || - failing" time="{duration}">
-      <failure message="&quot;this string contains 'abc' as a substring&quot; ( ( contains: &quot;string&quot; or contains: &quot;different&quot; ) and contains: &quot;random&quot; )" type="CHECK_THAT">
+      <failure message="testStringForMatching(), (Contains(&quot;string&quot;) || Contains(&quot;different&quot;)) &amp;&amp; Contains(&quot;random&quot;)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), (Contains("string") || Contains("different")) &amp;&amp; Contains("random") )
+with expansion:
+  "this string contains 'abc' as a substring" ( ( contains: "string" or
+  contains: "different" ) and contains: "random" )
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Matchers can be negated (Not) with the ! operator" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Matchers can be negated (Not) with the ! operator - failing" time="{duration}">
-      <failure message="&quot;this string contains 'abc' as a substring&quot; not contains: &quot;substring&quot;" type="CHECK_THAT">
+      <failure message="testStringForMatching(), !Contains(&quot;substring&quot;)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), !Contains("substring") )
+with expansion:
+  "this string contains 'abc' as a substring" not contains: "substring"
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Mismatching exception messages failing the test" time="{duration}">
-      <failure message="&quot;expected exception&quot; equals: &quot;should fail&quot;" type="REQUIRE_THROWS_WITH">
+      <failure message="thisThrows(), &quot;should fail&quot;" type="REQUIRE_THROWS_WITH">
+FAILED:
+  REQUIRE_THROWS_WITH( thisThrows(), "should fail" )
+with expansion:
+  "expected exception" equals: "should fail"
 Exception.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -522,6 +790,7 @@ Exception.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Nice descriptive name" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Non-std exceptions can be translated" time="{duration}">
       <error type="TEST_CASE">
+FAILED:
 custom exception
 Exception.tests.cpp:<line number>
       </error>
@@ -529,61 +798,137 @@ Exception.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Objects that evaluated in boolean contexts can be checked" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Optionally static assertions" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Ordering comparison checks that should fail" time="{duration}">
-      <failure message="7 > 7" type="CHECK">
+      <failure message="data.int_seven > 7" type="CHECK">
+FAILED:
+  CHECK( data.int_seven > 7 )
+with expansion:
+  7 > 7
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="7 &lt; 7" type="CHECK">
+      <failure message="data.int_seven &lt; 7" type="CHECK">
+FAILED:
+  CHECK( data.int_seven &lt; 7 )
+with expansion:
+  7 &lt; 7
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="7 > 8" type="CHECK">
+      <failure message="data.int_seven > 8" type="CHECK">
+FAILED:
+  CHECK( data.int_seven > 8 )
+with expansion:
+  7 > 8
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="7 &lt; 6" type="CHECK">
+      <failure message="data.int_seven &lt; 6" type="CHECK">
+FAILED:
+  CHECK( data.int_seven &lt; 6 )
+with expansion:
+  7 &lt; 6
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="7 &lt; 0" type="CHECK">
+      <failure message="data.int_seven &lt; 0" type="CHECK">
+FAILED:
+  CHECK( data.int_seven &lt; 0 )
+with expansion:
+  7 &lt; 0
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="7 &lt; -1" type="CHECK">
+      <failure message="data.int_seven &lt; -1" type="CHECK">
+FAILED:
+  CHECK( data.int_seven &lt; -1 )
+with expansion:
+  7 &lt; -1
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="7 >= 8" type="CHECK">
+      <failure message="data.int_seven >= 8" type="CHECK">
+FAILED:
+  CHECK( data.int_seven >= 8 )
+with expansion:
+  7 >= 8
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="7 &lt;= 6" type="CHECK">
+      <failure message="data.int_seven &lt;= 6" type="CHECK">
+FAILED:
+  CHECK( data.int_seven &lt;= 6 )
+with expansion:
+  7 &lt;= 6
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="9.1f &lt; 9" type="CHECK">
+      <failure message="data.float_nine_point_one &lt; 9" type="CHECK">
+FAILED:
+  CHECK( data.float_nine_point_one &lt; 9 )
+with expansion:
+  9.1f &lt; 9
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="9.1f > 10" type="CHECK">
+      <failure message="data.float_nine_point_one > 10" type="CHECK">
+FAILED:
+  CHECK( data.float_nine_point_one > 10 )
+with expansion:
+  9.1f > 10
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="9.1f > 9.2" type="CHECK">
+      <failure message="data.float_nine_point_one > 9.2" type="CHECK">
+FAILED:
+  CHECK( data.float_nine_point_one > 9.2 )
+with expansion:
+  9.1f > 9.2
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;hello&quot; > &quot;hello&quot;" type="CHECK">
+      <failure message="data.str_hello > &quot;hello&quot;" type="CHECK">
+FAILED:
+  CHECK( data.str_hello > "hello" )
+with expansion:
+  "hello" > "hello"
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;hello&quot; &lt; &quot;hello&quot;" type="CHECK">
+      <failure message="data.str_hello &lt; &quot;hello&quot;" type="CHECK">
+FAILED:
+  CHECK( data.str_hello &lt; "hello" )
+with expansion:
+  "hello" &lt; "hello"
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;hello&quot; > &quot;hellp&quot;" type="CHECK">
+      <failure message="data.str_hello > &quot;hellp&quot;" type="CHECK">
+FAILED:
+  CHECK( data.str_hello > "hellp" )
+with expansion:
+  "hello" > "hellp"
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;hello&quot; > &quot;z&quot;" type="CHECK">
+      <failure message="data.str_hello > &quot;z&quot;" type="CHECK">
+FAILED:
+  CHECK( data.str_hello > "z" )
+with expansion:
+  "hello" > "z"
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;hello&quot; &lt; &quot;hellm&quot;" type="CHECK">
+      <failure message="data.str_hello &lt; &quot;hellm&quot;" type="CHECK">
+FAILED:
+  CHECK( data.str_hello &lt; "hellm" )
+with expansion:
+  "hello" &lt; "hellm"
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;hello&quot; &lt; &quot;a&quot;" type="CHECK">
+      <failure message="data.str_hello &lt; &quot;a&quot;" type="CHECK">
+FAILED:
+  CHECK( data.str_hello &lt; "a" )
+with expansion:
+  "hello" &lt; "a"
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;hello&quot; >= &quot;z&quot;" type="CHECK">
+      <failure message="data.str_hello >= &quot;z&quot;" type="CHECK">
+FAILED:
+  CHECK( data.str_hello >= "z" )
+with expansion:
+  "hello" >= "z"
 Condition.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;hello&quot; &lt;= &quot;a&quot;" type="CHECK">
+      <failure message="data.str_hello &lt;= &quot;a&quot;" type="CHECK">
+FAILED:
+  CHECK( data.str_hello &lt;= "a" )
+with expansion:
+  "hello" &lt;= "a"
 Condition.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -592,12 +937,14 @@ Condition.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Our PCG implementation provides expected results for known seeds/Specific seed" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Output from all sections is reported/one" time="{duration}">
       <failure type="FAIL">
+FAILED:
 Message from section one
 Message.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Output from all sections is reported/two" time="{duration}">
       <failure type="FAIL">
+FAILED:
 Message from section two
 Message.tests.cpp:<line number>
       </failure>
@@ -672,18 +1019,37 @@ Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Product with differing arities - std::tuple&lt;int, double>" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Product with differing arities - std::tuple&lt;int>" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Reconstruction should be based on stringification: #914" time="{duration}">
-      <failure message="Hey, its truthy!" type="CHECK">
+      <failure message="truthy(false)" type="CHECK">
+FAILED:
+  CHECK( truthy(false) )
+with expansion:
+  Hey, its truthy!
 Decomposition.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Regex string matcher" time="{duration}">
-      <failure message="&quot;this string contains 'abc' as a substring&quot; matches &quot;this STRING contains 'abc' as a substring&quot; case sensitively" type="CHECK_THAT">
+      <failure message="testStringForMatching(), Matches(&quot;this STRING contains 'abc' as a substring&quot;)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), Matches("this STRING contains 'abc' as a substring") )
+with expansion:
+  "this string contains 'abc' as a substring" matches "this STRING contains
+  'abc' as a substring" case sensitively
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;this string contains 'abc' as a substring&quot; matches &quot;contains 'abc' as a substring&quot; case sensitively" type="CHECK_THAT">
+      <failure message="testStringForMatching(), Matches(&quot;contains 'abc' as a substring&quot;)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), Matches("contains 'abc' as a substring") )
+with expansion:
+  "this string contains 'abc' as a substring" matches "contains 'abc' as a
+  substring" case sensitively
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;this string contains 'abc' as a substring&quot; matches &quot;this string contains 'abc' as a&quot; case sensitively" type="CHECK_THAT">
+      <failure message="testStringForMatching(), Matches(&quot;this string contains 'abc' as a&quot;)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), Matches("this string contains 'abc' as a") )
+with expansion:
+  "this string contains 'abc' as a substring" matches "this string contains
+  'abc' as a" case sensitively
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -716,10 +1082,19 @@ Message from section two
       </system-out>
     </testcase>
     <testcase classname="<exe-name>.global" name="StartsWith string matcher" time="{duration}">
-      <failure message="&quot;this string contains 'abc' as a substring&quot; starts with: &quot;This String&quot;" type="CHECK_THAT">
+      <failure message="testStringForMatching(), StartsWith(&quot;This String&quot;)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), StartsWith("This String") )
+with expansion:
+  "this string contains 'abc' as a substring" starts with: "This String"
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="&quot;this string contains 'abc' as a substring&quot; starts with: &quot;string&quot; (case insensitive)" type="CHECK_THAT">
+      <failure message="testStringForMatching(), StartsWith(&quot;string&quot;, Catch::CaseSensitive::No)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( testStringForMatching(), StartsWith("string", Catch::CaseSensitive::No) )
+with expansion:
+  "this string contains 'abc' as a substring" starts with: "string" (case
+  insensitive)
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -748,14 +1123,18 @@ Matchers.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Stringifying std::chrono::duration with weird ratios" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Stringifying std::chrono::time_point&lt;system_clock>" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Tabs and newlines show in output" time="{duration}">
-      <failure message="&quot;if ($b == 10) {
-		$a	= 20;
-}&quot;
-==
-&quot;if ($b == 10) {
-	$a = 20;
-}
-&quot;" type="CHECK">
+      <failure message="s1 == s2" type="CHECK">
+FAILED:
+  CHECK( s1 == s2 )
+with expansion:
+  "if ($b == 10) {
+  		$a	= 20;
+  }"
+  ==
+  "if ($b == 10) {
+  	$a = 20;
+  }
+  "
 Misc.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -826,6 +1205,7 @@ Misc.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="This test 'should' fail but doesn't" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Thrown string literals are translated" time="{duration}">
       <error type="TEST_CASE">
+FAILED:
 For some reason someone is throwing a string literal!
 Exception.tests.cpp:<line number>
       </error>
@@ -843,6 +1223,7 @@ Exception.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Trim strings" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Unexpected exceptions can be translated" time="{duration}">
       <error type="TEST_CASE">
+FAILED:
 3.14
 Exception.tests.cpp:<line number>
       </error>
@@ -854,12 +1235,20 @@ Exception.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Vector Approx matcher/Vectors with elements/Different length" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Vector Approx matcher/Vectors with elements/Same length, different elements" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Vector Approx matcher -- failing/Empty and non empty vectors are not approx equal" time="{duration}">
-      <failure message="{  } is approx: { 1.0, 2.0 }" type="CHECK_THAT">
+      <failure message="empty, Approx(t1)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( empty, Approx(t1) )
+with expansion:
+  {  } is approx: { 1.0, 2.0 }
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Vector Approx matcher -- failing/Just different vectors" time="{duration}">
-      <failure message="{ 2.0, 4.0, 6.0 } is approx: { 1.0, 3.0, 5.0 }" type="CHECK_THAT">
+      <failure message="v1, Approx(v2)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( v1, Approx(v2) )
+with expansion:
+  { 2.0, 4.0, 6.0 } is approx: { 1.0, 3.0, 5.0 }
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -869,76 +1258,132 @@ Matchers.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Vector matchers/Equals" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Vector matchers/UnorderedEquals" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Vector matchers that fail/Contains (element)" time="{duration}">
-      <failure message="{ 1, 2, 3 } Contains: -1" type="CHECK_THAT">
+      <failure message="v, VectorContains(-1)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( v, VectorContains(-1) )
+with expansion:
+  { 1, 2, 3 } Contains: -1
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="{  } Contains: 1" type="CHECK_THAT">
+      <failure message="empty, VectorContains(1)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( empty, VectorContains(1) )
+with expansion:
+  {  } Contains: 1
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Vector matchers that fail/Contains (vector)" time="{duration}">
-      <failure message="{  } Contains: { 1, 2, 3 }" type="CHECK_THAT">
+      <failure message="empty, Contains(v)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( empty, Contains(v) )
+with expansion:
+  {  } Contains: { 1, 2, 3 }
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="{ 1, 2, 3 } Contains: { 1, 2, 4 }" type="CHECK_THAT">
+      <failure message="v, Contains(v2)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( v, Contains(v2) )
+with expansion:
+  { 1, 2, 3 } Contains: { 1, 2, 4 }
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Vector matchers that fail/Equals" time="{duration}">
-      <failure message="{ 1, 2, 3 } Equals: { 1, 2 }" type="CHECK_THAT">
+      <failure message="v, Equals(v2)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( v, Equals(v2) )
+with expansion:
+  { 1, 2, 3 } Equals: { 1, 2 }
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="{ 1, 2 } Equals: { 1, 2, 3 }" type="CHECK_THAT">
+      <failure message="v2, Equals(v)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( v2, Equals(v) )
+with expansion:
+  { 1, 2 } Equals: { 1, 2, 3 }
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="{  } Equals: { 1, 2, 3 }" type="CHECK_THAT">
+      <failure message="empty, Equals(v)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( empty, Equals(v) )
+with expansion:
+  {  } Equals: { 1, 2, 3 }
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="{ 1, 2, 3 } Equals: {  }" type="CHECK_THAT">
+      <failure message="v, Equals(empty)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( v, Equals(empty) )
+with expansion:
+  { 1, 2, 3 } Equals: {  }
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Vector matchers that fail/UnorderedEquals" time="{duration}">
-      <failure message="{ 1, 2, 3 } UnorderedEquals: {  }" type="CHECK_THAT">
+      <failure message="v, UnorderedEquals(empty)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( v, UnorderedEquals(empty) )
+with expansion:
+  { 1, 2, 3 } UnorderedEquals: {  }
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="{  } UnorderedEquals: { 1, 2, 3 }" type="CHECK_THAT">
+      <failure message="empty, UnorderedEquals(v)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( empty, UnorderedEquals(v) )
+with expansion:
+  {  } UnorderedEquals: { 1, 2, 3 }
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="{ 1, 3 } UnorderedEquals: { 1, 2, 3 }" type="CHECK_THAT">
+      <failure message="permuted, UnorderedEquals(v)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( permuted, UnorderedEquals(v) )
+with expansion:
+  { 1, 3 } UnorderedEquals: { 1, 2, 3 }
 Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="{ 3, 1 } UnorderedEquals: { 1, 2, 3 }" type="CHECK_THAT">
+      <failure message="permuted, UnorderedEquals(v)" type="CHECK_THAT">
+FAILED:
+  CHECK_THAT( permuted, UnorderedEquals(v) )
+with expansion:
+  { 3, 1 } UnorderedEquals: { 1, 2, 3 }
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="When checked exceptions are thrown they can be expected or unexpected" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="When unchecked exceptions are thrown directly they are always failures" time="{duration}">
       <error type="TEST_CASE">
+FAILED:
 unexpected exception
 Exception.tests.cpp:<line number>
       </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="When unchecked exceptions are thrown during a CHECK the test should continue" time="{duration}">
       <error message="thisThrows() == 0" type="CHECK">
+FAILED:
+  CHECK( thisThrows() == 0 )
 expected exception
 Exception.tests.cpp:<line number>
       </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="When unchecked exceptions are thrown during a REQUIRE the test should abort fail" time="{duration}">
       <error message="thisThrows() == 0" type="REQUIRE">
+FAILED:
+  REQUIRE( thisThrows() == 0 )
 expected exception
 Exception.tests.cpp:<line number>
       </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="When unchecked exceptions are thrown from functions they are always failures" time="{duration}">
       <error message="thisThrows() == 0" type="CHECK">
+FAILED:
+  CHECK( thisThrows() == 0 )
 expected exception
 Exception.tests.cpp:<line number>
       </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="When unchecked exceptions are thrown from sections they are always failures/section name" time="{duration}">
       <error type="TEST_CASE">
+FAILED:
 unexpected exception
 Exception.tests.cpp:<line number>
       </error>
@@ -968,19 +1413,35 @@ Exception.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="boolean member" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="checkedElse" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="checkedElse, failing" time="{duration}">
-      <failure message="false" type="CHECKED_ELSE">
+      <failure message="flag" type="CHECKED_ELSE">
+FAILED:
+  CHECKED_ELSE( flag )
+with expansion:
+  false
 Misc.tests.cpp:<line number>
       </failure>
-      <failure message="false" type="REQUIRE">
+      <failure message="testCheckedElse( false )" type="REQUIRE">
+FAILED:
+  REQUIRE( testCheckedElse( false ) )
+with expansion:
+  false
 Misc.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="checkedIf" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="checkedIf, failing" time="{duration}">
-      <failure message="false" type="CHECKED_IF">
+      <failure message="flag" type="CHECKED_IF">
+FAILED:
+  CHECKED_IF( flag )
+with expansion:
+  false
 Misc.tests.cpp:<line number>
       </failure>
-      <failure message="false" type="REQUIRE">
+      <failure message="testCheckedIf( false )" type="REQUIRE">
+FAILED:
+  REQUIRE( testCheckedIf( false ) )
+with expansion:
+  false
 Misc.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -991,24 +1452,34 @@ Misc.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="even more nested SECTION tests/f (leaf)" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="just failure" time="{duration}">
       <failure type="FAIL">
+FAILED:
 Previous info should not be seen
 Message.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="just failure after unscoped info" time="{duration}">
       <failure type="FAIL">
+FAILED:
 previous unscoped info SHOULD not be seen
 Message.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="long long" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="looped SECTION tests/b is currently: 0" time="{duration}">
-      <failure message="0 > 1" type="CHECK">
+      <failure message="b > a" type="CHECK">
+FAILED:
+  CHECK( b > a )
+with expansion:
+  0 > 1
 Misc.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="looped SECTION tests/b is currently: 1" time="{duration}">
-      <failure message="1 > 1" type="CHECK">
+      <failure message="b > a" type="CHECK">
+FAILED:
+  CHECK( b > a )
+with expansion:
+  1 > 1
 Misc.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -1021,34 +1492,62 @@ Misc.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="looped SECTION tests/b is currently: 8" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="looped SECTION tests/b is currently: 9" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="looped tests" time="{duration}">
-      <failure message="1 == 0" type="CHECK">
+      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
+FAILED:
+  CHECK( ( fib[i] % 2 ) == 0 )
+with expansion:
+  1 == 0
 Testing if fib[0] (1) is even
 Misc.tests.cpp:<line number>
       </failure>
-      <failure message="1 == 0" type="CHECK">
+      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
+FAILED:
+  CHECK( ( fib[i] % 2 ) == 0 )
+with expansion:
+  1 == 0
 Testing if fib[1] (1) is even
 Misc.tests.cpp:<line number>
       </failure>
-      <failure message="1 == 0" type="CHECK">
+      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
+FAILED:
+  CHECK( ( fib[i] % 2 ) == 0 )
+with expansion:
+  1 == 0
 Testing if fib[3] (3) is even
 Misc.tests.cpp:<line number>
       </failure>
-      <failure message="1 == 0" type="CHECK">
+      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
+FAILED:
+  CHECK( ( fib[i] % 2 ) == 0 )
+with expansion:
+  1 == 0
 Testing if fib[4] (5) is even
 Misc.tests.cpp:<line number>
       </failure>
-      <failure message="1 == 0" type="CHECK">
+      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
+FAILED:
+  CHECK( ( fib[i] % 2 ) == 0 )
+with expansion:
+  1 == 0
 Testing if fib[6] (13) is even
 Misc.tests.cpp:<line number>
       </failure>
-      <failure message="1 == 0" type="CHECK">
+      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
+FAILED:
+  CHECK( ( fib[i] % 2 ) == 0 )
+with expansion:
+  1 == 0
 Testing if fib[7] (21) is even
 Misc.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="mix info, unscoped info and warning" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="more nested SECTION tests/equal/doesn't equal" time="{duration}">
-      <failure message="1 == 2" type="REQUIRE">
+      <failure message="a == b" type="REQUIRE">
+FAILED:
+  REQUIRE( a == b )
+with expansion:
+  1 == 2
 Misc.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -1061,6 +1560,8 @@ Misc.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="not allowed" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="not prints unscoped info from previous failures" time="{duration}">
       <failure message="false" type="REQUIRE">
+FAILED:
+  REQUIRE( false )
 this SHOULD be seen
 Message.tests.cpp:<line number>
       </failure>
@@ -1075,6 +1576,8 @@ Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="print unscoped info if passing unscoped info is printed" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="prints unscoped info on failure" time="{duration}">
       <failure message="false" type="REQUIRE">
+FAILED:
+  REQUIRE( false )
 this SHOULD be seen
 this SHOULD also be seen
 Message.tests.cpp:<line number>
@@ -1082,6 +1585,8 @@ Message.tests.cpp:<line number>
     </testcase>
     <testcase classname="<exe-name>.global" name="prints unscoped info only for the first assertion" time="{duration}">
       <failure message="false" type="CHECK">
+FAILED:
+  CHECK( false )
 this SHOULD be seen only ONCE
 Message.tests.cpp:<line number>
       </failure>
@@ -1097,12 +1602,16 @@ Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="replaceInPlace/escape '" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="send a single char to INFO" time="{duration}">
       <failure message="false" type="REQUIRE">
+FAILED:
+  REQUIRE( false )
 3
 Misc.tests.cpp:<line number>
       </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="sends information to INFO" time="{duration}">
       <failure message="false" type="REQUIRE">
+FAILED:
+  REQUIRE( false )
 hi
 i := 7
 Message.tests.cpp:<line number>
@@ -1112,6 +1621,8 @@ Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="splitString" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="stacks unscoped info in loops" time="{duration}">
       <failure message="false" type="CHECK">
+FAILED:
+  CHECK( false )
 Count 1 to 3...
 1
 2
@@ -1119,6 +1630,8 @@ Count 1 to 3...
 Message.tests.cpp:<line number>
       </failure>
       <failure message="false" type="CHECK">
+FAILED:
+  CHECK( false )
 Count 4 to 6...
 4
 5
@@ -1136,7 +1649,11 @@ Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="std::set is convertible string/several items" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="std::vector&lt;std::pair&lt;std::string,int> > -> toString" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="string literals of different sizes can be compared" time="{duration}">
-      <failure message="&quot;first&quot; == &quot;second&quot;" type="REQUIRE">
+      <failure message="std::string( &quot;first&quot; ) == &quot;second&quot;" type="REQUIRE">
+FAILED:
+  REQUIRE( std::string( "first" ) == "second" )
+with expansion:
+  "first" == "second"
 Tricky.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -1153,6 +1670,7 @@ Tricky.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="tables" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="thrown std::strings are translated" time="{duration}">
       <error type="TEST_CASE">
+FAILED:
 Why would you throw a std::string?
 Exception.tests.cpp:<line number>
       </error>


### PR DESCRIPTION
The JUnit report is improved in that:
* The message shows the testing condition, not the result
* The actual message has similar output than the console one

My reason is that using catch2 with junit reporter in a gitlab testing environment, failures report next to nothing, just the line where the failure happened. So i modified the output to be similar to the console one.
I think this also addresses #1347