### PR TITLE
Rename template parameter names to avoid name conflict on Solaris.

### DIFF
--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -44,9 +44,9 @@ namespace Catch {
 
         template<typename T>
         class IsStreamInsertable {
-            template<typename SS, typename TT>
+            template<typename Stream, typename U>
             static auto test(int)
-                -> decltype(std::declval<SS&>() << std::declval<TT>(), std::true_type());
+                -> decltype(std::declval<Stream&>() << std::declval<U>(), std::true_type());
 
             template<typename, typename>
             static auto test(...)->std::false_type;


### PR DESCRIPTION
Closes #1722

This PR fixes a compilation issue on Solaris 11.4 with GCC 7.3.0 on the latest Catch2 master branch. A #define in the Solaris 11.4 <sys/regset.h> header conflicts with a template parameter name used in catch_tostring.h and it gets renamed to an integer constant. This causes an obvious compilation issue. Please refer to the issue for more details about the bug.

The bug is simply fixed by re-naming the 'SS' template parameter name to something more descriptive like 'Stream'. I also took the liberty of renaming the template parameter name 'TT' to 'U' because I saw the template parameter name 'U' used throughout the codebase and couldn't find any other "same double letter" names used.

After making this change, I can confirm that Catch2 compiles and builds with the main.cpp file detailed in the issue, with a non-trivial project and with the Catch2 SelfTest target on Solaris 11.4.