### PR TITLE
Small updates to include directives

### DIFF
--- a/include/internal/catch_interfaces_config.cpp
+++ b/include/internal/catch_interfaces_config.cpp
@@ -1,4 +1,4 @@
-#include "internal/catch_interfaces_config.h"
+#include "catch_interfaces_config.h"
 
 namespace Catch {
     IConfig::~IConfig() = default;

--- a/include/internal/catch_interfaces_exception.cpp
+++ b/include/internal/catch_interfaces_exception.cpp
@@ -1,4 +1,4 @@
-#include "internal/catch_interfaces_exception.h"
+#include "catch_interfaces_exception.h"
 
 namespace Catch {
     IExceptionTranslator::~IExceptionTranslator() = default;

--- a/include/internal/catch_interfaces_registry_hub.cpp
+++ b/include/internal/catch_interfaces_registry_hub.cpp
@@ -1,4 +1,4 @@
-#include "internal/catch_interfaces_registry_hub.h"
+#include "catch_interfaces_registry_hub.h"
 
 namespace Catch {
     IRegistryHub::~IRegistryHub() = default;

--- a/include/internal/catch_interfaces_runner.cpp
+++ b/include/internal/catch_interfaces_runner.cpp
@@ -1,4 +1,4 @@
-#include "internal/catch_interfaces_runner.h"
+#include "catch_interfaces_runner.h"
 
 namespace Catch {
     IRunner::~IRunner() = default;

--- a/include/internal/catch_interfaces_testcase.cpp
+++ b/include/internal/catch_interfaces_testcase.cpp
@@ -1,4 +1,4 @@
-#include "internal/catch_interfaces_testcase.h"
+#include "catch_interfaces_testcase.h"
 
 namespace Catch {
     ITestInvoker::~ITestInvoker() = default;

--- a/include/reporters/catch_reporter_compact.cpp
+++ b/include/reporters/catch_reporter_compact.cpp
@@ -8,7 +8,7 @@
 #include "catch_reporter_compact.h"
 
 #include "../internal/catch_reporter_registrars.hpp"
-#include "internal/catch_console_colour.h"
+#include "../internal/catch_console_colour.h"
 
 namespace {
 

--- a/include/reporters/catch_reporter_console.cpp
+++ b/include/reporters/catch_reporter_console.cpp
@@ -9,7 +9,7 @@
 #include "catch_reporter_console.h"
 
 #include "../internal/catch_reporter_registrars.hpp"
-#include "internal/catch_console_colour.h"
+#include "../internal/catch_console_colour.h"
 #include "../internal/catch_version.h"
 #include "../internal/catch_text.h"
 #include "../internal/catch_stringref.h"


### PR DESCRIPTION
## Description
Updated some include directives to improve consistency and add more flexibility when integrating Catch2 with regard to include directories (e.g., allows setting the root as include directory).