### PR TITLE
Enable variadic macros support for MSVS 2005 as it has them

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -163,7 +163,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Use variadic macros if the compiler supports them
-#if ( defined _MSC_VER && _MSC_VER > 1400 && !defined __EDGE__) || \
+#if ( defined _MSC_VER && _MSC_VER >= 1400 && !defined __EDGE__) || \
     ( defined __WAVE__ && __WAVE_HAS_VARIADICS ) || \
     ( defined __GNUC__ && __GNUC__ >= 3 ) || \
     ( !defined __cplusplus && __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L )


### PR DESCRIPTION
Fix the test for MSVC version: variadic macros support is available
since MSVS 2005, a.k.a. MSVC 8, using _MSC_VER=1400.

---

I know nobody cares about this ancient compiler any more, but unfortunately I still have to build some projects using it, and I'd still like to use CATCH with it and it does support variadic macros.