### PR TITLE
Suppress false positive from clang-analyzer

### DIFF
--- a/include/internal/catch_context.h
+++ b/include/internal/catch_context.h
@@ -46,6 +46,7 @@ namespace Catch {
     {
         if( !IMutableContext::currentContext )
             IMutableContext::createContext();
+        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
         return *IMutableContext::currentContext;
     }
 


### PR DESCRIPTION
Fixes issue #1230

## Description
Suppress a false positive warning from the Clang static analysis tools which thought that a null reference was potentially being returned here.