### PR TITLE
approvalTests.py incorrect substitution of macros

### DIFF
--- a/include/internal/catch_context.cpp
+++ b/include/internal/catch_context.cpp
@@ -7,7 +7,7 @@
  */
 #include "catch_context.h"
 #include "catch_common.h"
-
+#include "catch_interfaces_config.h"
 namespace Catch {
 
     class Context : public IMutableContext, NonCopyable {
@@ -35,14 +35,18 @@ namespace Catch {
         }
         void setConfig( IConfigPtr const& config ) override {
             m_config = config;
+            m_rand.seed(m_config->rngSeed());
         }
-
+        std::minstd_rand& getRandomGenerator() override {
+            return m_rand;
+	      }
         friend IMutableContext& getCurrentMutableContext();
 
     private:
         IConfigPtr m_config;
         IRunner* m_runner = nullptr;
         IResultCapture* m_resultCapture = nullptr;
+        std::minstd_rand m_rand;
     };
 
     IMutableContext *IMutableContext::currentContext = nullptr;

--- a/include/internal/catch_context.cpp
+++ b/include/internal/catch_context.cpp
@@ -39,7 +39,7 @@ namespace Catch {
         }
         std::minstd_rand& getRandomGenerator() override {
             return m_rand;
-	      }
+	}
         friend IMutableContext& getCurrentMutableContext();
 
     private:

--- a/include/internal/catch_context.h
+++ b/include/internal/catch_context.h
@@ -7,7 +7,7 @@
  */
 #ifndef TWOBLUECUBES_CATCH_CONTEXT_H_INCLUDED
 #define TWOBLUECUBES_CATCH_CONTEXT_H_INCLUDED
-
+#include <random>
 #include <memory>
 
 namespace Catch {
@@ -26,6 +26,7 @@ namespace Catch {
         virtual IResultCapture* getResultCapture() = 0;
         virtual IRunner* getRunner() = 0;
         virtual IConfigPtr const& getConfig() const = 0;
+        virtual std::minstd_rand& getRandomGenerator()= 0;
     };
 
     struct IMutableContext : IContext

--- a/include/internal/catch_generators_specific.hpp
+++ b/include/internal/catch_generators_specific.hpp
@@ -19,13 +19,13 @@ namespace Generators {
 template <typename Float>
 class RandomFloatingGenerator final : public IGenerator<Float> {
     // FIXME: What is the right seed?
-    std::minstd_rand m_rand;
+    std::minstd_rand &m_rand;
     std::uniform_real_distribution<Float> m_dist;
     Float m_current_number;
 public:
 
     RandomFloatingGenerator(Float a, Float b):
-        m_rand(getCurrentContext().getConfig()->rngSeed()),
+        m_rand(getCurrentContext().getRandomGenerator()),
         m_dist(a, b) {
         static_cast<void>(next());
     }
@@ -41,13 +41,13 @@ public:
 
 template <typename Integer>
 class RandomIntegerGenerator final : public IGenerator<Integer> {
-    std::minstd_rand m_rand;
+    std::minstd_rand &m_rand;
     std::uniform_int_distribution<Integer> m_dist;
     Integer m_current_number;
 public:
 
     RandomIntegerGenerator(Integer a, Integer b):
-        m_rand(getCurrentContext().getConfig()->rngSeed()),
+        m_rand(getCurrentContext().getRandomGenerator()),
         m_dist(a, b) {
         static_cast<void>(next());
     }


### PR DESCRIPTION
When compiling SelfTest with MinGW32 on Windows, ApprovalTests fails due to a mismatch between the regular expressions and how NAN and INFINITY expand in this particular compiler.
I decided to change the code a bit to correct this problem