### PR TITLE
SonarQube Generic Execution Test Data reporter

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,6 +14,7 @@ coverage:
     - "**/catch_reporter_tap.hpp"
     - "**/catch_reporter_automake.hpp"
     - "**/catch_reporter_teamcity.hpp"
+    - "**/catch_reporter_sonarqube.hpp"
     - "**/external/clara.hpp"
 
 

--- a/docs/ci-and-misc.md
+++ b/docs/ci-and-misc.md
@@ -12,7 +12,7 @@ Build Systems may refer to low-level tools, like CMake, or larger systems that r
 
 ## Continuous Integration systems
 
-Probably the most important aspect to using Catch with a build server is the use of different reporters. Catch comes bundled with three reporters that should cover the majority of build servers out there - although adding more for better integration with some is always a possibility (currently we also offer TeamCity, TAP and Automake reporters).
+Probably the most important aspect to using Catch with a build server is the use of different reporters. Catch comes bundled with three reporters that should cover the majority of build servers out there - although adding more for better integration with some is always a possibility (currently we also offer TeamCity, TAP, Automake and SonarQube reporters).
 
 Two of these reporters are built in (XML and JUnit) and the third (TeamCity) is included as a separate header. It's possible that the other two may be split out in the future too - as that would make the core of Catch smaller for those that don't need them.
 
@@ -64,6 +64,10 @@ The Automake Reporter writes out the [meta tags](https://www.gnu.org/software/au
 ```-r tap```
 
 Because of the incremental nature of Catch's test suites and ability to run specific tests, our implementation of TAP reporter writes out the number of tests in a suite last.
+
+### SonarQube Reporter
+```-r sonarqube```
+[SonarQube Generic Test Data](https://docs.sonarqube.org/latest/analysis/generic-test/) XML format for tests metrics.
 
 ## Low-level tools
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -42,8 +42,8 @@ Tag version and release title should be same as the new version,
 description should contain the release notes for the current release.
 Single header version of `catch.hpp` *needs* to be attached as a binary,
 as that is where the official download link links to. Preferably
-it should use linux line endings. All non-bundled reporters (Automake,
-TAP, TeamCity) should also be attached as binaries, as they might be
+it should use linux line endings. All non-bundled reporters (Automake, TAP,
+TeamCity, SonarQube) should also be attached as binaries, as they might be
 dependent on a specific version of the single-include header.
 
 Since 2.5.0, the release tag and the "binaries" (headers) should be PGP

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -29,6 +29,7 @@ Do this in one source file - the same one you have `CATCH_CONFIG_MAIN` or `CATCH
 Use this when building as part of a TeamCity build to see results as they happen ([code example](../examples/207-Rpt-TeamCityReporter.cpp)).
 * `tap` writes in the TAP ([Test Anything Protocol](https://en.wikipedia.org/wiki/Test_Anything_Protocol)) format.
 * `automake` writes in a format that correspond to [automake  .trs](https://www.gnu.org/software/automake/manual/html_node/Log-files-generation-and-test-results-recording.html) files
+* `sonarqube` writes the [SonarQube Generic Test Data](https://docs.sonarqube.org/latest/analysis/generic-test/) XML format.
 
 You see what reporters are available from the command line by running with `--list-reporters`.
 

--- a/include/reporters/catch_reporter_sonarqube.hpp
+++ b/include/reporters/catch_reporter_sonarqube.hpp
@@ -1,0 +1,181 @@
+/*
+ *  Created by Daniel Garcia on 2018-12-04.
+ *  Copyright Social Point SL. All rights reserved.
+ *
+ *  Distributed under the Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+#ifndef CATCH_REPORTER_SONARQUBE_HPP_INCLUDED
+#define CATCH_REPORTER_SONARQUBE_HPP_INCLUDED
+
+
+// Don't #include any Catch headers here - we can assume they are already
+// included before this header.
+// This is not good practice in general but is necessary in this case so this
+// file can be distributed as a single header that works with the main
+// Catch single header.
+
+#include <map>
+
+namespace Catch {
+
+    struct SonarQubeReporter : CumulativeReporterBase<SonarQubeReporter> {
+
+        SonarQubeReporter(ReporterConfig const& config)
+        : CumulativeReporterBase(config)
+        , xml(config.stream()) {
+            m_reporterPrefs.shouldRedirectStdOut = true;
+            m_reporterPrefs.shouldReportAllAssertions = true;
+        }
+
+        ~SonarQubeReporter() override;
+
+        static std::string getDescription() {
+            return "Reports test results in the Generic Test Data SonarQube XML format";
+        }
+
+        static std::set<Verbosity> getSupportedVerbosities() {
+            return { Verbosity::Normal };
+        }
+
+        void noMatchingTestCases(std::string const& /*spec*/) override {}
+
+        void testRunStarting(TestRunInfo const& testRunInfo) override {
+            CumulativeReporterBase::testRunStarting(testRunInfo);
+            xml.startElement("testExecutions");
+            xml.writeAttribute("version", "1");
+        }
+
+        void testGroupEnded(TestGroupStats const& testGroupStats) override {
+            CumulativeReporterBase::testGroupEnded(testGroupStats);
+            writeGroup(*m_testGroups.back());
+        }
+
+        void testRunEndedCumulative() override {
+            xml.endElement();
+        }
+
+        void writeGroup(TestGroupNode const& groupNode) {
+            std::map<std::string, TestGroupNode::ChildNodes> testsPerFile;
+            for(auto const& child : groupNode.children)
+                testsPerFile[child->value.testInfo.lineInfo.file].push_back(child);
+
+            for(auto const& kv : testsPerFile)
+                writeTestFile(kv.first.c_str(), kv.second);
+        }
+
+        void writeTestFile(const char* filename, TestGroupNode::ChildNodes const& testCaseNodes) {
+            XmlWriter::ScopedElement e = xml.scopedElement("file");
+            xml.writeAttribute("path", filename);
+
+            for(auto const& child : testCaseNodes)
+                writeTestCase(*child);
+        }
+
+        void writeTestCase(TestCaseNode const& testCaseNode) {
+            // All test cases have exactly one section - which represents the
+            // test case itself. That section may have 0-n nested sections
+            assert(testCaseNode.children.size() == 1);
+            SectionNode const& rootSection = *testCaseNode.children.front();
+            writeSection("", rootSection, testCaseNode.value.testInfo.okToFail());
+        }
+
+        void writeSection(std::string const& rootName, SectionNode const& sectionNode, bool okToFail) {
+            std::string name = trim(sectionNode.stats.sectionInfo.name);
+            if(!rootName.empty())
+                name = rootName + '/' + name;
+
+            if(!sectionNode.assertions.empty() || !sectionNode.stdOut.empty() || !sectionNode.stdErr.empty()) {
+                XmlWriter::ScopedElement e = xml.scopedElement("testCase");
+                xml.writeAttribute("name", name);
+                xml.writeAttribute("duration", static_cast<long>(sectionNode.stats.durationInSeconds * 1000));
+
+                writeAssertions(sectionNode, okToFail);
+            }
+
+            for(auto const& childNode : sectionNode.childSections)
+                writeSection(name, *childNode, okToFail);
+        }
+
+        void writeAssertions(SectionNode const& sectionNode, bool okToFail) {
+            for(auto const& assertion : sectionNode.assertions)
+                writeAssertion( assertion, okToFail);
+        }
+
+        void writeAssertion(AssertionStats const& stats, bool okToFail) {
+            AssertionResult const& result = stats.assertionResult;
+            if(!result.isOk()) {
+                std::string elementName;
+                if(okToFail) {
+                    elementName = "skipped";
+                }
+                else {
+                    switch(result.getResultType()) {
+                        case ResultWas::ThrewException:
+                        case ResultWas::FatalErrorCondition:
+                            elementName = "error";
+                            break;
+                        case ResultWas::ExplicitFailure:
+                            elementName = "failure";
+                            break;
+                        case ResultWas::ExpressionFailed:
+                            elementName = "failure";
+                            break;
+                        case ResultWas::DidntThrowException:
+                            elementName = "failure";
+                            break;
+
+                            // We should never see these here:
+                        case ResultWas::Info:
+                        case ResultWas::Warning:
+                        case ResultWas::Ok:
+                        case ResultWas::Unknown:
+                        case ResultWas::FailureBit:
+                        case ResultWas::Exception:
+                            elementName = "internalError";
+                            break;
+                    }
+                }
+
+                XmlWriter::ScopedElement e = xml.scopedElement(elementName);
+
+                ReusableStringStream messageRss;
+                messageRss << result.getTestMacroName() << "(" << result.getExpression() << ")";
+                xml.writeAttribute("message", messageRss.str());
+
+                ReusableStringStream textRss;
+                if (stats.totals.assertions.total() > 0) {
+                    textRss << "FAILED:\n";
+                    if (result.hasExpression()) {
+                        textRss << "\t" << result.getExpressionInMacro() << "\n";
+                    }
+                    if (result.hasExpandedExpression()) {
+                        textRss << "with expansion:\n\t" << result.getExpandedExpression() << "\n";
+                    }
+                }
+
+                if(!result.getMessage().empty())
+                    textRss << result.getMessage() << "\n";
+
+                for(auto const& msg : stats.infoMessages)
+                    if(msg.type == ResultWas::Info)
+                        textRss << msg.message << "\n";
+
+                textRss << "at " << result.getSourceInfo();
+                xml.writeText(textRss.str(), false);
+            }
+        }
+
+    private:
+        XmlWriter xml;
+    };
+
+#ifdef CATCH_IMPL
+    SonarQubeReporter::~SonarQubeReporter() {}
+#endif
+
+    CATCH_REGISTER_REPORTER( "sonarqube", SonarQubeReporter )
+
+} // end namespace Catch
+
+#endif // CATCH_REPORTER_SONARQUBE_HPP_INCLUDED

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -278,6 +278,7 @@ set(REPORTER_HEADERS
         ${HEADER_DIR}/reporters/catch_reporter_tap.hpp
         ${HEADER_DIR}/reporters/catch_reporter_teamcity.hpp
         ${HEADER_DIR}/reporters/catch_reporter_xml.h
+        ${HEADER_DIR}/reporters/catch_reporter_sonarqube.hpp
         )
 set(REPORTER_SOURCES
         ${HEADER_DIR}/reporters/catch_reporter_bases.cpp

--- a/projects/SelfTest/Baselines/sonarqube.sw.approved.txt
+++ b/projects/SelfTest/Baselines/sonarqube.sw.approved.txt
@@ -2,187 +2,187 @@
 <testExecutions version="1"loose text artifact
 >
   <file path="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp">
-    <testCase name="Parse test names and tags/Empty test spec should have no filters" duration="0"/>
-    <testCase name="Parse test names and tags/Test spec from empty string should have no filters" duration="0"/>
-    <testCase name="Parse test names and tags/Test spec from just a comma should have no filters" duration="0"/>
-    <testCase name="Parse test names and tags/Test spec from name should have one filter" duration="0"/>
-    <testCase name="Parse test names and tags/Test spec from quoted name should have one filter" duration="0"/>
-    <testCase name="Parse test names and tags/Test spec from name should have one filter" duration="0"/>
-    <testCase name="Parse test names and tags/Wildcard at the start" duration="0"/>
-    <testCase name="Parse test names and tags/Wildcard at the end" duration="0"/>
-    <testCase name="Parse test names and tags/Wildcard at both ends" duration="0"/>
-    <testCase name="Parse test names and tags/Redundant wildcard at the start" duration="0"/>
-    <testCase name="Parse test names and tags/Redundant wildcard at the end" duration="0"/>
-    <testCase name="Parse test names and tags/Redundant wildcard at both ends" duration="0"/>
-    <testCase name="Parse test names and tags/Wildcard at both ends, redundant at start" duration="0"/>
-    <testCase name="Parse test names and tags/Just wildcard" duration="0"/>
-    <testCase name="Parse test names and tags/Single tag" duration="0"/>
-    <testCase name="Parse test names and tags/Single tag, two matches" duration="0"/>
-    <testCase name="Parse test names and tags/Two tags" duration="0"/>
-    <testCase name="Parse test names and tags/Two tags, spare separated" duration="0"/>
-    <testCase name="Parse test names and tags/Wildcarded name and tag" duration="0"/>
-    <testCase name="Parse test names and tags/Single tag exclusion" duration="0"/>
-    <testCase name="Parse test names and tags/One tag exclusion and one tag inclusion" duration="0"/>
-    <testCase name="Parse test names and tags/One tag exclusion and one wldcarded name inclusion" duration="0"/>
-    <testCase name="Parse test names and tags/One tag exclusion, using exclude:, and one wldcarded name inclusion" duration="0"/>
-    <testCase name="Parse test names and tags/name exclusion" duration="0"/>
-    <testCase name="Parse test names and tags/wildcarded name exclusion" duration="0"/>
-    <testCase name="Parse test names and tags/wildcarded name exclusion with tag inclusion" duration="0"/>
-    <testCase name="Parse test names and tags/wildcarded name exclusion, using exclude:, with tag inclusion" duration="0"/>
-    <testCase name="Parse test names and tags/two wildcarded names" duration="0"/>
-    <testCase name="Parse test names and tags/empty tag" duration="0"/>
-    <testCase name="Parse test names and tags/empty quoted name" duration="0"/>
-    <testCase name="Parse test names and tags/quoted string followed by tag exclusion" duration="0"/>
-    <testCase name="Process can be configured on command line/empty args don't cause a crash" duration="0"/>
-    <testCase name="Process can be configured on command line/default - no arguments" duration="0"/>
-    <testCase name="Process can be configured on command line/test lists/Specify one test case using" duration="0"/>
-    <testCase name="Process can be configured on command line/test lists/Specify one test case exclusion using exclude:" duration="0"/>
-    <testCase name="Process can be configured on command line/test lists/Specify one test case exclusion using ~" duration="0"/>
-    <testCase name="Process can be configured on command line/reporter/-r/console" duration="0"/>
-    <testCase name="Process can be configured on command line/reporter/-r/xml" duration="0"/>
-    <testCase name="Process can be configured on command line/reporter/--reporter/junit" duration="0"/>
-    <testCase name="Process can be configured on command line/reporter/Only one reporter is accepted" duration="0"/>
-    <testCase name="Process can be configured on command line/reporter/must match one of the available ones" duration="0"/>
-    <testCase name="Process can be configured on command line/debugger/-b" duration="0"/>
-    <testCase name="Process can be configured on command line/debugger/--break" duration="0"/>
-    <testCase name="Process can be configured on command line/abort/-a aborts after first failure" duration="0"/>
-    <testCase name="Process can be configured on command line/abort/-x 2 aborts after two failures" duration="0"/>
-    <testCase name="Process can be configured on command line/abort/-x must be numeric" duration="0"/>
-    <testCase name="Process can be configured on command line/nothrow/-e" duration="0"/>
-    <testCase name="Process can be configured on command line/nothrow/--nothrow" duration="0"/>
-    <testCase name="Process can be configured on command line/output filename/-o filename" duration="0"/>
-    <testCase name="Process can be configured on command line/output filename/--out" duration="0"/>
-    <testCase name="Process can be configured on command line/combinations/Single character flags can be combined" duration="0"/>
-    <testCase name="Process can be configured on command line/use-colour/without option" duration="0"/>
-    <testCase name="Process can be configured on command line/use-colour/auto" duration="0"/>
-    <testCase name="Process can be configured on command line/use-colour/yes" duration="0"/>
-    <testCase name="Process can be configured on command line/use-colour/no" duration="0"/>
-    <testCase name="Process can be configured on command line/use-colour/error" duration="0"/>
-    <testCase name="Process can be configured on command line/Benchmark options/samples" duration="0"/>
-    <testCase name="Process can be configured on command line/Benchmark options/resamples" duration="0"/>
-    <testCase name="Process can be configured on command line/Benchmark options/resamples" duration="0"/>
-    <testCase name="Process can be configured on command line/Benchmark options/resamples" duration="0"/>
+    <testCase name="Parse test names and tags/Empty test spec should have no filters" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Test spec from empty string should have no filters" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Test spec from just a comma should have no filters" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Test spec from name should have one filter" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Test spec from quoted name should have one filter" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Test spec from name should have one filter" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Wildcard at the start" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Wildcard at the end" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Wildcard at both ends" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Redundant wildcard at the start" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Redundant wildcard at the end" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Redundant wildcard at both ends" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Wildcard at both ends, redundant at start" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Just wildcard" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Single tag" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Single tag, two matches" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Two tags" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Two tags, spare separated" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Wildcarded name and tag" duration="{duration}"/>
+    <testCase name="Parse test names and tags/Single tag exclusion" duration="{duration}"/>
+    <testCase name="Parse test names and tags/One tag exclusion and one tag inclusion" duration="{duration}"/>
+    <testCase name="Parse test names and tags/One tag exclusion and one wldcarded name inclusion" duration="{duration}"/>
+    <testCase name="Parse test names and tags/One tag exclusion, using exclude:, and one wldcarded name inclusion" duration="{duration}"/>
+    <testCase name="Parse test names and tags/name exclusion" duration="{duration}"/>
+    <testCase name="Parse test names and tags/wildcarded name exclusion" duration="{duration}"/>
+    <testCase name="Parse test names and tags/wildcarded name exclusion with tag inclusion" duration="{duration}"/>
+    <testCase name="Parse test names and tags/wildcarded name exclusion, using exclude:, with tag inclusion" duration="{duration}"/>
+    <testCase name="Parse test names and tags/two wildcarded names" duration="{duration}"/>
+    <testCase name="Parse test names and tags/empty tag" duration="{duration}"/>
+    <testCase name="Parse test names and tags/empty quoted name" duration="{duration}"/>
+    <testCase name="Parse test names and tags/quoted string followed by tag exclusion" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/empty args don't cause a crash" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/default - no arguments" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/test lists/Specify one test case using" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/test lists/Specify one test case exclusion using exclude:" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/test lists/Specify one test case exclusion using ~" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/reporter/-r/console" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/reporter/-r/xml" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/reporter/--reporter/junit" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/reporter/Only one reporter is accepted" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/reporter/must match one of the available ones" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/debugger/-b" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/debugger/--break" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/abort/-a aborts after first failure" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/abort/-x 2 aborts after two failures" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/abort/-x must be numeric" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/nothrow/-e" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/nothrow/--nothrow" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/output filename/-o filename" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/output filename/--out" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/combinations/Single character flags can be combined" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/use-colour/without option" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/use-colour/auto" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/use-colour/yes" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/use-colour/no" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/use-colour/error" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/Benchmark options/samples" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/Benchmark options/resamples" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/Benchmark options/resamples" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/Benchmark options/resamples" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp">
-    <testCase name="Generators internals/Single value" duration="0"/>
-    <testCase name="Generators internals/Preset values" duration="0"/>
-    <testCase name="Generators internals/Generator combinator" duration="0"/>
-    <testCase name="Generators internals/Explicitly typed generator sequence" duration="0"/>
-    <testCase name="Generators internals/Filter generator" duration="0"/>
-    <testCase name="Generators internals/Take generator/Take less" duration="0"/>
-    <testCase name="Generators internals/Take generator/Take more" duration="0"/>
-    <testCase name="Generators internals/Map with explicit return type" duration="0"/>
-    <testCase name="Generators internals/Map with deduced return type" duration="0"/>
-    <testCase name="Generators internals/Repeat/Singular repeat" duration="0"/>
-    <testCase name="Generators internals/Repeat/Actual repeat" duration="0"/>
-    <testCase name="Generators internals/Range/Positive auto step/Integer" duration="0"/>
-    <testCase name="Generators internals/Range/Negative auto step/Integer" duration="0"/>
-    <testCase name="Generators internals/Range/Positive manual step/Integer/Exact" duration="0"/>
-    <testCase name="Generators internals/Range/Positive manual step/Integer/Slightly over end" duration="0"/>
-    <testCase name="Generators internals/Range/Positive manual step/Integer/Slightly under end" duration="0"/>
-    <testCase name="Generators internals/Range/Negative manual step/Integer/Exact" duration="0"/>
-    <testCase name="Generators internals/Range/Negative manual step/Integer/Slightly over end" duration="0"/>
-    <testCase name="Generators internals/Range/Negative manual step/Integer/Slightly under end" duration="0"/>
+    <testCase name="Generators internals/Single value" duration="{duration}"/>
+    <testCase name="Generators internals/Preset values" duration="{duration}"/>
+    <testCase name="Generators internals/Generator combinator" duration="{duration}"/>
+    <testCase name="Generators internals/Explicitly typed generator sequence" duration="{duration}"/>
+    <testCase name="Generators internals/Filter generator" duration="{duration}"/>
+    <testCase name="Generators internals/Take generator/Take less" duration="{duration}"/>
+    <testCase name="Generators internals/Take generator/Take more" duration="{duration}"/>
+    <testCase name="Generators internals/Map with explicit return type" duration="{duration}"/>
+    <testCase name="Generators internals/Map with deduced return type" duration="{duration}"/>
+    <testCase name="Generators internals/Repeat/Singular repeat" duration="{duration}"/>
+    <testCase name="Generators internals/Repeat/Actual repeat" duration="{duration}"/>
+    <testCase name="Generators internals/Range/Positive auto step/Integer" duration="{duration}"/>
+    <testCase name="Generators internals/Range/Negative auto step/Integer" duration="{duration}"/>
+    <testCase name="Generators internals/Range/Positive manual step/Integer/Exact" duration="{duration}"/>
+    <testCase name="Generators internals/Range/Positive manual step/Integer/Slightly over end" duration="{duration}"/>
+    <testCase name="Generators internals/Range/Positive manual step/Integer/Slightly under end" duration="{duration}"/>
+    <testCase name="Generators internals/Range/Negative manual step/Integer/Exact" duration="{duration}"/>
+    <testCase name="Generators internals/Range/Negative manual step/Integer/Slightly over end" duration="{duration}"/>
+    <testCase name="Generators internals/Range/Negative manual step/Integer/Slightly under end" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/IntrospectiveTests/PartTracker.tests.cpp">
-    <testCase name="Tracker" duration="0"/>
-    <testCase name="Tracker/successfully close one section" duration="0"/>
-    <testCase name="Tracker/fail one section" duration="0"/>
-    <testCase name="Tracker/fail one section/re-enter after failed section" duration="0"/>
-    <testCase name="Tracker/fail one section/re-enter after failed section and find next section" duration="0"/>
-    <testCase name="Tracker/successfully close one section, then find another" duration="0"/>
-    <testCase name="Tracker/successfully close one section, then find another/Re-enter - skips S1 and enters S2" duration="0"/>
-    <testCase name="Tracker/successfully close one section, then find another/Re-enter - skips S1 and enters S2/Successfully close S2" duration="0"/>
-    <testCase name="Tracker/successfully close one section, then find another/Re-enter - skips S1 and enters S2/fail S2" duration="0"/>
-    <testCase name="Tracker/open a nested section" duration="0"/>
+    <testCase name="Tracker" duration="{duration}"/>
+    <testCase name="Tracker/successfully close one section" duration="{duration}"/>
+    <testCase name="Tracker/fail one section" duration="{duration}"/>
+    <testCase name="Tracker/fail one section/re-enter after failed section" duration="{duration}"/>
+    <testCase name="Tracker/fail one section/re-enter after failed section and find next section" duration="{duration}"/>
+    <testCase name="Tracker/successfully close one section, then find another" duration="{duration}"/>
+    <testCase name="Tracker/successfully close one section, then find another/Re-enter - skips S1 and enters S2" duration="{duration}"/>
+    <testCase name="Tracker/successfully close one section, then find another/Re-enter - skips S1 and enters S2/Successfully close S2" duration="{duration}"/>
+    <testCase name="Tracker/successfully close one section, then find another/Re-enter - skips S1 and enters S2/fail S2" duration="{duration}"/>
+    <testCase name="Tracker/open a nested section" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/IntrospectiveTests/String.tests.cpp">
-    <testCase name="StringRef/Empty string" duration="0"/>
-    <testCase name="StringRef/From string literal" duration="0"/>
-    <testCase name="StringRef/From string literal/c_str() does not cause copy" duration="0"/>
-    <testCase name="StringRef/From sub-string" duration="0"/>
-    <testCase name="StringRef/Substrings/zero-based substring" duration="0"/>
-    <testCase name="StringRef/Substrings/c_str() causes copy" duration="0"/>
-    <testCase name="StringRef/Substrings/c_str() causes copy/Self-assignment after substring" duration="0"/>
-    <testCase name="StringRef/Substrings/non-zero-based substring" duration="0"/>
-    <testCase name="StringRef/Substrings/Pointer values of full refs should match" duration="0"/>
-    <testCase name="StringRef/Substrings/Pointer values of substring refs should not match" duration="0"/>
-    <testCase name="StringRef/Comparisons" duration="0"/>
-    <testCase name="StringRef/from std::string/implicitly constructed" duration="0"/>
-    <testCase name="StringRef/from std::string/explicitly constructed" duration="0"/>
-    <testCase name="StringRef/from std::string/assigned" duration="0"/>
-    <testCase name="StringRef/to std::string/implicitly constructed" duration="0"/>
-    <testCase name="StringRef/to std::string/explicitly constructed" duration="0"/>
-    <testCase name="StringRef/to std::string/assigned" duration="0"/>
-    <testCase name="StringRef/Counting utf-8 codepoints" duration="0"/>
-    <testCase name="replaceInPlace/replace single char" duration="0"/>
-    <testCase name="replaceInPlace/replace two chars" duration="0"/>
-    <testCase name="replaceInPlace/replace first char" duration="0"/>
-    <testCase name="replaceInPlace/replace last char" duration="0"/>
-    <testCase name="replaceInPlace/replace all chars" duration="0"/>
-    <testCase name="replaceInPlace/replace no chars" duration="0"/>
-    <testCase name="replaceInPlace/escape '" duration="0"/>
-    <testCase name="splitString" duration="0"/>
+    <testCase name="StringRef/Empty string" duration="{duration}"/>
+    <testCase name="StringRef/From string literal" duration="{duration}"/>
+    <testCase name="StringRef/From string literal/c_str() does not cause copy" duration="{duration}"/>
+    <testCase name="StringRef/From sub-string" duration="{duration}"/>
+    <testCase name="StringRef/Substrings/zero-based substring" duration="{duration}"/>
+    <testCase name="StringRef/Substrings/c_str() causes copy" duration="{duration}"/>
+    <testCase name="StringRef/Substrings/c_str() causes copy/Self-assignment after substring" duration="{duration}"/>
+    <testCase name="StringRef/Substrings/non-zero-based substring" duration="{duration}"/>
+    <testCase name="StringRef/Substrings/Pointer values of full refs should match" duration="{duration}"/>
+    <testCase name="StringRef/Substrings/Pointer values of substring refs should not match" duration="{duration}"/>
+    <testCase name="StringRef/Comparisons" duration="{duration}"/>
+    <testCase name="StringRef/from std::string/implicitly constructed" duration="{duration}"/>
+    <testCase name="StringRef/from std::string/explicitly constructed" duration="{duration}"/>
+    <testCase name="StringRef/from std::string/assigned" duration="{duration}"/>
+    <testCase name="StringRef/to std::string/implicitly constructed" duration="{duration}"/>
+    <testCase name="StringRef/to std::string/explicitly constructed" duration="{duration}"/>
+    <testCase name="StringRef/to std::string/assigned" duration="{duration}"/>
+    <testCase name="StringRef/Counting utf-8 codepoints" duration="{duration}"/>
+    <testCase name="replaceInPlace/replace single char" duration="{duration}"/>
+    <testCase name="replaceInPlace/replace two chars" duration="{duration}"/>
+    <testCase name="replaceInPlace/replace first char" duration="{duration}"/>
+    <testCase name="replaceInPlace/replace last char" duration="{duration}"/>
+    <testCase name="replaceInPlace/replace all chars" duration="{duration}"/>
+    <testCase name="replaceInPlace/replace no chars" duration="{duration}"/>
+    <testCase name="replaceInPlace/escape '" duration="{duration}"/>
+    <testCase name="splitString" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/IntrospectiveTests/Tag.tests.cpp">
-    <testCase name="Tag alias can be registered against tag patterns/The same tag alias can only be registered once" duration="0"/>
-    <testCase name="Tag alias can be registered against tag patterns/Tag aliases must be of the form [@name]" duration="0"/>
-    <testCase name="shortened hide tags are split apart" duration="0"/>
+    <testCase name="Tag alias can be registered against tag patterns/The same tag alias can only be registered once" duration="{duration}"/>
+    <testCase name="Tag alias can be registered against tag patterns/Tag aliases must be of the form [@name]" duration="{duration}"/>
+    <testCase name="shortened hide tags are split apart" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/IntrospectiveTests/ToString.tests.cpp">
-    <testCase name="Directly creating an EnumInfo" duration="0"/>
-    <testCase name="parseEnums/No enums" duration="0"/>
-    <testCase name="parseEnums/One enum value" duration="0"/>
-    <testCase name="parseEnums/Multiple enum values" duration="0"/>
+    <testCase name="Directly creating an EnumInfo" duration="{duration}"/>
+    <testCase name="parseEnums/No enums" duration="{duration}"/>
+    <testCase name="parseEnums/One enum value" duration="{duration}"/>
+    <testCase name="parseEnums/Multiple enum values" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/IntrospectiveTests/Xml.tests.cpp">
-    <testCase name="XmlEncode/normal string" duration="0"/>
-    <testCase name="XmlEncode/empty string" duration="0"/>
-    <testCase name="XmlEncode/string with ampersand" duration="0"/>
-    <testCase name="XmlEncode/string with less-than" duration="0"/>
-    <testCase name="XmlEncode/string with greater-than" duration="0"/>
-    <testCase name="XmlEncode/string with quotes" duration="0"/>
-    <testCase name="XmlEncode/string with control char (1)" duration="0"/>
-    <testCase name="XmlEncode/string with control char (x7F)" duration="0"/>
-    <testCase name="XmlEncode: UTF-8/Valid utf-8 strings" duration="0"/>
-    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Various broken strings" duration="0"/>
-    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Overlong encodings" duration="0"/>
-    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Surrogate pairs" duration="0"/>
-    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Invalid start byte" duration="0"/>
-    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Missing continuation byte(s)" duration="0"/>
+    <testCase name="XmlEncode/normal string" duration="{duration}"/>
+    <testCase name="XmlEncode/empty string" duration="{duration}"/>
+    <testCase name="XmlEncode/string with ampersand" duration="{duration}"/>
+    <testCase name="XmlEncode/string with less-than" duration="{duration}"/>
+    <testCase name="XmlEncode/string with greater-than" duration="{duration}"/>
+    <testCase name="XmlEncode/string with quotes" duration="{duration}"/>
+    <testCase name="XmlEncode/string with control char (1)" duration="{duration}"/>
+    <testCase name="XmlEncode/string with control char (x7F)" duration="{duration}"/>
+    <testCase name="XmlEncode: UTF-8/Valid utf-8 strings" duration="{duration}"/>
+    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Various broken strings" duration="{duration}"/>
+    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Overlong encodings" duration="{duration}"/>
+    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Surrogate pairs" duration="{duration}"/>
+    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Invalid start byte" duration="{duration}"/>
+    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Missing continuation byte(s)" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/Approx.tests.cpp">
-    <testCase name="A comparison that uses literals instead of the normal constructor" duration="0"/>
-    <testCase name="Absolute margin" duration="0"/>
-    <testCase name="Approx setters validate their arguments" duration="0"/>
-    <testCase name="Approx with exactly-representable margin" duration="0"/>
-    <testCase name="Approximate PI" duration="0"/>
-    <testCase name="Approximate comparisons with different epsilons" duration="0"/>
-    <testCase name="Approximate comparisons with floats" duration="0"/>
-    <testCase name="Approximate comparisons with ints" duration="0"/>
-    <testCase name="Approximate comparisons with mixed numeric types" duration="0"/>
-    <testCase name="Assorted miscellaneous tests" duration="0"/>
-    <testCase name="Comparison with explicitly convertible types" duration="0"/>
-    <testCase name="Default scale is invisible to comparison" duration="0"/>
-    <testCase name="Epsilon only applies to Approx's value" duration="0"/>
-    <testCase name="Greater-than inequalities with different epsilons" duration="0"/>
-    <testCase name="Less-than inequalities with different epsilons" duration="0"/>
-    <testCase name="Some simple comparisons between doubles" duration="0"/>
-    <testCase name="Use a custom approx" duration="0"/>
+    <testCase name="A comparison that uses literals instead of the normal constructor" duration="{duration}"/>
+    <testCase name="Absolute margin" duration="{duration}"/>
+    <testCase name="Approx setters validate their arguments" duration="{duration}"/>
+    <testCase name="Approx with exactly-representable margin" duration="{duration}"/>
+    <testCase name="Approximate PI" duration="{duration}"/>
+    <testCase name="Approximate comparisons with different epsilons" duration="{duration}"/>
+    <testCase name="Approximate comparisons with floats" duration="{duration}"/>
+    <testCase name="Approximate comparisons with ints" duration="{duration}"/>
+    <testCase name="Approximate comparisons with mixed numeric types" duration="{duration}"/>
+    <testCase name="Assorted miscellaneous tests" duration="{duration}"/>
+    <testCase name="Comparison with explicitly convertible types" duration="{duration}"/>
+    <testCase name="Default scale is invisible to comparison" duration="{duration}"/>
+    <testCase name="Epsilon only applies to Approx's value" duration="{duration}"/>
+    <testCase name="Greater-than inequalities with different epsilons" duration="{duration}"/>
+    <testCase name="Less-than inequalities with different epsilons" duration="{duration}"/>
+    <testCase name="Some simple comparisons between doubles" duration="{duration}"/>
+    <testCase name="Use a custom approx" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/BDD.tests.cpp">
-    <testCase name="Scenario: BDD tests requiring Fixtures to provide commonly-accessed data or methods/Given: No operations precede me" duration="0"/>
-    <testCase name="Scenario: BDD tests requiring Fixtures to provide commonly-accessed data or methods/Given: No operations precede me/When: We get the count/Then: Subsequently values are higher" duration="0"/>
-    <testCase name="Scenario: Do that thing with the thing/Given: This stuff exists/And given: And some assumption/When: I do this/Then: it should do this" duration="0"/>
-    <testCase name="Scenario: Do that thing with the thing/Given: This stuff exists/And given: And some assumption/When: I do this/Then: it should do this/And: do that" duration="0"/>
-    <testCase name="Scenario: This is a really long scenario name to see how the list command deals with wrapping/Given: A section name that is so long that it cannot fit in a single console width/When: The test headers are printed as part of the normal running of the scenario/Then: The, deliberately very long and overly verbose (you see what I did there?) section names must wrap, along with an indent" duration="0"/>
-    <testCase name="Scenario: Vector resizing affects size and capacity/Given: an empty vector" duration="0"/>
-    <testCase name="Scenario: Vector resizing affects size and capacity/Given: an empty vector/When: it is made larger/Then: the size and capacity go up" duration="0"/>
-    <testCase name="Scenario: Vector resizing affects size and capacity/Given: an empty vector/When: it is made larger/Then: the size and capacity go up/And when: it is made smaller again/Then: the size goes down but the capacity stays the same" duration="0"/>
-    <testCase name="Scenario: Vector resizing affects size and capacity/Given: an empty vector/When: we reserve more space/Then: The capacity is increased but the size remains the same" duration="0"/>
+    <testCase name="Scenario: BDD tests requiring Fixtures to provide commonly-accessed data or methods/Given: No operations precede me" duration="{duration}"/>
+    <testCase name="Scenario: BDD tests requiring Fixtures to provide commonly-accessed data or methods/Given: No operations precede me/When: We get the count/Then: Subsequently values are higher" duration="{duration}"/>
+    <testCase name="Scenario: Do that thing with the thing/Given: This stuff exists/And given: And some assumption/When: I do this/Then: it should do this" duration="{duration}"/>
+    <testCase name="Scenario: Do that thing with the thing/Given: This stuff exists/And given: And some assumption/When: I do this/Then: it should do this/And: do that" duration="{duration}"/>
+    <testCase name="Scenario: This is a really long scenario name to see how the list command deals with wrapping/Given: A section name that is so long that it cannot fit in a single console width/When: The test headers are printed as part of the normal running of the scenario/Then: The, deliberately very long and overly verbose (you see what I did there?) section names must wrap, along with an indent" duration="{duration}"/>
+    <testCase name="Scenario: Vector resizing affects size and capacity/Given: an empty vector" duration="{duration}"/>
+    <testCase name="Scenario: Vector resizing affects size and capacity/Given: an empty vector/When: it is made larger/Then: the size and capacity go up" duration="{duration}"/>
+    <testCase name="Scenario: Vector resizing affects size and capacity/Given: an empty vector/When: it is made larger/Then: the size and capacity go up/And when: it is made smaller again/Then: the size goes down but the capacity stays the same" duration="{duration}"/>
+    <testCase name="Scenario: Vector resizing affects size and capacity/Given: an empty vector/When: we reserve more space/Then: The capacity is increased but the size remains the same" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/Class.tests.cpp">
-    <testCase name="A METHOD_AS_TEST_CASE based test run that fails" duration="0">
+    <testCase name="A METHOD_AS_TEST_CASE based test run that fails" duration="{duration}">
       <failure message="REQUIRE(s == &quot;world&quot;)">
 FAILED:
 	REQUIRE( s == "world" )
@@ -191,8 +191,8 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A METHOD_AS_TEST_CASE based test run that succeeds" duration="0"/>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - Template_Foo&lt;float>" duration="0">
+    <testCase name="A METHOD_AS_TEST_CASE based test run that succeeds" duration="{duration}"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - Template_Foo&lt;float>" duration="{duration}">
       <failure message="REQUIRE(Template_Fixture_2&lt;TestType>::m_a.size() == 1)">
 FAILED:
 	REQUIRE( Template_Fixture_2&lt;TestType>::m_a.size() == 1 )
@@ -201,7 +201,7 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - Template_Foo&lt;int>" duration="0">
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - Template_Foo&lt;int>" duration="{duration}">
       <failure message="REQUIRE(Template_Fixture_2&lt;TestType>::m_a.size() == 1)">
 FAILED:
 	REQUIRE( Template_Fixture_2&lt;TestType>::m_a.size() == 1 )
@@ -210,7 +210,7 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - std::vector&lt;float>" duration="0">
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - std::vector&lt;float>" duration="{duration}">
       <failure message="REQUIRE(Template_Fixture_2&lt;TestType>::m_a.size() == 1)">
 FAILED:
 	REQUIRE( Template_Fixture_2&lt;TestType>::m_a.size() == 1 )
@@ -219,7 +219,7 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - std::vector&lt;int>" duration="0">
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - std::vector&lt;int>" duration="{duration}">
       <failure message="REQUIRE(Template_Fixture_2&lt;TestType>::m_a.size() == 1)">
 FAILED:
 	REQUIRE( Template_Fixture_2&lt;TestType>::m_a.size() == 1 )
@@ -228,11 +228,11 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - Template_Foo&lt;float>" duration="0"/>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - Template_Foo&lt;int>" duration="0"/>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - std::vector&lt;float>" duration="0"/>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - std::vector&lt;int>" duration="0"/>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - Template_Foo_2&lt;float, 6>" duration="0">
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - Template_Foo&lt;float>" duration="{duration}"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - Template_Foo&lt;int>" duration="{duration}"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - std::vector&lt;float>" duration="{duration}"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - std::vector&lt;int>" duration="{duration}"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - Template_Foo_2&lt;float, 6>" duration="{duration}">
       <failure message="REQUIRE(Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2)">
 FAILED:
 	REQUIRE( Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2 )
@@ -241,7 +241,7 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - Template_Foo_2&lt;int, 2>" duration="0">
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - Template_Foo_2&lt;int, 2>" duration="{duration}">
       <failure message="REQUIRE(Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2)">
 FAILED:
 	REQUIRE( Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2 )
@@ -250,7 +250,7 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - std::array&lt;float, 6>" duration="0">
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - std::array&lt;float, 6>" duration="{duration}">
       <failure message="REQUIRE(Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2)">
 FAILED:
 	REQUIRE( Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2 )
@@ -259,7 +259,7 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - std::array&lt;int, 2>" duration="0">
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - std::array&lt;int, 2>" duration="{duration}">
       <failure message="REQUIRE(Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2)">
 FAILED:
 	REQUIRE( Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2 )
@@ -268,11 +268,11 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - Template_Foo_2&lt;float,6>" duration="0"/>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - Template_Foo_2&lt;int,2>" duration="0"/>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - std::array&lt;float,6>" duration="0"/>
-    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - std::array&lt;int,2>" duration="0"/>
-    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that fails - double" duration="0">
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - Template_Foo_2&lt;float,6>" duration="{duration}"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - Template_Foo_2&lt;int,2>" duration="{duration}"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - std::array&lt;float,6>" duration="{duration}"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - std::array&lt;int,2>" duration="{duration}"/>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that fails - double" duration="{duration}">
       <failure message="REQUIRE(Template_Fixture&lt;TestType>::m_a == 2)">
 FAILED:
 	REQUIRE( Template_Fixture&lt;TestType>::m_a == 2 )
@@ -281,7 +281,7 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that fails - float" duration="0">
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that fails - float" duration="{duration}">
       <failure message="REQUIRE(Template_Fixture&lt;TestType>::m_a == 2)">
 FAILED:
 	REQUIRE( Template_Fixture&lt;TestType>::m_a == 2 )
@@ -290,7 +290,7 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that fails - int" duration="0">
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that fails - int" duration="{duration}">
       <failure message="REQUIRE(Template_Fixture&lt;TestType>::m_a == 2)">
 FAILED:
 	REQUIRE( Template_Fixture&lt;TestType>::m_a == 2 )
@@ -299,10 +299,10 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that succeeds - double" duration="0"/>
-    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that succeeds - float" duration="0"/>
-    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that succeeds - int" duration="0"/>
-    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that fails - 1" duration="0">
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that succeeds - double" duration="{duration}"/>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that succeeds - float" duration="{duration}"/>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that succeeds - int" duration="{duration}"/>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that fails - 1" duration="{duration}">
       <failure message="REQUIRE(Nttp_Fixture&lt;V>::value == 0)">
 FAILED:
 	REQUIRE( Nttp_Fixture&lt;V>::value == 0 )
@@ -311,7 +311,7 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that fails - 3" duration="0">
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that fails - 3" duration="{duration}">
       <failure message="REQUIRE(Nttp_Fixture&lt;V>::value == 0)">
 FAILED:
 	REQUIRE( Nttp_Fixture&lt;V>::value == 0 )
@@ -320,7 +320,7 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that fails - 6" duration="0">
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that fails - 6" duration="{duration}">
       <failure message="REQUIRE(Nttp_Fixture&lt;V>::value == 0)">
 FAILED:
 	REQUIRE( Nttp_Fixture&lt;V>::value == 0 )
@@ -329,10 +329,10 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds - 1" duration="0"/>
-    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds - 3" duration="0"/>
-    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds - 6" duration="0"/>
-    <testCase name="A TEST_CASE_METHOD based test run that fails" duration="0">
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds - 1" duration="{duration}"/>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds - 3" duration="{duration}"/>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds - 6" duration="{duration}"/>
+    <testCase name="A TEST_CASE_METHOD based test run that fails" duration="{duration}">
       <failure message="REQUIRE(m_a == 2)">
 FAILED:
 	REQUIRE( m_a == 2 )
@@ -341,26 +341,26 @@ with expansion:
 Class.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A TEST_CASE_METHOD based test run that succeeds" duration="0"/>
-    <testCase name="Template test case method with test types specified inside std::tuple - MyTypes - 0" duration="0"/>
-    <testCase name="Template test case method with test types specified inside std::tuple - MyTypes - 1" duration="0"/>
-    <testCase name="Template test case method with test types specified inside std::tuple - MyTypes - 2" duration="0"/>
+    <testCase name="A TEST_CASE_METHOD based test run that succeeds" duration="{duration}"/>
+    <testCase name="Template test case method with test types specified inside std::tuple - MyTypes - 0" duration="{duration}"/>
+    <testCase name="Template test case method with test types specified inside std::tuple - MyTypes - 1" duration="{duration}"/>
+    <testCase name="Template test case method with test types specified inside std::tuple - MyTypes - 2" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/Compilation.tests.cpp">
-    <testCase name="#1027" duration="0"/>
-    <testCase name="#1027: Bitfields can be captured" duration="0"/>
-    <testCase name="#1147" duration="0"/>
-    <testCase name="#1238" duration="0"/>
-    <testCase name="#1245" duration="0"/>
-    <testCase name="#1403" duration="0"/>
-    <testCase name="#1548" duration="0"/>
-    <testCase name="#809" duration="0"/>
-    <testCase name="#833" duration="0"/>
-    <testCase name="#872" duration="0"/>
-    <testCase name="Optionally static assertions" duration="0"/>
+    <testCase name="#1027" duration="{duration}"/>
+    <testCase name="#1027: Bitfields can be captured" duration="{duration}"/>
+    <testCase name="#1147" duration="{duration}"/>
+    <testCase name="#1238" duration="{duration}"/>
+    <testCase name="#1245" duration="{duration}"/>
+    <testCase name="#1403" duration="{duration}"/>
+    <testCase name="#1548" duration="{duration}"/>
+    <testCase name="#809" duration="{duration}"/>
+    <testCase name="#833" duration="{duration}"/>
+    <testCase name="#872" duration="{duration}"/>
+    <testCase name="Optionally static assertions" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/Condition.tests.cpp">
-    <testCase name="'Not' checks that should fail" duration="0">
+    <testCase name="'Not' checks that should fail" duration="{duration}">
       <failure message="CHECK(false != false)">
 FAILED:
 	CHECK( false != false )
@@ -412,11 +412,11 @@ FAILED:
 Condition.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="'Not' checks that should succeed" duration="0"/>
-    <testCase name="Comparisons between ints where one side is computed" duration="0"/>
-    <testCase name="Comparisons between unsigned ints and negative signed ints match c++ standard behaviour" duration="0"/>
-    <testCase name="Comparisons with int literals don't warn when mixing signed/ unsigned" duration="0"/>
-    <testCase name="Equality checks that should fail" duration="0">
+    <testCase name="'Not' checks that should succeed" duration="{duration}"/>
+    <testCase name="Comparisons between ints where one side is computed" duration="{duration}"/>
+    <testCase name="Comparisons between unsigned ints and negative signed ints match c++ standard behaviour" duration="{duration}"/>
+    <testCase name="Comparisons with int literals don't warn when mixing signed/ unsigned" duration="{duration}"/>
+    <testCase name="Equality checks that should fail" duration="{duration}">
       <skipped message="CHECK(data.int_seven == 6)">
 FAILED:
 	CHECK( data.int_seven == 6 )
@@ -509,8 +509,8 @@ with expansion:
 Condition.tests.cpp:<line number>
       </skipped>
     </testCase>
-    <testCase name="Equality checks that should succeed" duration="0"/>
-    <testCase name="Inequality checks that should fail" duration="0">
+    <testCase name="Equality checks that should succeed" duration="{duration}"/>
+    <testCase name="Inequality checks that should fail" duration="{duration}">
       <skipped message="CHECK(data.int_seven != 7)">
 FAILED:
 	CHECK( data.int_seven != 7 )
@@ -547,8 +547,8 @@ with expansion:
 Condition.tests.cpp:<line number>
       </skipped>
     </testCase>
-    <testCase name="Inequality checks that should succeed" duration="0"/>
-    <testCase name="Ordering comparison checks that should fail" duration="0">
+    <testCase name="Inequality checks that should succeed" duration="{duration}"/>
+    <testCase name="Ordering comparison checks that should fail" duration="{duration}">
       <failure message="CHECK(data.int_seven > 7)">
 FAILED:
 	CHECK( data.int_seven > 7 )
@@ -683,14 +683,14 @@ with expansion:
 Condition.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Ordering comparison checks that should succeed" duration="0"/>
-    <testCase name="Pointers can be compared to null" duration="0"/>
-    <testCase name="comparisons between const int variables" duration="0"/>
-    <testCase name="comparisons between int variables" duration="0"/>
+    <testCase name="Ordering comparison checks that should succeed" duration="{duration}"/>
+    <testCase name="Pointers can be compared to null" duration="{duration}"/>
+    <testCase name="comparisons between const int variables" duration="{duration}"/>
+    <testCase name="comparisons between int variables" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/Decomposition.tests.cpp">
-    <testCase name="#1005: Comparing pointer to int and long (NULL can be either on various systems)" duration="0"/>
-    <testCase name="Reconstruction should be based on stringification: #914" duration="0">
+    <testCase name="#1005: Comparing pointer to int and long (NULL can be either on various systems)" duration="{duration}"/>
+    <testCase name="Reconstruction should be based on stringification: #914" duration="{duration}">
       <failure message="CHECK(truthy(false))">
 FAILED:
 	CHECK( truthy(false) )
@@ -701,15 +701,15 @@ Decomposition.tests.cpp:<line number>
     </testCase>
   </file>
   <file path="projects/<exe-name>/UsageTests/EnumToString.tests.cpp">
-    <testCase name="Enums can quickly have stringification enabled using REGISTER_ENUM" duration="0"/>
-    <testCase name="Enums in namespaces can quickly have stringification enabled using REGISTER_ENUM" duration="0"/>
-    <testCase name="toString(enum class w/operator&lt;&lt;)" duration="0"/>
-    <testCase name="toString(enum class)" duration="0"/>
-    <testCase name="toString(enum w/operator&lt;&lt;)" duration="0"/>
-    <testCase name="toString(enum)" duration="0"/>
+    <testCase name="Enums can quickly have stringification enabled using REGISTER_ENUM" duration="{duration}"/>
+    <testCase name="Enums in namespaces can quickly have stringification enabled using REGISTER_ENUM" duration="{duration}"/>
+    <testCase name="toString(enum class w/operator&lt;&lt;)" duration="{duration}"/>
+    <testCase name="toString(enum class)" duration="{duration}"/>
+    <testCase name="toString(enum w/operator&lt;&lt;)" duration="{duration}"/>
+    <testCase name="toString(enum)" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/Exception.tests.cpp">
-    <testCase name="#748 - captures with unexpected exceptions/outside assertions" duration="0">
+    <testCase name="#748 - captures with unexpected exceptions/outside assertions" duration="{duration}">
       <skipped message="TEST_CASE()">
 FAILED:
 expected exception
@@ -717,7 +717,7 @@ answer := 42
 Exception.tests.cpp:<line number>
       </skipped>
     </testCase>
-    <testCase name="#748 - captures with unexpected exceptions/inside REQUIRE_NOTHROW" duration="0">
+    <testCase name="#748 - captures with unexpected exceptions/inside REQUIRE_NOTHROW" duration="{duration}">
       <skipped message="REQUIRE_NOTHROW(thisThrows())">
 FAILED:
 	REQUIRE_NOTHROW( thisThrows() )
@@ -726,8 +726,8 @@ answer := 42
 Exception.tests.cpp:<line number>
       </skipped>
     </testCase>
-    <testCase name="#748 - captures with unexpected exceptions/inside REQUIRE_THROWS" duration="0"/>
-    <testCase name="An unchecked exception reports the line of the last assertion" duration="0">
+    <testCase name="#748 - captures with unexpected exceptions/inside REQUIRE_THROWS" duration="{duration}"/>
+    <testCase name="An unchecked exception reports the line of the last assertion" duration="{duration}">
       <error message="({Unknown expression after the reported line})">
 FAILED:
 	{Unknown expression after the reported line}
@@ -735,7 +735,7 @@ unexpected exception
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="Custom exceptions can be translated when testing for nothrow" duration="0">
+    <testCase name="Custom exceptions can be translated when testing for nothrow" duration="{duration}">
       <error message="REQUIRE_NOTHROW(throwCustom())">
 FAILED:
 	REQUIRE_NOTHROW( throwCustom() )
@@ -743,7 +743,7 @@ custom exception - not std
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="Custom exceptions can be translated when testing for throwing as something else" duration="0">
+    <testCase name="Custom exceptions can be translated when testing for throwing as something else" duration="{duration}">
       <error message="REQUIRE_THROWS_AS(throwCustom(), std::exception)">
 FAILED:
 	REQUIRE_THROWS_AS( throwCustom(), std::exception )
@@ -751,17 +751,17 @@ custom exception - not std
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="Custom std-exceptions can be custom translated" duration="0">
+    <testCase name="Custom std-exceptions can be custom translated" duration="{duration}">
       <error message="TEST_CASE()">
 FAILED:
 custom std exception
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="Exception messages can be tested for/exact match" duration="0"/>
-    <testCase name="Exception messages can be tested for/different case" duration="0"/>
-    <testCase name="Exception messages can be tested for/wildcarded" duration="0"/>
-    <testCase name="Expected exceptions that don't throw or unexpected exceptions fail the test" duration="0">
+    <testCase name="Exception messages can be tested for/exact match" duration="{duration}"/>
+    <testCase name="Exception messages can be tested for/different case" duration="{duration}"/>
+    <testCase name="Exception messages can be tested for/wildcarded" duration="{duration}"/>
+    <testCase name="Expected exceptions that don't throw or unexpected exceptions fail the test" duration="{duration}">
       <error message="CHECK_THROWS_AS(thisThrows(), std::string)">
 FAILED:
 	CHECK_THROWS_AS( thisThrows(), std::string )
@@ -780,7 +780,7 @@ expected exception
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="Mismatching exception messages failing the test" duration="0">
+    <testCase name="Mismatching exception messages failing the test" duration="{duration}">
       <failure message="REQUIRE_THROWS_WITH(thisThrows(), &quot;should fail&quot;)">
 FAILED:
 	REQUIRE_THROWS_WITH( thisThrows(), "should fail" )
@@ -789,36 +789,36 @@ with expansion:
 Exception.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Non-std exceptions can be translated" duration="0">
+    <testCase name="Non-std exceptions can be translated" duration="{duration}">
       <error message="TEST_CASE()">
 FAILED:
 custom exception
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="Thrown string literals are translated" duration="0">
+    <testCase name="Thrown string literals are translated" duration="{duration}">
       <error message="TEST_CASE()">
 FAILED:
 For some reason someone is throwing a string literal!
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="Unexpected exceptions can be translated" duration="0">
+    <testCase name="Unexpected exceptions can be translated" duration="{duration}">
       <error message="TEST_CASE()">
 FAILED:
 3.14
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="When checked exceptions are thrown they can be expected or unexpected" duration="0"/>
-    <testCase name="When unchecked exceptions are thrown directly they are always failures" duration="0">
+    <testCase name="When checked exceptions are thrown they can be expected or unexpected" duration="{duration}"/>
+    <testCase name="When unchecked exceptions are thrown directly they are always failures" duration="{duration}">
       <error message="TEST_CASE()">
 FAILED:
 unexpected exception
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="When unchecked exceptions are thrown during a CHECK the test should continue" duration="0">
+    <testCase name="When unchecked exceptions are thrown during a CHECK the test should continue" duration="{duration}">
       <error message="CHECK(thisThrows() == 0)">
 FAILED:
 	CHECK( thisThrows() == 0 )
@@ -826,7 +826,7 @@ expected exception
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="When unchecked exceptions are thrown during a REQUIRE the test should abort fail" duration="0">
+    <testCase name="When unchecked exceptions are thrown during a REQUIRE the test should abort fail" duration="{duration}">
       <error message="REQUIRE(thisThrows() == 0)">
 FAILED:
 	REQUIRE( thisThrows() == 0 )
@@ -834,7 +834,7 @@ expected exception
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="When unchecked exceptions are thrown from functions they are always failures" duration="0">
+    <testCase name="When unchecked exceptions are thrown from functions they are always failures" duration="{duration}">
       <error message="CHECK(thisThrows() == 0)">
 FAILED:
 	CHECK( thisThrows() == 0 )
@@ -842,14 +842,14 @@ expected exception
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="When unchecked exceptions are thrown from sections they are always failures/section name" duration="0">
+    <testCase name="When unchecked exceptions are thrown from sections they are always failures/section name" duration="{duration}">
       <error message="TEST_CASE()">
 FAILED:
 unexpected exception
 Exception.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="thrown std::strings are translated" duration="0">
+    <testCase name="thrown std::strings are translated" duration="{duration}">
       <error message="TEST_CASE()">
 FAILED:
 Why would you throw a std::string?
@@ -858,28 +858,28 @@ Exception.tests.cpp:<line number>
     </testCase>
   </file>
   <file path="projects/<exe-name>/UsageTests/Generators.tests.cpp">
-    <testCase name="3x3x3 ints" duration="0"/>
-    <testCase name="Generators -- adapters/Filtering by predicate/Basic usage" duration="0"/>
-    <testCase name="Generators -- adapters/Filtering by predicate/Throws if there are no matching values" duration="0"/>
-    <testCase name="Generators -- adapters/Shortening a range" duration="0"/>
-    <testCase name="Generators -- adapters/Transforming elements/Same type" duration="0"/>
-    <testCase name="Generators -- adapters/Transforming elements/Different type" duration="0"/>
-    <testCase name="Generators -- adapters/Transforming elements/Different deduced type" duration="0"/>
-    <testCase name="Generators -- adapters/Repeating a generator" duration="0"/>
-    <testCase name="Generators -- adapters/Chunking a generator into sized pieces/Number of elements in source is divisible by chunk size" duration="0"/>
-    <testCase name="Generators -- adapters/Chunking a generator into sized pieces/Number of elements in source is not divisible by chunk size" duration="0"/>
-    <testCase name="Generators -- adapters/Chunking a generator into sized pieces/Chunk size of zero" duration="0"/>
-    <testCase name="Generators -- adapters/Chunking a generator into sized pieces/Throws on too small generators" duration="0"/>
-    <testCase name="Generators -- simple/one" duration="0"/>
-    <testCase name="Generators -- simple/two" duration="0"/>
-    <testCase name="Nested generators and captured variables" duration="0"/>
-    <testCase name="strlen3" duration="0"/>
-    <testCase name="tables" duration="0"/>
+    <testCase name="3x3x3 ints" duration="{duration}"/>
+    <testCase name="Generators -- adapters/Filtering by predicate/Basic usage" duration="{duration}"/>
+    <testCase name="Generators -- adapters/Filtering by predicate/Throws if there are no matching values" duration="{duration}"/>
+    <testCase name="Generators -- adapters/Shortening a range" duration="{duration}"/>
+    <testCase name="Generators -- adapters/Transforming elements/Same type" duration="{duration}"/>
+    <testCase name="Generators -- adapters/Transforming elements/Different type" duration="{duration}"/>
+    <testCase name="Generators -- adapters/Transforming elements/Different deduced type" duration="{duration}"/>
+    <testCase name="Generators -- adapters/Repeating a generator" duration="{duration}"/>
+    <testCase name="Generators -- adapters/Chunking a generator into sized pieces/Number of elements in source is divisible by chunk size" duration="{duration}"/>
+    <testCase name="Generators -- adapters/Chunking a generator into sized pieces/Number of elements in source is not divisible by chunk size" duration="{duration}"/>
+    <testCase name="Generators -- adapters/Chunking a generator into sized pieces/Chunk size of zero" duration="{duration}"/>
+    <testCase name="Generators -- adapters/Chunking a generator into sized pieces/Throws on too small generators" duration="{duration}"/>
+    <testCase name="Generators -- simple/one" duration="{duration}"/>
+    <testCase name="Generators -- simple/two" duration="{duration}"/>
+    <testCase name="Nested generators and captured variables" duration="{duration}"/>
+    <testCase name="strlen3" duration="{duration}"/>
+    <testCase name="tables" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/Matchers.tests.cpp">
-    <testCase name="Arbitrary predicate matcher/Function pointer" duration="0"/>
-    <testCase name="Arbitrary predicate matcher/Lambdas + different type" duration="0"/>
-    <testCase name="Contains string matcher" duration="0">
+    <testCase name="Arbitrary predicate matcher/Function pointer" duration="{duration}"/>
+    <testCase name="Arbitrary predicate matcher/Lambdas + different type" duration="{duration}"/>
+    <testCase name="Contains string matcher" duration="{duration}">
       <failure message="CHECK_THAT(testStringForMatching(), Contains(&quot;not there&quot;, Catch::CaseSensitive::No))">
 FAILED:
 	CHECK_THAT( testStringForMatching(), Contains("not there", Catch::CaseSensitive::No) )
@@ -895,7 +895,7 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="EndsWith string matcher" duration="0">
+    <testCase name="EndsWith string matcher" duration="{duration}">
       <failure message="CHECK_THAT(testStringForMatching(), EndsWith(&quot;Substring&quot;))">
 FAILED:
 	CHECK_THAT( testStringForMatching(), EndsWith("Substring") )
@@ -911,8 +911,8 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Equals" duration="0"/>
-    <testCase name="Equals string matcher" duration="0">
+    <testCase name="Equals" duration="{duration}"/>
+    <testCase name="Equals string matcher" duration="{duration}">
       <failure message="CHECK_THAT(testStringForMatching(), Equals(&quot;this string contains 'ABC' as a substring&quot;))">
 FAILED:
 	CHECK_THAT( testStringForMatching(), Equals("this string contains 'ABC' as a substring") )
@@ -928,7 +928,7 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Exception matchers that fail/No exception" duration="0">
+    <testCase name="Exception matchers that fail/No exception" duration="{duration}">
       <failure message="CHECK_THROWS_MATCHES(doesNotThrow(), SpecialException, ExceptionMatcher{1})">
 FAILED:
 	CHECK_THROWS_MATCHES( doesNotThrow(), SpecialException, ExceptionMatcher{1} )
@@ -940,7 +940,7 @@ FAILED:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Exception matchers that fail/Type mismatch" duration="0">
+    <testCase name="Exception matchers that fail/Type mismatch" duration="{duration}">
       <error message="CHECK_THROWS_MATCHES(throwsAsInt(1), SpecialException, ExceptionMatcher{1})">
 FAILED:
 	CHECK_THROWS_MATCHES( throwsAsInt(1), SpecialException, ExceptionMatcher{1} )
@@ -954,7 +954,7 @@ Unknown exception
 Matchers.tests.cpp:<line number>
       </error>
     </testCase>
-    <testCase name="Exception matchers that fail/Contents are wrong" duration="0">
+    <testCase name="Exception matchers that fail/Contents are wrong" duration="{duration}">
       <failure message="CHECK_THROWS_MATCHES(throws(3), SpecialException, ExceptionMatcher{1})">
 FAILED:
 	CHECK_THROWS_MATCHES( throws(3), SpecialException, ExceptionMatcher{1} )
@@ -970,19 +970,19 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Exception matchers that succeed" duration="0"/>
-    <testCase name="Floating point matchers: double/Margin" duration="0"/>
-    <testCase name="Floating point matchers: double/ULPs" duration="0"/>
-    <testCase name="Floating point matchers: double/Composed" duration="0"/>
-    <testCase name="Floating point matchers: double/Constructor validation" duration="0"/>
-    <testCase name="Floating point matchers: float/Margin" duration="0"/>
-    <testCase name="Floating point matchers: float/ULPs" duration="0"/>
-    <testCase name="Floating point matchers: float/Composed" duration="0"/>
-    <testCase name="Floating point matchers: float/Constructor validation" duration="0"/>
-    <testCase name="Matchers can be (AllOf) composed with the &amp;&amp; operator" duration="0"/>
-    <testCase name="Matchers can be (AnyOf) composed with the || operator" duration="0"/>
-    <testCase name="Matchers can be composed with both &amp;&amp; and ||" duration="0"/>
-    <testCase name="Matchers can be composed with both &amp;&amp; and || - failing" duration="0">
+    <testCase name="Exception matchers that succeed" duration="{duration}"/>
+    <testCase name="Floating point matchers: double/Margin" duration="{duration}"/>
+    <testCase name="Floating point matchers: double/ULPs" duration="{duration}"/>
+    <testCase name="Floating point matchers: double/Composed" duration="{duration}"/>
+    <testCase name="Floating point matchers: double/Constructor validation" duration="{duration}"/>
+    <testCase name="Floating point matchers: float/Margin" duration="{duration}"/>
+    <testCase name="Floating point matchers: float/ULPs" duration="{duration}"/>
+    <testCase name="Floating point matchers: float/Composed" duration="{duration}"/>
+    <testCase name="Floating point matchers: float/Constructor validation" duration="{duration}"/>
+    <testCase name="Matchers can be (AllOf) composed with the &amp;&amp; operator" duration="{duration}"/>
+    <testCase name="Matchers can be (AnyOf) composed with the || operator" duration="{duration}"/>
+    <testCase name="Matchers can be composed with both &amp;&amp; and ||" duration="{duration}"/>
+    <testCase name="Matchers can be composed with both &amp;&amp; and || - failing" duration="{duration}">
       <failure message="CHECK_THAT(testStringForMatching(), (Contains(&quot;string&quot;) || Contains(&quot;different&quot;)) &amp;&amp; Contains(&quot;random&quot;))">
 FAILED:
 	CHECK_THAT( testStringForMatching(), (Contains("string") || Contains("different")) &amp;&amp; Contains("random") )
@@ -991,8 +991,8 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Matchers can be negated (Not) with the ! operator" duration="0"/>
-    <testCase name="Matchers can be negated (Not) with the ! operator - failing" duration="0">
+    <testCase name="Matchers can be negated (Not) with the ! operator" duration="{duration}"/>
+    <testCase name="Matchers can be negated (Not) with the ! operator - failing" duration="{duration}">
       <failure message="CHECK_THAT(testStringForMatching(), !Contains(&quot;substring&quot;))">
 FAILED:
 	CHECK_THAT( testStringForMatching(), !Contains("substring") )
@@ -1001,8 +1001,8 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Predicate matcher can accept const char*" duration="0"/>
-    <testCase name="Regex string matcher" duration="0">
+    <testCase name="Predicate matcher can accept const char*" duration="{duration}"/>
+    <testCase name="Regex string matcher" duration="{duration}">
       <failure message="CHECK_THAT(testStringForMatching(), Matches(&quot;this STRING contains 'abc' as a substring&quot;))">
 FAILED:
 	CHECK_THAT( testStringForMatching(), Matches("this STRING contains 'abc' as a substring") )
@@ -1025,8 +1025,8 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Regression test #1" duration="0"/>
-    <testCase name="StartsWith string matcher" duration="0">
+    <testCase name="Regression test #1" duration="{duration}"/>
+    <testCase name="StartsWith string matcher" duration="{duration}">
       <failure message="CHECK_THAT(testStringForMatching(), StartsWith(&quot;This String&quot;))">
 FAILED:
 	CHECK_THAT( testStringForMatching(), StartsWith("This String") )
@@ -1042,12 +1042,12 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="String matchers" duration="0"/>
-    <testCase name="Vector Approx matcher/Empty vector is roughly equal to an empty vector" duration="0"/>
-    <testCase name="Vector Approx matcher/Vectors with elements/A vector is approx equal to itself" duration="0"/>
-    <testCase name="Vector Approx matcher/Vectors with elements/Different length" duration="0"/>
-    <testCase name="Vector Approx matcher/Vectors with elements/Same length, different elements" duration="0"/>
-    <testCase name="Vector Approx matcher -- failing/Empty and non empty vectors are not approx equal" duration="0">
+    <testCase name="String matchers" duration="{duration}"/>
+    <testCase name="Vector Approx matcher/Empty vector is roughly equal to an empty vector" duration="{duration}"/>
+    <testCase name="Vector Approx matcher/Vectors with elements/A vector is approx equal to itself" duration="{duration}"/>
+    <testCase name="Vector Approx matcher/Vectors with elements/Different length" duration="{duration}"/>
+    <testCase name="Vector Approx matcher/Vectors with elements/Same length, different elements" duration="{duration}"/>
+    <testCase name="Vector Approx matcher -- failing/Empty and non empty vectors are not approx equal" duration="{duration}">
       <failure message="CHECK_THAT(empty, Approx(t1))">
 FAILED:
 	CHECK_THAT( empty, Approx(t1) )
@@ -1056,7 +1056,7 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Vector Approx matcher -- failing/Just different vectors" duration="0">
+    <testCase name="Vector Approx matcher -- failing/Just different vectors" duration="{duration}">
       <failure message="CHECK_THAT(v1, Approx(v2))">
 FAILED:
 	CHECK_THAT( v1, Approx(v2) )
@@ -1065,12 +1065,12 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Vector matchers/Contains (element)" duration="0"/>
-    <testCase name="Vector matchers/Contains (vector)" duration="0"/>
-    <testCase name="Vector matchers/Contains (element), composed" duration="0"/>
-    <testCase name="Vector matchers/Equals" duration="0"/>
-    <testCase name="Vector matchers/UnorderedEquals" duration="0"/>
-    <testCase name="Vector matchers that fail/Contains (element)" duration="0">
+    <testCase name="Vector matchers/Contains (element)" duration="{duration}"/>
+    <testCase name="Vector matchers/Contains (vector)" duration="{duration}"/>
+    <testCase name="Vector matchers/Contains (element), composed" duration="{duration}"/>
+    <testCase name="Vector matchers/Equals" duration="{duration}"/>
+    <testCase name="Vector matchers/UnorderedEquals" duration="{duration}"/>
+    <testCase name="Vector matchers that fail/Contains (element)" duration="{duration}">
       <failure message="CHECK_THAT(v, VectorContains(-1))">
 FAILED:
 	CHECK_THAT( v, VectorContains(-1) )
@@ -1086,7 +1086,7 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Vector matchers that fail/Contains (vector)" duration="0">
+    <testCase name="Vector matchers that fail/Contains (vector)" duration="{duration}">
       <failure message="CHECK_THAT(empty, Contains(v))">
 FAILED:
 	CHECK_THAT( empty, Contains(v) )
@@ -1102,7 +1102,7 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Vector matchers that fail/Equals" duration="0">
+    <testCase name="Vector matchers that fail/Equals" duration="{duration}">
       <failure message="CHECK_THAT(v, Equals(v2))">
 FAILED:
 	CHECK_THAT( v, Equals(v2) )
@@ -1132,7 +1132,7 @@ with expansion:
 Matchers.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Vector matchers that fail/UnorderedEquals" duration="0">
+    <testCase name="Vector matchers that fail/UnorderedEquals" duration="{duration}">
       <failure message="CHECK_THAT(v, UnorderedEquals(empty))">
 FAILED:
 	CHECK_THAT( v, UnorderedEquals(empty) )
@@ -1164,32 +1164,32 @@ Matchers.tests.cpp:<line number>
     </testCase>
   </file>
   <file path="projects/<exe-name>/UsageTests/Message.tests.cpp">
-    <testCase name="#1455 - INFO and WARN can start with a linebreak" duration="0"/>
-    <testCase name="CAPTURE can deal with complex expressions" duration="0"/>
-    <testCase name="CAPTURE can deal with complex expressions involving commas" duration="0"/>
-    <testCase name="CAPTURE parses string and character constants" duration="0"/>
-    <testCase name="FAIL aborts the test" duration="0">
+    <testCase name="#1455 - INFO and WARN can start with a linebreak" duration="{duration}"/>
+    <testCase name="CAPTURE can deal with complex expressions" duration="{duration}"/>
+    <testCase name="CAPTURE can deal with complex expressions involving commas" duration="{duration}"/>
+    <testCase name="CAPTURE parses string and character constants" duration="{duration}"/>
+    <testCase name="FAIL aborts the test" duration="{duration}">
       <failure message="FAIL()">
 FAILED:
 This is a failure
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="FAIL does not require an argument" duration="0">
+    <testCase name="FAIL does not require an argument" duration="{duration}">
       <failure message="FAIL()">
 FAILED:
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="FAIL_CHECK does not abort the test" duration="0">
+    <testCase name="FAIL_CHECK does not abort the test" duration="{duration}">
       <failure message="FAIL_CHECK()">
 FAILED:
 This is a failure
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="INFO and WARN do not abort tests" duration="0"/>
-    <testCase name="INFO gets logged on failure" duration="0">
+    <testCase name="INFO and WARN do not abort tests" duration="{duration}"/>
+    <testCase name="INFO gets logged on failure" duration="{duration}">
       <failure message="REQUIRE(a == 1)">
 FAILED:
 	REQUIRE( a == 1 )
@@ -1200,7 +1200,7 @@ so should this
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="INFO gets logged on failure, even if captured before successful assertions" duration="0">
+    <testCase name="INFO gets logged on failure, even if captured before successful assertions" duration="{duration}">
       <failure message="CHECK(a == 1)">
 FAILED:
 	CHECK( a == 1 )
@@ -1221,7 +1221,7 @@ and this, but later
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="INFO is reset for each loop" duration="0">
+    <testCase name="INFO is reset for each loop" duration="{duration}">
       <failure message="REQUIRE(i &lt; 10)">
 FAILED:
 	REQUIRE( i &lt; 10 )
@@ -1232,40 +1232,40 @@ i := 10
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Output from all sections is reported/one" duration="0">
+    <testCase name="Output from all sections is reported/one" duration="{duration}">
       <failure message="FAIL()">
 FAILED:
 Message from section one
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Output from all sections is reported/two" duration="0">
+    <testCase name="Output from all sections is reported/two" duration="{duration}">
       <failure message="FAIL()">
 FAILED:
 Message from section two
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="SUCCEED counts as a test pass" duration="0"/>
-    <testCase name="SUCCEED does not require an argument" duration="0"/>
-    <testCase name="Standard output from all sections is reported/two" duration="0"/>
-    <testCase name="The NO_FAIL macro reports a failure but does not fail the test" duration="0"/>
-    <testCase name="just failure" duration="0">
+    <testCase name="SUCCEED counts as a test pass" duration="{duration}"/>
+    <testCase name="SUCCEED does not require an argument" duration="{duration}"/>
+    <testCase name="Standard output from all sections is reported/two" duration="{duration}"/>
+    <testCase name="The NO_FAIL macro reports a failure but does not fail the test" duration="{duration}"/>
+    <testCase name="just failure" duration="{duration}">
       <failure message="FAIL()">
 FAILED:
 Previous info should not be seen
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="just failure after unscoped info" duration="0">
+    <testCase name="just failure after unscoped info" duration="{duration}">
       <failure message="FAIL()">
 FAILED:
 previous unscoped info SHOULD not be seen
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="mix info, unscoped info and warning" duration="0"/>
-    <testCase name="not prints unscoped info from previous failures" duration="0">
+    <testCase name="mix info, unscoped info and warning" duration="{duration}"/>
+    <testCase name="not prints unscoped info from previous failures" duration="{duration}">
       <failure message="REQUIRE(false)">
 FAILED:
 	REQUIRE( false )
@@ -1273,8 +1273,8 @@ this SHOULD be seen
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="print unscoped info if passing unscoped info is printed" duration="0"/>
-    <testCase name="prints unscoped info on failure" duration="0">
+    <testCase name="print unscoped info if passing unscoped info is printed" duration="{duration}"/>
+    <testCase name="prints unscoped info on failure" duration="{duration}">
       <failure message="REQUIRE(false)">
 FAILED:
 	REQUIRE( false )
@@ -1283,7 +1283,7 @@ this SHOULD also be seen
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="prints unscoped info only for the first assertion" duration="0">
+    <testCase name="prints unscoped info only for the first assertion" duration="{duration}">
       <failure message="CHECK(false)">
 FAILED:
 	CHECK( false )
@@ -1291,7 +1291,7 @@ this SHOULD be seen only ONCE
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="sends information to INFO" duration="0">
+    <testCase name="sends information to INFO" duration="{duration}">
       <failure message="REQUIRE(false)">
 FAILED:
 	REQUIRE( false )
@@ -1300,7 +1300,7 @@ i := 7
 Message.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="stacks unscoped info in loops" duration="0">
+    <testCase name="stacks unscoped info in loops" duration="{duration}">
       <failure message="CHECK(false)">
 FAILED:
 	CHECK( false )
@@ -1322,9 +1322,9 @@ Message.tests.cpp:<line number>
     </testCase>
   </file>
   <file path="projects/<exe-name>/UsageTests/Misc.tests.cpp">
-    <testCase name="# A test name that starts with a #" duration="0"/>
-    <testCase name="#1175 - Hidden Test" duration="0"/>
-    <testCase name="#835 -- errno should not be touched by Catch" duration="0">
+    <testCase name="# A test name that starts with a #" duration="{duration}"/>
+    <testCase name="#1175 - Hidden Test" duration="{duration}"/>
+    <testCase name="#835 -- errno should not be touched by Catch" duration="{duration}">
       <skipped message="CHECK(f() == 0)">
 FAILED:
 	CHECK( f() == 0 )
@@ -1333,35 +1333,35 @@ with expansion:
 Misc.tests.cpp:<line number>
       </skipped>
     </testCase>
-    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 0" duration="0"/>
-    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 1" duration="0"/>
-    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 2" duration="0"/>
-    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 3" duration="0"/>
-    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 4" duration="0"/>
-    <testCase name="A Template product test case - Foo&lt;float>" duration="0"/>
-    <testCase name="A Template product test case - Foo&lt;int>" duration="0"/>
-    <testCase name="A Template product test case - std::vector&lt;float>" duration="0"/>
-    <testCase name="A Template product test case - std::vector&lt;int>" duration="0"/>
-    <testCase name="A Template product test case with array signature - Bar&lt;float, 42>" duration="0"/>
-    <testCase name="A Template product test case with array signature - Bar&lt;int, 9>" duration="0"/>
-    <testCase name="A Template product test case with array signature - std::array&lt;float, 42>" duration="0"/>
-    <testCase name="A Template product test case with array signature - std::array&lt;int, 9>" duration="0"/>
-    <testCase name="A couple of nested sections followed by a failure" duration="0">
+    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 0" duration="{duration}"/>
+    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 1" duration="{duration}"/>
+    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 2" duration="{duration}"/>
+    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 3" duration="{duration}"/>
+    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 4" duration="{duration}"/>
+    <testCase name="A Template product test case - Foo&lt;float>" duration="{duration}"/>
+    <testCase name="A Template product test case - Foo&lt;int>" duration="{duration}"/>
+    <testCase name="A Template product test case - std::vector&lt;float>" duration="{duration}"/>
+    <testCase name="A Template product test case - std::vector&lt;int>" duration="{duration}"/>
+    <testCase name="A Template product test case with array signature - Bar&lt;float, 42>" duration="{duration}"/>
+    <testCase name="A Template product test case with array signature - Bar&lt;int, 9>" duration="{duration}"/>
+    <testCase name="A Template product test case with array signature - std::array&lt;float, 42>" duration="{duration}"/>
+    <testCase name="A Template product test case with array signature - std::array&lt;int, 9>" duration="{duration}"/>
+    <testCase name="A couple of nested sections followed by a failure" duration="{duration}">
       <failure message="FAIL()">
 FAILED:
 to infinity and beyond
 Misc.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="A couple of nested sections followed by a failure/Outer/Inner" duration="0"/>
-    <testCase name="Factorials are computed" duration="0"/>
-    <testCase name="ManuallyRegistered" duration="0"/>
-    <testCase name="Nice descriptive name" duration="0"/>
-    <testCase name="Product with differing arities - std::tuple&lt;int, double, float>" duration="0"/>
-    <testCase name="Product with differing arities - std::tuple&lt;int, double>" duration="0"/>
-    <testCase name="Product with differing arities - std::tuple&lt;int>" duration="0"/>
-    <testCase name="Sends stuff to stdout and stderr" duration="0"/>
-    <testCase name="Tabs and newlines show in output" duration="0">
+    <testCase name="A couple of nested sections followed by a failure/Outer/Inner" duration="{duration}"/>
+    <testCase name="Factorials are computed" duration="{duration}"/>
+    <testCase name="ManuallyRegistered" duration="{duration}"/>
+    <testCase name="Nice descriptive name" duration="{duration}"/>
+    <testCase name="Product with differing arities - std::tuple&lt;int, double, float>" duration="{duration}"/>
+    <testCase name="Product with differing arities - std::tuple&lt;int, double>" duration="{duration}"/>
+    <testCase name="Product with differing arities - std::tuple&lt;int>" duration="{duration}"/>
+    <testCase name="Sends stuff to stdout and stderr" duration="{duration}"/>
+    <testCase name="Tabs and newlines show in output" duration="{duration}">
       <failure message="CHECK(s1 == s2)">
 FAILED:
 	CHECK( s1 == s2 )
@@ -1377,64 +1377,64 @@ with expansion:
 Misc.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 0" duration="0"/>
-    <testCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 1" duration="0"/>
-    <testCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 2" duration="0"/>
-    <testCase name="Template test case with test types specified inside std::tuple - MyTypes - 0" duration="0"/>
-    <testCase name="Template test case with test types specified inside std::tuple - MyTypes - 1" duration="0"/>
-    <testCase name="Template test case with test types specified inside std::tuple - MyTypes - 2" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - float" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - float/resizing bigger changes size and capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - float/resizing smaller changes size but not capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - float/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - float/reserving bigger changes capacity but not size" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - float/reserving smaller does not change size or capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - int" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - int/resizing bigger changes size and capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - int/resizing smaller changes size but not capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - int/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - int/reserving bigger changes capacity but not size" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - int/reserving smaller does not change size or capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - std::string" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - std::string/resizing bigger changes size and capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - std::string/resizing smaller changes size but not capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - std::string/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - std::string/reserving bigger changes capacity but not size" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - std::string/reserving smaller does not change size or capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/resizing bigger changes size and capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/resizing smaller changes size but not capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/reserving bigger changes capacity but not size" duration="0"/>
-    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/reserving smaller does not change size or capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/resizing bigger changes size and capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/resizing smaller changes size but not capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/reserving bigger changes capacity but not size" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/reserving smaller does not change size or capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/resizing bigger changes size and capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/resizing smaller changes size but not capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/reserving bigger changes capacity but not size" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/reserving smaller does not change size or capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/resizing bigger changes size and capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/resizing smaller changes size but not capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/reserving bigger changes capacity but not size" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/reserving smaller does not change size or capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/resizing bigger changes size and capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/resizing smaller changes size but not capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/reserving bigger changes capacity but not size" duration="0"/>
-    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/reserving smaller does not change size or capacity" duration="0"/>
-    <testCase name="This test 'should' fail but doesn't" duration="0"/>
-    <testCase name="atomic if" duration="0"/>
-    <testCase name="checkedElse" duration="0"/>
-    <testCase name="checkedElse, failing" duration="0">
+    <testCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 0" duration="{duration}"/>
+    <testCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 1" duration="{duration}"/>
+    <testCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 2" duration="{duration}"/>
+    <testCase name="Template test case with test types specified inside std::tuple - MyTypes - 0" duration="{duration}"/>
+    <testCase name="Template test case with test types specified inside std::tuple - MyTypes - 1" duration="{duration}"/>
+    <testCase name="Template test case with test types specified inside std::tuple - MyTypes - 2" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - float" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - float/resizing bigger changes size and capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - float/resizing smaller changes size but not capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - float/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - float/reserving bigger changes capacity but not size" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - float/reserving smaller does not change size or capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - int" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - int/resizing bigger changes size and capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - int/resizing smaller changes size but not capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - int/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - int/reserving bigger changes capacity but not size" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - int/reserving smaller does not change size or capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::string" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::string/resizing bigger changes size and capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::string/resizing smaller changes size but not capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::string/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::string/reserving bigger changes capacity but not size" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::string/reserving smaller does not change size or capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/resizing bigger changes size and capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/resizing smaller changes size but not capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/reserving bigger changes capacity but not size" duration="{duration}"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/reserving smaller does not change size or capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/resizing bigger changes size and capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/resizing smaller changes size but not capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/reserving bigger changes capacity but not size" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/reserving smaller does not change size or capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/resizing bigger changes size and capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/resizing smaller changes size but not capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/reserving bigger changes capacity but not size" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/reserving smaller does not change size or capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/resizing bigger changes size and capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/resizing smaller changes size but not capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/reserving bigger changes capacity but not size" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/reserving smaller does not change size or capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/resizing bigger changes size and capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/resizing smaller changes size but not capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/reserving bigger changes capacity but not size" duration="{duration}"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/reserving smaller does not change size or capacity" duration="{duration}"/>
+    <testCase name="This test 'should' fail but doesn't" duration="{duration}"/>
+    <testCase name="atomic if" duration="{duration}"/>
+    <testCase name="checkedElse" duration="{duration}"/>
+    <testCase name="checkedElse, failing" duration="{duration}">
       <failure message="CHECKED_ELSE(flag)">
 FAILED:
 	CHECKED_ELSE( flag )
@@ -1450,8 +1450,8 @@ with expansion:
 Misc.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="checkedIf" duration="0"/>
-    <testCase name="checkedIf, failing" duration="0">
+    <testCase name="checkedIf" duration="{duration}"/>
+    <testCase name="checkedIf, failing" duration="{duration}">
       <failure message="CHECKED_IF(flag)">
 FAILED:
 	CHECKED_IF( flag )
@@ -1467,11 +1467,11 @@ with expansion:
 Misc.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="even more nested SECTION tests/c/d (leaf)" duration="0"/>
-    <testCase name="even more nested SECTION tests/c/e (leaf)" duration="0"/>
-    <testCase name="even more nested SECTION tests/f (leaf)" duration="0"/>
-    <testCase name="long long" duration="0"/>
-    <testCase name="looped SECTION tests/b is currently: 0" duration="0">
+    <testCase name="even more nested SECTION tests/c/d (leaf)" duration="{duration}"/>
+    <testCase name="even more nested SECTION tests/c/e (leaf)" duration="{duration}"/>
+    <testCase name="even more nested SECTION tests/f (leaf)" duration="{duration}"/>
+    <testCase name="long long" duration="{duration}"/>
+    <testCase name="looped SECTION tests/b is currently: 0" duration="{duration}">
       <failure message="CHECK(b > a)">
 FAILED:
 	CHECK( b > a )
@@ -1480,7 +1480,7 @@ with expansion:
 Misc.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="looped SECTION tests/b is currently: 1" duration="0">
+    <testCase name="looped SECTION tests/b is currently: 1" duration="{duration}">
       <failure message="CHECK(b > a)">
 FAILED:
 	CHECK( b > a )
@@ -1489,15 +1489,15 @@ with expansion:
 Misc.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="looped SECTION tests/b is currently: 2" duration="0"/>
-    <testCase name="looped SECTION tests/b is currently: 3" duration="0"/>
-    <testCase name="looped SECTION tests/b is currently: 4" duration="0"/>
-    <testCase name="looped SECTION tests/b is currently: 5" duration="0"/>
-    <testCase name="looped SECTION tests/b is currently: 6" duration="0"/>
-    <testCase name="looped SECTION tests/b is currently: 7" duration="0"/>
-    <testCase name="looped SECTION tests/b is currently: 8" duration="0"/>
-    <testCase name="looped SECTION tests/b is currently: 9" duration="0"/>
-    <testCase name="looped tests" duration="0">
+    <testCase name="looped SECTION tests/b is currently: 2" duration="{duration}"/>
+    <testCase name="looped SECTION tests/b is currently: 3" duration="{duration}"/>
+    <testCase name="looped SECTION tests/b is currently: 4" duration="{duration}"/>
+    <testCase name="looped SECTION tests/b is currently: 5" duration="{duration}"/>
+    <testCase name="looped SECTION tests/b is currently: 6" duration="{duration}"/>
+    <testCase name="looped SECTION tests/b is currently: 7" duration="{duration}"/>
+    <testCase name="looped SECTION tests/b is currently: 8" duration="{duration}"/>
+    <testCase name="looped SECTION tests/b is currently: 9" duration="{duration}"/>
+    <testCase name="looped tests" duration="{duration}">
       <failure message="CHECK(( fib[i] % 2 ) == 0)">
 FAILED:
 	CHECK( ( fib[i] % 2 ) == 0 )
@@ -1547,7 +1547,7 @@ Testing if fib[7] (21) is even
 Misc.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="more nested SECTION tests/equal/doesn't equal" duration="0">
+    <testCase name="more nested SECTION tests/equal/doesn't equal" duration="{duration}">
       <failure message="REQUIRE(a == b)">
 FAILED:
 	REQUIRE( a == b )
@@ -1556,15 +1556,15 @@ with expansion:
 Misc.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="more nested SECTION tests/doesn't equal/not equal" duration="0"/>
-    <testCase name="more nested SECTION tests/doesn't equal/less than" duration="0"/>
-    <testCase name="nested SECTION tests/doesn't equal" duration="0"/>
-    <testCase name="nested SECTION tests/doesn't equal/not equal" duration="0"/>
-    <testCase name="not allowed" duration="0"/>
-    <testCase name="null strings" duration="0"/>
-    <testCase name="random SECTION tests/doesn't equal" duration="0"/>
-    <testCase name="random SECTION tests/not equal" duration="0"/>
-    <testCase name="send a single char to INFO" duration="0">
+    <testCase name="more nested SECTION tests/doesn't equal/not equal" duration="{duration}"/>
+    <testCase name="more nested SECTION tests/doesn't equal/less than" duration="{duration}"/>
+    <testCase name="nested SECTION tests/doesn't equal" duration="{duration}"/>
+    <testCase name="nested SECTION tests/doesn't equal/not equal" duration="{duration}"/>
+    <testCase name="not allowed" duration="{duration}"/>
+    <testCase name="null strings" duration="{duration}"/>
+    <testCase name="random SECTION tests/doesn't equal" duration="{duration}"/>
+    <testCase name="random SECTION tests/not equal" duration="{duration}"/>
+    <testCase name="send a single char to INFO" duration="{duration}">
       <failure message="REQUIRE(false)">
 FAILED:
 	REQUIRE( false )
@@ -1572,90 +1572,90 @@ FAILED:
 Misc.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="toString on const wchar_t const pointer returns the string contents" duration="0"/>
-    <testCase name="toString on const wchar_t pointer returns the string contents" duration="0"/>
-    <testCase name="toString on wchar_t const pointer returns the string contents" duration="0"/>
-    <testCase name="toString on wchar_t returns the string contents" duration="0"/>
-    <testCase name="vectors can be sized and resized" duration="0"/>
-    <testCase name="vectors can be sized and resized/resizing bigger changes size and capacity" duration="0"/>
-    <testCase name="vectors can be sized and resized/resizing smaller changes size but not capacity" duration="0"/>
-    <testCase name="vectors can be sized and resized/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
-    <testCase name="vectors can be sized and resized/reserving bigger changes capacity but not size" duration="0"/>
-    <testCase name="vectors can be sized and resized/reserving smaller does not change size or capacity" duration="0"/>
-    <testCase name="xmlentitycheck/embedded xml: &lt;test>it should be possible to embed xml characters, such as &lt;, &quot; or &amp;, or even whole &lt;xml>documents&lt;/xml> within an attribute&lt;/test>" duration="0"/>
-    <testCase name="xmlentitycheck/encoded chars: these should all be encoded: &amp;&amp;&amp;&quot;&quot;&quot;&lt;&lt;&lt;&amp;&quot;&lt;&lt;&amp;&quot;" duration="0"/>
+    <testCase name="toString on const wchar_t const pointer returns the string contents" duration="{duration}"/>
+    <testCase name="toString on const wchar_t pointer returns the string contents" duration="{duration}"/>
+    <testCase name="toString on wchar_t const pointer returns the string contents" duration="{duration}"/>
+    <testCase name="toString on wchar_t returns the string contents" duration="{duration}"/>
+    <testCase name="vectors can be sized and resized" duration="{duration}"/>
+    <testCase name="vectors can be sized and resized/resizing bigger changes size and capacity" duration="{duration}"/>
+    <testCase name="vectors can be sized and resized/resizing smaller changes size but not capacity" duration="{duration}"/>
+    <testCase name="vectors can be sized and resized/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="{duration}"/>
+    <testCase name="vectors can be sized and resized/reserving bigger changes capacity but not size" duration="{duration}"/>
+    <testCase name="vectors can be sized and resized/reserving smaller does not change size or capacity" duration="{duration}"/>
+    <testCase name="xmlentitycheck/embedded xml: &lt;test>it should be possible to embed xml characters, such as &lt;, &quot; or &amp;, or even whole &lt;xml>documents&lt;/xml> within an attribute&lt;/test>" duration="{duration}"/>
+    <testCase name="xmlentitycheck/encoded chars: these should all be encoded: &amp;&amp;&amp;&quot;&quot;&quot;&lt;&lt;&lt;&amp;&quot;&lt;&lt;&amp;&quot;" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/ToStringChrono.tests.cpp">
-    <testCase name="Stringifying std::chrono::duration helpers" duration="0"/>
-    <testCase name="Stringifying std::chrono::duration with weird ratios" duration="0"/>
-    <testCase name="Stringifying std::chrono::time_point&lt;system_clock>" duration="0"/>
+    <testCase name="Stringifying std::chrono::duration helpers" duration="{duration}"/>
+    <testCase name="Stringifying std::chrono::duration with weird ratios" duration="{duration}"/>
+    <testCase name="Stringifying std::chrono::time_point&lt;system_clock>" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/ToStringGeneral.tests.cpp">
-    <testCase name="Capture and info messages/Capture should stringify like assertions" duration="0"/>
-    <testCase name="Capture and info messages/Info should NOT stringify the way assertions do" duration="0"/>
-    <testCase name="Character pretty printing/Specifically escaped" duration="0"/>
-    <testCase name="Character pretty printing/General chars" duration="0"/>
-    <testCase name="Character pretty printing/Low ASCII" duration="0"/>
-    <testCase name="Exception as a value (e.g. in REQUIRE_THROWS_MATCHES) can be stringified" duration="0"/>
-    <testCase name="Precision of floating point stringification can be set/Floats" duration="0"/>
-    <testCase name="Precision of floating point stringification can be set/Double" duration="0"/>
-    <testCase name="Static arrays are convertible to string/Single item" duration="0"/>
-    <testCase name="Static arrays are convertible to string/Multiple" duration="0"/>
-    <testCase name="Static arrays are convertible to string/Non-trivial inner items" duration="0"/>
-    <testCase name="std::map is convertible string/empty" duration="0"/>
-    <testCase name="std::map is convertible string/single item" duration="0"/>
-    <testCase name="std::map is convertible string/several items" duration="0"/>
-    <testCase name="std::set is convertible string/empty" duration="0"/>
-    <testCase name="std::set is convertible string/single item" duration="0"/>
-    <testCase name="std::set is convertible string/several items" duration="0"/>
+    <testCase name="Capture and info messages/Capture should stringify like assertions" duration="{duration}"/>
+    <testCase name="Capture and info messages/Info should NOT stringify the way assertions do" duration="{duration}"/>
+    <testCase name="Character pretty printing/Specifically escaped" duration="{duration}"/>
+    <testCase name="Character pretty printing/General chars" duration="{duration}"/>
+    <testCase name="Character pretty printing/Low ASCII" duration="{duration}"/>
+    <testCase name="Exception as a value (e.g. in REQUIRE_THROWS_MATCHES) can be stringified" duration="{duration}"/>
+    <testCase name="Precision of floating point stringification can be set/Floats" duration="{duration}"/>
+    <testCase name="Precision of floating point stringification can be set/Double" duration="{duration}"/>
+    <testCase name="Static arrays are convertible to string/Single item" duration="{duration}"/>
+    <testCase name="Static arrays are convertible to string/Multiple" duration="{duration}"/>
+    <testCase name="Static arrays are convertible to string/Non-trivial inner items" duration="{duration}"/>
+    <testCase name="std::map is convertible string/empty" duration="{duration}"/>
+    <testCase name="std::map is convertible string/single item" duration="{duration}"/>
+    <testCase name="std::map is convertible string/several items" duration="{duration}"/>
+    <testCase name="std::set is convertible string/empty" duration="{duration}"/>
+    <testCase name="std::set is convertible string/single item" duration="{duration}"/>
+    <testCase name="std::set is convertible string/several items" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/ToStringPair.tests.cpp">
-    <testCase name="pair&lt;pair&lt;int,const char *,pair&lt;std::string,int> > -> toString" duration="0"/>
-    <testCase name="std::pair&lt;int,const std::string> -> toString" duration="0"/>
-    <testCase name="std::pair&lt;int,std::string> -> toString" duration="0"/>
-    <testCase name="std::vector&lt;std::pair&lt;std::string,int> > -> toString" duration="0"/>
+    <testCase name="pair&lt;pair&lt;int,const char *,pair&lt;std::string,int> > -> toString" duration="{duration}"/>
+    <testCase name="std::pair&lt;int,const std::string> -> toString" duration="{duration}"/>
+    <testCase name="std::pair&lt;int,std::string> -> toString" duration="{duration}"/>
+    <testCase name="std::vector&lt;std::pair&lt;std::string,int> > -> toString" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/ToStringTuple.tests.cpp">
-    <testCase name="tuple&lt;>" duration="0"/>
-    <testCase name="tuple&lt;float,int>" duration="0"/>
-    <testCase name="tuple&lt;int>" duration="0"/>
-    <testCase name="tuple&lt;0,int,const char *>" duration="0"/>
-    <testCase name="tuple&lt;string,string>" duration="0"/>
-    <testCase name="tuple&lt;tuple&lt;int>,tuple&lt;>,float>" duration="0"/>
+    <testCase name="tuple&lt;>" duration="{duration}"/>
+    <testCase name="tuple&lt;float,int>" duration="{duration}"/>
+    <testCase name="tuple&lt;int>" duration="{duration}"/>
+    <testCase name="tuple&lt;0,int,const char *>" duration="{duration}"/>
+    <testCase name="tuple&lt;string,string>" duration="{duration}"/>
+    <testCase name="tuple&lt;tuple&lt;int>,tuple&lt;>,float>" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/ToStringVector.tests.cpp">
-    <testCase name="array&lt;int, N> -> toString" duration="0"/>
-    <testCase name="vec&lt;vec&lt;string,alloc>> -> toString" duration="0"/>
-    <testCase name="vector&lt;bool> -> toString" duration="0"/>
-    <testCase name="vector&lt;int,allocator> -> toString" duration="0"/>
-    <testCase name="vector&lt;int> -> toString" duration="0"/>
-    <testCase name="vector&lt;string> -> toString" duration="0"/>
+    <testCase name="array&lt;int, N> -> toString" duration="{duration}"/>
+    <testCase name="vec&lt;vec&lt;string,alloc>> -> toString" duration="{duration}"/>
+    <testCase name="vector&lt;bool> -> toString" duration="{duration}"/>
+    <testCase name="vector&lt;int,allocator> -> toString" duration="{duration}"/>
+    <testCase name="vector&lt;int> -> toString" duration="{duration}"/>
+    <testCase name="vector&lt;string> -> toString" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/ToStringWhich.tests.cpp">
-    <testCase name="stringify ranges" duration="0"/>
-    <testCase name="stringify( has_maker )" duration="0"/>
-    <testCase name="stringify( has_maker_and_operator )" duration="0"/>
-    <testCase name="stringify( has_neither )" duration="0"/>
-    <testCase name="stringify( has_operator )" duration="0"/>
-    <testCase name="stringify( has_template_operator )" duration="0"/>
-    <testCase name="stringify( vectors&lt;has_maker> )" duration="0"/>
-    <testCase name="stringify( vectors&lt;has_maker_and_operator> )" duration="0"/>
-    <testCase name="stringify( vectors&lt;has_operator> )" duration="0"/>
+    <testCase name="stringify ranges" duration="{duration}"/>
+    <testCase name="stringify( has_maker )" duration="{duration}"/>
+    <testCase name="stringify( has_maker_and_operator )" duration="{duration}"/>
+    <testCase name="stringify( has_neither )" duration="{duration}"/>
+    <testCase name="stringify( has_operator )" duration="{duration}"/>
+    <testCase name="stringify( has_template_operator )" duration="{duration}"/>
+    <testCase name="stringify( vectors&lt;has_maker> )" duration="{duration}"/>
+    <testCase name="stringify( vectors&lt;has_maker_and_operator> )" duration="{duration}"/>
+    <testCase name="stringify( vectors&lt;has_operator> )" duration="{duration}"/>
   </file>
   <file path="projects/<exe-name>/UsageTests/Tricky.tests.cpp">
-    <testCase name="#1514: stderr/stdout is not captured in tests aborted by an exception" duration="0">
+    <testCase name="#1514: stderr/stdout is not captured in tests aborted by an exception" duration="{duration}">
       <failure message="FAIL()">
 FAILED:
 1514
 Tricky.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="(unimplemented) static bools can be evaluated/compare to true" duration="0"/>
-    <testCase name="(unimplemented) static bools can be evaluated/compare to false" duration="0"/>
-    <testCase name="(unimplemented) static bools can be evaluated/negation" duration="0"/>
-    <testCase name="(unimplemented) static bools can be evaluated/double negation" duration="0"/>
-    <testCase name="(unimplemented) static bools can be evaluated/direct" duration="0"/>
-    <testCase name="A failing expression with a non streamable type is still captured" duration="0">
+    <testCase name="(unimplemented) static bools can be evaluated/compare to true" duration="{duration}"/>
+    <testCase name="(unimplemented) static bools can be evaluated/compare to false" duration="{duration}"/>
+    <testCase name="(unimplemented) static bools can be evaluated/negation" duration="{duration}"/>
+    <testCase name="(unimplemented) static bools can be evaluated/double negation" duration="{duration}"/>
+    <testCase name="(unimplemented) static bools can be evaluated/direct" duration="{duration}"/>
+    <testCase name="A failing expression with a non streamable type is still captured" duration="{duration}">
       <failure message="CHECK(&amp;o1 == &amp;o2)">
 FAILED:
 	CHECK( &amp;o1 == &amp;o2 )
@@ -1671,27 +1671,27 @@ with expansion:
 Tricky.tests.cpp:<line number>
       </failure>
     </testCase>
-    <testCase name="An expression with side-effects should only be evaluated once" duration="0"/>
-    <testCase name="Assertions then sections" duration="0"/>
-    <testCase name="Assertions then sections/A section" duration="0"/>
-    <testCase name="Assertions then sections/A section/Another section" duration="0"/>
-    <testCase name="Assertions then sections/A section/Another other section" duration="0"/>
-    <testCase name="Commas in various macros are allowed" duration="0"/>
-    <testCase name="Comparing function pointers" duration="0"/>
-    <testCase name="Objects that evaluated in boolean contexts can be checked" duration="0"/>
-    <testCase name="Test enum bit values" duration="0"/>
-    <testCase name="Where the LHS is not a simple value" duration="0"/>
-    <testCase name="Where there is more to the expression after the RHS" duration="0"/>
-    <testCase name="X/level/0/a" duration="0"/>
-    <testCase name="X/level/0/b" duration="0"/>
-    <testCase name="X/level/1/a" duration="0"/>
-    <testCase name="X/level/1/b" duration="0"/>
-    <testCase name="boolean member" duration="0"/>
-    <testCase name="non streamable - with conv. op" duration="0"/>
-    <testCase name="non-copyable objects" duration="0"/>
-    <testCase name="null_ptr" duration="0"/>
-    <testCase name="pointer to class" duration="0"/>
-    <testCase name="string literals of different sizes can be compared" duration="0">
+    <testCase name="An expression with side-effects should only be evaluated once" duration="{duration}"/>
+    <testCase name="Assertions then sections" duration="{duration}"/>
+    <testCase name="Assertions then sections/A section" duration="{duration}"/>
+    <testCase name="Assertions then sections/A section/Another section" duration="{duration}"/>
+    <testCase name="Assertions then sections/A section/Another other section" duration="{duration}"/>
+    <testCase name="Commas in various macros are allowed" duration="{duration}"/>
+    <testCase name="Comparing function pointers" duration="{duration}"/>
+    <testCase name="Objects that evaluated in boolean contexts can be checked" duration="{duration}"/>
+    <testCase name="Test enum bit values" duration="{duration}"/>
+    <testCase name="Where the LHS is not a simple value" duration="{duration}"/>
+    <testCase name="Where there is more to the expression after the RHS" duration="{duration}"/>
+    <testCase name="X/level/0/a" duration="{duration}"/>
+    <testCase name="X/level/0/b" duration="{duration}"/>
+    <testCase name="X/level/1/a" duration="{duration}"/>
+    <testCase name="X/level/1/b" duration="{duration}"/>
+    <testCase name="boolean member" duration="{duration}"/>
+    <testCase name="non streamable - with conv. op" duration="{duration}"/>
+    <testCase name="non-copyable objects" duration="{duration}"/>
+    <testCase name="null_ptr" duration="{duration}"/>
+    <testCase name="pointer to class" duration="{duration}"/>
+    <testCase name="string literals of different sizes can be compared" duration="{duration}">
       <failure message="REQUIRE(std::string( &quot;first&quot; ) == &quot;second&quot;)">
 FAILED:
 	REQUIRE( std::string( "first" ) == "second" )
@@ -1702,8 +1702,8 @@ Tricky.tests.cpp:<line number>
     </testCase>
   </file>
   <file path="projects/<exe-name>/UsageTests/VariadicMacros.tests.cpp">
-    <testCase name="Anonymous test case 1" duration="0"/>
-    <testCase name="Test case with one argument" duration="0"/>
-    <testCase name="Variadic macros/Section with one argument" duration="0"/>
+    <testCase name="Anonymous test case 1" duration="{duration}"/>
+    <testCase name="Test case with one argument" duration="{duration}"/>
+    <testCase name="Variadic macros/Section with one argument" duration="{duration}"/>
   </file>
 </testExecutions>

--- a/projects/SelfTest/Baselines/sonarqube.sw.approved.txt
+++ b/projects/SelfTest/Baselines/sonarqube.sw.approved.txt
@@ -1,0 +1,1709 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testExecutions version="1"loose text artifact
+>
+  <file path="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp">
+    <testCase name="Parse test names and tags/Empty test spec should have no filters" duration="0"/>
+    <testCase name="Parse test names and tags/Test spec from empty string should have no filters" duration="0"/>
+    <testCase name="Parse test names and tags/Test spec from just a comma should have no filters" duration="0"/>
+    <testCase name="Parse test names and tags/Test spec from name should have one filter" duration="0"/>
+    <testCase name="Parse test names and tags/Test spec from quoted name should have one filter" duration="0"/>
+    <testCase name="Parse test names and tags/Test spec from name should have one filter" duration="0"/>
+    <testCase name="Parse test names and tags/Wildcard at the start" duration="0"/>
+    <testCase name="Parse test names and tags/Wildcard at the end" duration="0"/>
+    <testCase name="Parse test names and tags/Wildcard at both ends" duration="0"/>
+    <testCase name="Parse test names and tags/Redundant wildcard at the start" duration="0"/>
+    <testCase name="Parse test names and tags/Redundant wildcard at the end" duration="0"/>
+    <testCase name="Parse test names and tags/Redundant wildcard at both ends" duration="0"/>
+    <testCase name="Parse test names and tags/Wildcard at both ends, redundant at start" duration="0"/>
+    <testCase name="Parse test names and tags/Just wildcard" duration="0"/>
+    <testCase name="Parse test names and tags/Single tag" duration="0"/>
+    <testCase name="Parse test names and tags/Single tag, two matches" duration="0"/>
+    <testCase name="Parse test names and tags/Two tags" duration="0"/>
+    <testCase name="Parse test names and tags/Two tags, spare separated" duration="0"/>
+    <testCase name="Parse test names and tags/Wildcarded name and tag" duration="0"/>
+    <testCase name="Parse test names and tags/Single tag exclusion" duration="0"/>
+    <testCase name="Parse test names and tags/One tag exclusion and one tag inclusion" duration="0"/>
+    <testCase name="Parse test names and tags/One tag exclusion and one wldcarded name inclusion" duration="0"/>
+    <testCase name="Parse test names and tags/One tag exclusion, using exclude:, and one wldcarded name inclusion" duration="0"/>
+    <testCase name="Parse test names and tags/name exclusion" duration="0"/>
+    <testCase name="Parse test names and tags/wildcarded name exclusion" duration="0"/>
+    <testCase name="Parse test names and tags/wildcarded name exclusion with tag inclusion" duration="0"/>
+    <testCase name="Parse test names and tags/wildcarded name exclusion, using exclude:, with tag inclusion" duration="0"/>
+    <testCase name="Parse test names and tags/two wildcarded names" duration="0"/>
+    <testCase name="Parse test names and tags/empty tag" duration="0"/>
+    <testCase name="Parse test names and tags/empty quoted name" duration="0"/>
+    <testCase name="Parse test names and tags/quoted string followed by tag exclusion" duration="0"/>
+    <testCase name="Process can be configured on command line/empty args don't cause a crash" duration="0"/>
+    <testCase name="Process can be configured on command line/default - no arguments" duration="0"/>
+    <testCase name="Process can be configured on command line/test lists/Specify one test case using" duration="0"/>
+    <testCase name="Process can be configured on command line/test lists/Specify one test case exclusion using exclude:" duration="0"/>
+    <testCase name="Process can be configured on command line/test lists/Specify one test case exclusion using ~" duration="0"/>
+    <testCase name="Process can be configured on command line/reporter/-r/console" duration="0"/>
+    <testCase name="Process can be configured on command line/reporter/-r/xml" duration="0"/>
+    <testCase name="Process can be configured on command line/reporter/--reporter/junit" duration="0"/>
+    <testCase name="Process can be configured on command line/reporter/Only one reporter is accepted" duration="0"/>
+    <testCase name="Process can be configured on command line/reporter/must match one of the available ones" duration="0"/>
+    <testCase name="Process can be configured on command line/debugger/-b" duration="0"/>
+    <testCase name="Process can be configured on command line/debugger/--break" duration="0"/>
+    <testCase name="Process can be configured on command line/abort/-a aborts after first failure" duration="0"/>
+    <testCase name="Process can be configured on command line/abort/-x 2 aborts after two failures" duration="0"/>
+    <testCase name="Process can be configured on command line/abort/-x must be numeric" duration="0"/>
+    <testCase name="Process can be configured on command line/nothrow/-e" duration="0"/>
+    <testCase name="Process can be configured on command line/nothrow/--nothrow" duration="0"/>
+    <testCase name="Process can be configured on command line/output filename/-o filename" duration="0"/>
+    <testCase name="Process can be configured on command line/output filename/--out" duration="0"/>
+    <testCase name="Process can be configured on command line/combinations/Single character flags can be combined" duration="0"/>
+    <testCase name="Process can be configured on command line/use-colour/without option" duration="0"/>
+    <testCase name="Process can be configured on command line/use-colour/auto" duration="0"/>
+    <testCase name="Process can be configured on command line/use-colour/yes" duration="0"/>
+    <testCase name="Process can be configured on command line/use-colour/no" duration="0"/>
+    <testCase name="Process can be configured on command line/use-colour/error" duration="0"/>
+    <testCase name="Process can be configured on command line/Benchmark options/samples" duration="0"/>
+    <testCase name="Process can be configured on command line/Benchmark options/resamples" duration="0"/>
+    <testCase name="Process can be configured on command line/Benchmark options/resamples" duration="0"/>
+    <testCase name="Process can be configured on command line/Benchmark options/resamples" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp">
+    <testCase name="Generators internals/Single value" duration="0"/>
+    <testCase name="Generators internals/Preset values" duration="0"/>
+    <testCase name="Generators internals/Generator combinator" duration="0"/>
+    <testCase name="Generators internals/Explicitly typed generator sequence" duration="0"/>
+    <testCase name="Generators internals/Filter generator" duration="0"/>
+    <testCase name="Generators internals/Take generator/Take less" duration="0"/>
+    <testCase name="Generators internals/Take generator/Take more" duration="0"/>
+    <testCase name="Generators internals/Map with explicit return type" duration="0"/>
+    <testCase name="Generators internals/Map with deduced return type" duration="0"/>
+    <testCase name="Generators internals/Repeat/Singular repeat" duration="0"/>
+    <testCase name="Generators internals/Repeat/Actual repeat" duration="0"/>
+    <testCase name="Generators internals/Range/Positive auto step/Integer" duration="0"/>
+    <testCase name="Generators internals/Range/Negative auto step/Integer" duration="0"/>
+    <testCase name="Generators internals/Range/Positive manual step/Integer/Exact" duration="0"/>
+    <testCase name="Generators internals/Range/Positive manual step/Integer/Slightly over end" duration="0"/>
+    <testCase name="Generators internals/Range/Positive manual step/Integer/Slightly under end" duration="0"/>
+    <testCase name="Generators internals/Range/Negative manual step/Integer/Exact" duration="0"/>
+    <testCase name="Generators internals/Range/Negative manual step/Integer/Slightly over end" duration="0"/>
+    <testCase name="Generators internals/Range/Negative manual step/Integer/Slightly under end" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/IntrospectiveTests/PartTracker.tests.cpp">
+    <testCase name="Tracker" duration="0"/>
+    <testCase name="Tracker/successfully close one section" duration="0"/>
+    <testCase name="Tracker/fail one section" duration="0"/>
+    <testCase name="Tracker/fail one section/re-enter after failed section" duration="0"/>
+    <testCase name="Tracker/fail one section/re-enter after failed section and find next section" duration="0"/>
+    <testCase name="Tracker/successfully close one section, then find another" duration="0"/>
+    <testCase name="Tracker/successfully close one section, then find another/Re-enter - skips S1 and enters S2" duration="0"/>
+    <testCase name="Tracker/successfully close one section, then find another/Re-enter - skips S1 and enters S2/Successfully close S2" duration="0"/>
+    <testCase name="Tracker/successfully close one section, then find another/Re-enter - skips S1 and enters S2/fail S2" duration="0"/>
+    <testCase name="Tracker/open a nested section" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/IntrospectiveTests/String.tests.cpp">
+    <testCase name="StringRef/Empty string" duration="0"/>
+    <testCase name="StringRef/From string literal" duration="0"/>
+    <testCase name="StringRef/From string literal/c_str() does not cause copy" duration="0"/>
+    <testCase name="StringRef/From sub-string" duration="0"/>
+    <testCase name="StringRef/Substrings/zero-based substring" duration="0"/>
+    <testCase name="StringRef/Substrings/c_str() causes copy" duration="0"/>
+    <testCase name="StringRef/Substrings/c_str() causes copy/Self-assignment after substring" duration="0"/>
+    <testCase name="StringRef/Substrings/non-zero-based substring" duration="0"/>
+    <testCase name="StringRef/Substrings/Pointer values of full refs should match" duration="0"/>
+    <testCase name="StringRef/Substrings/Pointer values of substring refs should not match" duration="0"/>
+    <testCase name="StringRef/Comparisons" duration="0"/>
+    <testCase name="StringRef/from std::string/implicitly constructed" duration="0"/>
+    <testCase name="StringRef/from std::string/explicitly constructed" duration="0"/>
+    <testCase name="StringRef/from std::string/assigned" duration="0"/>
+    <testCase name="StringRef/to std::string/implicitly constructed" duration="0"/>
+    <testCase name="StringRef/to std::string/explicitly constructed" duration="0"/>
+    <testCase name="StringRef/to std::string/assigned" duration="0"/>
+    <testCase name="StringRef/Counting utf-8 codepoints" duration="0"/>
+    <testCase name="replaceInPlace/replace single char" duration="0"/>
+    <testCase name="replaceInPlace/replace two chars" duration="0"/>
+    <testCase name="replaceInPlace/replace first char" duration="0"/>
+    <testCase name="replaceInPlace/replace last char" duration="0"/>
+    <testCase name="replaceInPlace/replace all chars" duration="0"/>
+    <testCase name="replaceInPlace/replace no chars" duration="0"/>
+    <testCase name="replaceInPlace/escape '" duration="0"/>
+    <testCase name="splitString" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/IntrospectiveTests/Tag.tests.cpp">
+    <testCase name="Tag alias can be registered against tag patterns/The same tag alias can only be registered once" duration="0"/>
+    <testCase name="Tag alias can be registered against tag patterns/Tag aliases must be of the form [@name]" duration="0"/>
+    <testCase name="shortened hide tags are split apart" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/IntrospectiveTests/ToString.tests.cpp">
+    <testCase name="Directly creating an EnumInfo" duration="0"/>
+    <testCase name="parseEnums/No enums" duration="0"/>
+    <testCase name="parseEnums/One enum value" duration="0"/>
+    <testCase name="parseEnums/Multiple enum values" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/IntrospectiveTests/Xml.tests.cpp">
+    <testCase name="XmlEncode/normal string" duration="0"/>
+    <testCase name="XmlEncode/empty string" duration="0"/>
+    <testCase name="XmlEncode/string with ampersand" duration="0"/>
+    <testCase name="XmlEncode/string with less-than" duration="0"/>
+    <testCase name="XmlEncode/string with greater-than" duration="0"/>
+    <testCase name="XmlEncode/string with quotes" duration="0"/>
+    <testCase name="XmlEncode/string with control char (1)" duration="0"/>
+    <testCase name="XmlEncode/string with control char (x7F)" duration="0"/>
+    <testCase name="XmlEncode: UTF-8/Valid utf-8 strings" duration="0"/>
+    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Various broken strings" duration="0"/>
+    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Overlong encodings" duration="0"/>
+    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Surrogate pairs" duration="0"/>
+    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Invalid start byte" duration="0"/>
+    <testCase name="XmlEncode: UTF-8/Invalid utf-8 strings/Missing continuation byte(s)" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/Approx.tests.cpp">
+    <testCase name="A comparison that uses literals instead of the normal constructor" duration="0"/>
+    <testCase name="Absolute margin" duration="0"/>
+    <testCase name="Approx setters validate their arguments" duration="0"/>
+    <testCase name="Approx with exactly-representable margin" duration="0"/>
+    <testCase name="Approximate PI" duration="0"/>
+    <testCase name="Approximate comparisons with different epsilons" duration="0"/>
+    <testCase name="Approximate comparisons with floats" duration="0"/>
+    <testCase name="Approximate comparisons with ints" duration="0"/>
+    <testCase name="Approximate comparisons with mixed numeric types" duration="0"/>
+    <testCase name="Assorted miscellaneous tests" duration="0"/>
+    <testCase name="Comparison with explicitly convertible types" duration="0"/>
+    <testCase name="Default scale is invisible to comparison" duration="0"/>
+    <testCase name="Epsilon only applies to Approx's value" duration="0"/>
+    <testCase name="Greater-than inequalities with different epsilons" duration="0"/>
+    <testCase name="Less-than inequalities with different epsilons" duration="0"/>
+    <testCase name="Some simple comparisons between doubles" duration="0"/>
+    <testCase name="Use a custom approx" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/BDD.tests.cpp">
+    <testCase name="Scenario: BDD tests requiring Fixtures to provide commonly-accessed data or methods/Given: No operations precede me" duration="0"/>
+    <testCase name="Scenario: BDD tests requiring Fixtures to provide commonly-accessed data or methods/Given: No operations precede me/When: We get the count/Then: Subsequently values are higher" duration="0"/>
+    <testCase name="Scenario: Do that thing with the thing/Given: This stuff exists/And given: And some assumption/When: I do this/Then: it should do this" duration="0"/>
+    <testCase name="Scenario: Do that thing with the thing/Given: This stuff exists/And given: And some assumption/When: I do this/Then: it should do this/And: do that" duration="0"/>
+    <testCase name="Scenario: This is a really long scenario name to see how the list command deals with wrapping/Given: A section name that is so long that it cannot fit in a single console width/When: The test headers are printed as part of the normal running of the scenario/Then: The, deliberately very long and overly verbose (you see what I did there?) section names must wrap, along with an indent" duration="0"/>
+    <testCase name="Scenario: Vector resizing affects size and capacity/Given: an empty vector" duration="0"/>
+    <testCase name="Scenario: Vector resizing affects size and capacity/Given: an empty vector/When: it is made larger/Then: the size and capacity go up" duration="0"/>
+    <testCase name="Scenario: Vector resizing affects size and capacity/Given: an empty vector/When: it is made larger/Then: the size and capacity go up/And when: it is made smaller again/Then: the size goes down but the capacity stays the same" duration="0"/>
+    <testCase name="Scenario: Vector resizing affects size and capacity/Given: an empty vector/When: we reserve more space/Then: The capacity is increased but the size remains the same" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/Class.tests.cpp">
+    <testCase name="A METHOD_AS_TEST_CASE based test run that fails" duration="0">
+      <failure message="REQUIRE(s == &quot;world&quot;)">
+FAILED:
+	REQUIRE( s == "world" )
+with expansion:
+	"hello" == "world"
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A METHOD_AS_TEST_CASE based test run that succeeds" duration="0"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - Template_Foo&lt;float>" duration="0">
+      <failure message="REQUIRE(Template_Fixture_2&lt;TestType>::m_a.size() == 1)">
+FAILED:
+	REQUIRE( Template_Fixture_2&lt;TestType>::m_a.size() == 1 )
+with expansion:
+	0 == 1
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - Template_Foo&lt;int>" duration="0">
+      <failure message="REQUIRE(Template_Fixture_2&lt;TestType>::m_a.size() == 1)">
+FAILED:
+	REQUIRE( Template_Fixture_2&lt;TestType>::m_a.size() == 1 )
+with expansion:
+	0 == 1
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - std::vector&lt;float>" duration="0">
+      <failure message="REQUIRE(Template_Fixture_2&lt;TestType>::m_a.size() == 1)">
+FAILED:
+	REQUIRE( Template_Fixture_2&lt;TestType>::m_a.size() == 1 )
+with expansion:
+	0 == 1
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that fails - std::vector&lt;int>" duration="0">
+      <failure message="REQUIRE(Template_Fixture_2&lt;TestType>::m_a.size() == 1)">
+FAILED:
+	REQUIRE( Template_Fixture_2&lt;TestType>::m_a.size() == 1 )
+with expansion:
+	0 == 1
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - Template_Foo&lt;float>" duration="0"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - Template_Foo&lt;int>" duration="0"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - std::vector&lt;float>" duration="0"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test run that succeeds - std::vector&lt;int>" duration="0"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - Template_Foo_2&lt;float, 6>" duration="0">
+      <failure message="REQUIRE(Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2)">
+FAILED:
+	REQUIRE( Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2 )
+with expansion:
+	6 &lt; 2
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - Template_Foo_2&lt;int, 2>" duration="0">
+      <failure message="REQUIRE(Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2)">
+FAILED:
+	REQUIRE( Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2 )
+with expansion:
+	2 &lt; 2
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - std::array&lt;float, 6>" duration="0">
+      <failure message="REQUIRE(Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2)">
+FAILED:
+	REQUIRE( Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2 )
+with expansion:
+	6 &lt; 2
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that fails - std::array&lt;int, 2>" duration="0">
+      <failure message="REQUIRE(Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2)">
+FAILED:
+	REQUIRE( Template_Fixture_2&lt;TestType>{}.m_a.size() &lt; 2 )
+with expansion:
+	2 &lt; 2
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - Template_Foo_2&lt;float,6>" duration="0"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - Template_Foo_2&lt;int,2>" duration="0"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - std::array&lt;float,6>" duration="0"/>
+    <testCase name="A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds - std::array&lt;int,2>" duration="0"/>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that fails - double" duration="0">
+      <failure message="REQUIRE(Template_Fixture&lt;TestType>::m_a == 2)">
+FAILED:
+	REQUIRE( Template_Fixture&lt;TestType>::m_a == 2 )
+with expansion:
+	1.0 == 2
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that fails - float" duration="0">
+      <failure message="REQUIRE(Template_Fixture&lt;TestType>::m_a == 2)">
+FAILED:
+	REQUIRE( Template_Fixture&lt;TestType>::m_a == 2 )
+with expansion:
+	1.0f == 2
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that fails - int" duration="0">
+      <failure message="REQUIRE(Template_Fixture&lt;TestType>::m_a == 2)">
+FAILED:
+	REQUIRE( Template_Fixture&lt;TestType>::m_a == 2 )
+with expansion:
+	1 == 2
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that succeeds - double" duration="0"/>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that succeeds - float" duration="0"/>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD based test run that succeeds - int" duration="0"/>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that fails - 1" duration="0">
+      <failure message="REQUIRE(Nttp_Fixture&lt;V>::value == 0)">
+FAILED:
+	REQUIRE( Nttp_Fixture&lt;V>::value == 0 )
+with expansion:
+	1 == 0
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that fails - 3" duration="0">
+      <failure message="REQUIRE(Nttp_Fixture&lt;V>::value == 0)">
+FAILED:
+	REQUIRE( Nttp_Fixture&lt;V>::value == 0 )
+with expansion:
+	3 == 0
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that fails - 6" duration="0">
+      <failure message="REQUIRE(Nttp_Fixture&lt;V>::value == 0)">
+FAILED:
+	REQUIRE( Nttp_Fixture&lt;V>::value == 0 )
+with expansion:
+	6 == 0
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds - 1" duration="0"/>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds - 3" duration="0"/>
+    <testCase name="A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds - 6" duration="0"/>
+    <testCase name="A TEST_CASE_METHOD based test run that fails" duration="0">
+      <failure message="REQUIRE(m_a == 2)">
+FAILED:
+	REQUIRE( m_a == 2 )
+with expansion:
+	1 == 2
+Class.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A TEST_CASE_METHOD based test run that succeeds" duration="0"/>
+    <testCase name="Template test case method with test types specified inside std::tuple - MyTypes - 0" duration="0"/>
+    <testCase name="Template test case method with test types specified inside std::tuple - MyTypes - 1" duration="0"/>
+    <testCase name="Template test case method with test types specified inside std::tuple - MyTypes - 2" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/Compilation.tests.cpp">
+    <testCase name="#1027" duration="0"/>
+    <testCase name="#1027: Bitfields can be captured" duration="0"/>
+    <testCase name="#1147" duration="0"/>
+    <testCase name="#1238" duration="0"/>
+    <testCase name="#1245" duration="0"/>
+    <testCase name="#1403" duration="0"/>
+    <testCase name="#1548" duration="0"/>
+    <testCase name="#809" duration="0"/>
+    <testCase name="#833" duration="0"/>
+    <testCase name="#872" duration="0"/>
+    <testCase name="Optionally static assertions" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/Condition.tests.cpp">
+    <testCase name="'Not' checks that should fail" duration="0">
+      <failure message="CHECK(false != false)">
+FAILED:
+	CHECK( false != false )
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(true != true)">
+FAILED:
+	CHECK( true != true )
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(!true)">
+FAILED:
+	CHECK( !true )
+with expansion:
+	false
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_FALSE(!(true))">
+FAILED:
+	CHECK_FALSE( true )
+with expansion:
+	!true
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(!trueValue)">
+FAILED:
+	CHECK( !trueValue )
+with expansion:
+	false
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_FALSE(!(trueValue))">
+FAILED:
+	CHECK_FALSE( trueValue )
+with expansion:
+	!true
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(!(1 == 1))">
+FAILED:
+	CHECK( !(1 == 1) )
+with expansion:
+	false
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_FALSE(!(1 == 1))">
+FAILED:
+	CHECK_FALSE( 1 == 1 )
+Condition.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="'Not' checks that should succeed" duration="0"/>
+    <testCase name="Comparisons between ints where one side is computed" duration="0"/>
+    <testCase name="Comparisons between unsigned ints and negative signed ints match c++ standard behaviour" duration="0"/>
+    <testCase name="Comparisons with int literals don't warn when mixing signed/ unsigned" duration="0"/>
+    <testCase name="Equality checks that should fail" duration="0">
+      <skipped message="CHECK(data.int_seven == 6)">
+FAILED:
+	CHECK( data.int_seven == 6 )
+with expansion:
+	7 == 6
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.int_seven == 8)">
+FAILED:
+	CHECK( data.int_seven == 8 )
+with expansion:
+	7 == 8
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.int_seven == 0)">
+FAILED:
+	CHECK( data.int_seven == 0 )
+with expansion:
+	7 == 0
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.float_nine_point_one == Approx( 9.11f ))">
+FAILED:
+	CHECK( data.float_nine_point_one == Approx( 9.11f ) )
+with expansion:
+	9.1f == Approx( 9.1099996567 )
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.float_nine_point_one == Approx( 9.0f ))">
+FAILED:
+	CHECK( data.float_nine_point_one == Approx( 9.0f ) )
+with expansion:
+	9.1f == Approx( 9.0 )
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.float_nine_point_one == Approx( 1 ))">
+FAILED:
+	CHECK( data.float_nine_point_one == Approx( 1 ) )
+with expansion:
+	9.1f == Approx( 1.0 )
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.float_nine_point_one == Approx( 0 ))">
+FAILED:
+	CHECK( data.float_nine_point_one == Approx( 0 ) )
+with expansion:
+	9.1f == Approx( 0.0 )
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.double_pi == Approx( 3.1415 ))">
+FAILED:
+	CHECK( data.double_pi == Approx( 3.1415 ) )
+with expansion:
+	3.1415926535 == Approx( 3.1415 )
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.str_hello == &quot;goodbye&quot;)">
+FAILED:
+	CHECK( data.str_hello == "goodbye" )
+with expansion:
+	"hello" == "goodbye"
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.str_hello == &quot;hell&quot;)">
+FAILED:
+	CHECK( data.str_hello == "hell" )
+with expansion:
+	"hello" == "hell"
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.str_hello == &quot;hello1&quot;)">
+FAILED:
+	CHECK( data.str_hello == "hello1" )
+with expansion:
+	"hello" == "hello1"
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.str_hello.size() == 6)">
+FAILED:
+	CHECK( data.str_hello.size() == 6 )
+with expansion:
+	5 == 6
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(x == Approx( 1.301 ))">
+FAILED:
+	CHECK( x == Approx( 1.301 ) )
+with expansion:
+	1.3 == Approx( 1.301 )
+Condition.tests.cpp:<line number>
+      </skipped>
+    </testCase>
+    <testCase name="Equality checks that should succeed" duration="0"/>
+    <testCase name="Inequality checks that should fail" duration="0">
+      <skipped message="CHECK(data.int_seven != 7)">
+FAILED:
+	CHECK( data.int_seven != 7 )
+with expansion:
+	7 != 7
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.float_nine_point_one != Approx( 9.1f ))">
+FAILED:
+	CHECK( data.float_nine_point_one != Approx( 9.1f ) )
+with expansion:
+	9.1f != Approx( 9.1000003815 )
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.double_pi != Approx( 3.1415926535 ))">
+FAILED:
+	CHECK( data.double_pi != Approx( 3.1415926535 ) )
+with expansion:
+	3.1415926535 != Approx( 3.1415926535 )
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.str_hello != &quot;hello&quot;)">
+FAILED:
+	CHECK( data.str_hello != "hello" )
+with expansion:
+	"hello" != "hello"
+Condition.tests.cpp:<line number>
+      </skipped>
+      <skipped message="CHECK(data.str_hello.size() != 5)">
+FAILED:
+	CHECK( data.str_hello.size() != 5 )
+with expansion:
+	5 != 5
+Condition.tests.cpp:<line number>
+      </skipped>
+    </testCase>
+    <testCase name="Inequality checks that should succeed" duration="0"/>
+    <testCase name="Ordering comparison checks that should fail" duration="0">
+      <failure message="CHECK(data.int_seven > 7)">
+FAILED:
+	CHECK( data.int_seven > 7 )
+with expansion:
+	7 > 7
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.int_seven &lt; 7)">
+FAILED:
+	CHECK( data.int_seven &lt; 7 )
+with expansion:
+	7 &lt; 7
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.int_seven > 8)">
+FAILED:
+	CHECK( data.int_seven > 8 )
+with expansion:
+	7 > 8
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.int_seven &lt; 6)">
+FAILED:
+	CHECK( data.int_seven &lt; 6 )
+with expansion:
+	7 &lt; 6
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.int_seven &lt; 0)">
+FAILED:
+	CHECK( data.int_seven &lt; 0 )
+with expansion:
+	7 &lt; 0
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.int_seven &lt; -1)">
+FAILED:
+	CHECK( data.int_seven &lt; -1 )
+with expansion:
+	7 &lt; -1
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.int_seven >= 8)">
+FAILED:
+	CHECK( data.int_seven >= 8 )
+with expansion:
+	7 >= 8
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.int_seven &lt;= 6)">
+FAILED:
+	CHECK( data.int_seven &lt;= 6 )
+with expansion:
+	7 &lt;= 6
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.float_nine_point_one &lt; 9)">
+FAILED:
+	CHECK( data.float_nine_point_one &lt; 9 )
+with expansion:
+	9.1f &lt; 9
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.float_nine_point_one > 10)">
+FAILED:
+	CHECK( data.float_nine_point_one > 10 )
+with expansion:
+	9.1f > 10
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.float_nine_point_one > 9.2)">
+FAILED:
+	CHECK( data.float_nine_point_one > 9.2 )
+with expansion:
+	9.1f > 9.2
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.str_hello > &quot;hello&quot;)">
+FAILED:
+	CHECK( data.str_hello > "hello" )
+with expansion:
+	"hello" > "hello"
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.str_hello &lt; &quot;hello&quot;)">
+FAILED:
+	CHECK( data.str_hello &lt; "hello" )
+with expansion:
+	"hello" &lt; "hello"
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.str_hello > &quot;hellp&quot;)">
+FAILED:
+	CHECK( data.str_hello > "hellp" )
+with expansion:
+	"hello" > "hellp"
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.str_hello > &quot;z&quot;)">
+FAILED:
+	CHECK( data.str_hello > "z" )
+with expansion:
+	"hello" > "z"
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.str_hello &lt; &quot;hellm&quot;)">
+FAILED:
+	CHECK( data.str_hello &lt; "hellm" )
+with expansion:
+	"hello" &lt; "hellm"
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.str_hello &lt; &quot;a&quot;)">
+FAILED:
+	CHECK( data.str_hello &lt; "a" )
+with expansion:
+	"hello" &lt; "a"
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.str_hello >= &quot;z&quot;)">
+FAILED:
+	CHECK( data.str_hello >= "z" )
+with expansion:
+	"hello" >= "z"
+Condition.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(data.str_hello &lt;= &quot;a&quot;)">
+FAILED:
+	CHECK( data.str_hello &lt;= "a" )
+with expansion:
+	"hello" &lt;= "a"
+Condition.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Ordering comparison checks that should succeed" duration="0"/>
+    <testCase name="Pointers can be compared to null" duration="0"/>
+    <testCase name="comparisons between const int variables" duration="0"/>
+    <testCase name="comparisons between int variables" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/Decomposition.tests.cpp">
+    <testCase name="#1005: Comparing pointer to int and long (NULL can be either on various systems)" duration="0"/>
+    <testCase name="Reconstruction should be based on stringification: #914" duration="0">
+      <failure message="CHECK(truthy(false))">
+FAILED:
+	CHECK( truthy(false) )
+with expansion:
+	Hey, its truthy!
+Decomposition.tests.cpp:<line number>
+      </failure>
+    </testCase>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/EnumToString.tests.cpp">
+    <testCase name="Enums can quickly have stringification enabled using REGISTER_ENUM" duration="0"/>
+    <testCase name="Enums in namespaces can quickly have stringification enabled using REGISTER_ENUM" duration="0"/>
+    <testCase name="toString(enum class w/operator&lt;&lt;)" duration="0"/>
+    <testCase name="toString(enum class)" duration="0"/>
+    <testCase name="toString(enum w/operator&lt;&lt;)" duration="0"/>
+    <testCase name="toString(enum)" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/Exception.tests.cpp">
+    <testCase name="#748 - captures with unexpected exceptions/outside assertions" duration="0">
+      <skipped message="TEST_CASE()">
+FAILED:
+expected exception
+answer := 42
+Exception.tests.cpp:<line number>
+      </skipped>
+    </testCase>
+    <testCase name="#748 - captures with unexpected exceptions/inside REQUIRE_NOTHROW" duration="0">
+      <skipped message="REQUIRE_NOTHROW(thisThrows())">
+FAILED:
+	REQUIRE_NOTHROW( thisThrows() )
+expected exception
+answer := 42
+Exception.tests.cpp:<line number>
+      </skipped>
+    </testCase>
+    <testCase name="#748 - captures with unexpected exceptions/inside REQUIRE_THROWS" duration="0"/>
+    <testCase name="An unchecked exception reports the line of the last assertion" duration="0">
+      <error message="({Unknown expression after the reported line})">
+FAILED:
+	{Unknown expression after the reported line}
+unexpected exception
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="Custom exceptions can be translated when testing for nothrow" duration="0">
+      <error message="REQUIRE_NOTHROW(throwCustom())">
+FAILED:
+	REQUIRE_NOTHROW( throwCustom() )
+custom exception - not std
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="Custom exceptions can be translated when testing for throwing as something else" duration="0">
+      <error message="REQUIRE_THROWS_AS(throwCustom(), std::exception)">
+FAILED:
+	REQUIRE_THROWS_AS( throwCustom(), std::exception )
+custom exception - not std
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="Custom std-exceptions can be custom translated" duration="0">
+      <error message="TEST_CASE()">
+FAILED:
+custom std exception
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="Exception messages can be tested for/exact match" duration="0"/>
+    <testCase name="Exception messages can be tested for/different case" duration="0"/>
+    <testCase name="Exception messages can be tested for/wildcarded" duration="0"/>
+    <testCase name="Expected exceptions that don't throw or unexpected exceptions fail the test" duration="0">
+      <error message="CHECK_THROWS_AS(thisThrows(), std::string)">
+FAILED:
+	CHECK_THROWS_AS( thisThrows(), std::string )
+expected exception
+Exception.tests.cpp:<line number>
+      </error>
+      <failure message="CHECK_THROWS_AS(thisDoesntThrow(), std::domain_error)">
+FAILED:
+	CHECK_THROWS_AS( thisDoesntThrow(), std::domain_error )
+Exception.tests.cpp:<line number>
+      </failure>
+      <error message="CHECK_NOTHROW(thisThrows())">
+FAILED:
+	CHECK_NOTHROW( thisThrows() )
+expected exception
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="Mismatching exception messages failing the test" duration="0">
+      <failure message="REQUIRE_THROWS_WITH(thisThrows(), &quot;should fail&quot;)">
+FAILED:
+	REQUIRE_THROWS_WITH( thisThrows(), "should fail" )
+with expansion:
+	"expected exception" equals: "should fail"
+Exception.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Non-std exceptions can be translated" duration="0">
+      <error message="TEST_CASE()">
+FAILED:
+custom exception
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="Thrown string literals are translated" duration="0">
+      <error message="TEST_CASE()">
+FAILED:
+For some reason someone is throwing a string literal!
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="Unexpected exceptions can be translated" duration="0">
+      <error message="TEST_CASE()">
+FAILED:
+3.14
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="When checked exceptions are thrown they can be expected or unexpected" duration="0"/>
+    <testCase name="When unchecked exceptions are thrown directly they are always failures" duration="0">
+      <error message="TEST_CASE()">
+FAILED:
+unexpected exception
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="When unchecked exceptions are thrown during a CHECK the test should continue" duration="0">
+      <error message="CHECK(thisThrows() == 0)">
+FAILED:
+	CHECK( thisThrows() == 0 )
+expected exception
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="When unchecked exceptions are thrown during a REQUIRE the test should abort fail" duration="0">
+      <error message="REQUIRE(thisThrows() == 0)">
+FAILED:
+	REQUIRE( thisThrows() == 0 )
+expected exception
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="When unchecked exceptions are thrown from functions they are always failures" duration="0">
+      <error message="CHECK(thisThrows() == 0)">
+FAILED:
+	CHECK( thisThrows() == 0 )
+expected exception
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="When unchecked exceptions are thrown from sections they are always failures/section name" duration="0">
+      <error message="TEST_CASE()">
+FAILED:
+unexpected exception
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="thrown std::strings are translated" duration="0">
+      <error message="TEST_CASE()">
+FAILED:
+Why would you throw a std::string?
+Exception.tests.cpp:<line number>
+      </error>
+    </testCase>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/Generators.tests.cpp">
+    <testCase name="3x3x3 ints" duration="0"/>
+    <testCase name="Generators -- adapters/Filtering by predicate/Basic usage" duration="0"/>
+    <testCase name="Generators -- adapters/Filtering by predicate/Throws if there are no matching values" duration="0"/>
+    <testCase name="Generators -- adapters/Shortening a range" duration="0"/>
+    <testCase name="Generators -- adapters/Transforming elements/Same type" duration="0"/>
+    <testCase name="Generators -- adapters/Transforming elements/Different type" duration="0"/>
+    <testCase name="Generators -- adapters/Transforming elements/Different deduced type" duration="0"/>
+    <testCase name="Generators -- adapters/Repeating a generator" duration="0"/>
+    <testCase name="Generators -- adapters/Chunking a generator into sized pieces/Number of elements in source is divisible by chunk size" duration="0"/>
+    <testCase name="Generators -- adapters/Chunking a generator into sized pieces/Number of elements in source is not divisible by chunk size" duration="0"/>
+    <testCase name="Generators -- adapters/Chunking a generator into sized pieces/Chunk size of zero" duration="0"/>
+    <testCase name="Generators -- adapters/Chunking a generator into sized pieces/Throws on too small generators" duration="0"/>
+    <testCase name="Generators -- simple/one" duration="0"/>
+    <testCase name="Generators -- simple/two" duration="0"/>
+    <testCase name="Nested generators and captured variables" duration="0"/>
+    <testCase name="strlen3" duration="0"/>
+    <testCase name="tables" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/Matchers.tests.cpp">
+    <testCase name="Arbitrary predicate matcher/Function pointer" duration="0"/>
+    <testCase name="Arbitrary predicate matcher/Lambdas + different type" duration="0"/>
+    <testCase name="Contains string matcher" duration="0">
+      <failure message="CHECK_THAT(testStringForMatching(), Contains(&quot;not there&quot;, Catch::CaseSensitive::No))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), Contains("not there", Catch::CaseSensitive::No) )
+with expansion:
+	"this string contains 'abc' as a substring" contains: "not there" (case insensitive)
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(testStringForMatching(), Contains(&quot;STRING&quot;))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), Contains("STRING") )
+with expansion:
+	"this string contains 'abc' as a substring" contains: "STRING"
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="EndsWith string matcher" duration="0">
+      <failure message="CHECK_THAT(testStringForMatching(), EndsWith(&quot;Substring&quot;))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), EndsWith("Substring") )
+with expansion:
+	"this string contains 'abc' as a substring" ends with: "Substring"
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(testStringForMatching(), EndsWith(&quot;this&quot;, Catch::CaseSensitive::No))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), EndsWith("this", Catch::CaseSensitive::No) )
+with expansion:
+	"this string contains 'abc' as a substring" ends with: "this" (case insensitive)
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Equals" duration="0"/>
+    <testCase name="Equals string matcher" duration="0">
+      <failure message="CHECK_THAT(testStringForMatching(), Equals(&quot;this string contains 'ABC' as a substring&quot;))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), Equals("this string contains 'ABC' as a substring") )
+with expansion:
+	"this string contains 'abc' as a substring" equals: "this string contains 'ABC' as a substring"
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(testStringForMatching(), Equals(&quot;something else&quot;, Catch::CaseSensitive::No))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), Equals("something else", Catch::CaseSensitive::No) )
+with expansion:
+	"this string contains 'abc' as a substring" equals: "something else" (case insensitive)
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Exception matchers that fail/No exception" duration="0">
+      <failure message="CHECK_THROWS_MATCHES(doesNotThrow(), SpecialException, ExceptionMatcher{1})">
+FAILED:
+	CHECK_THROWS_MATCHES( doesNotThrow(), SpecialException, ExceptionMatcher{1} )
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="REQUIRE_THROWS_MATCHES(doesNotThrow(), SpecialException, ExceptionMatcher{1})">
+FAILED:
+	REQUIRE_THROWS_MATCHES( doesNotThrow(), SpecialException, ExceptionMatcher{1} )
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Exception matchers that fail/Type mismatch" duration="0">
+      <error message="CHECK_THROWS_MATCHES(throwsAsInt(1), SpecialException, ExceptionMatcher{1})">
+FAILED:
+	CHECK_THROWS_MATCHES( throwsAsInt(1), SpecialException, ExceptionMatcher{1} )
+Unknown exception
+Matchers.tests.cpp:<line number>
+      </error>
+      <error message="REQUIRE_THROWS_MATCHES(throwsAsInt(1), SpecialException, ExceptionMatcher{1})">
+FAILED:
+	REQUIRE_THROWS_MATCHES( throwsAsInt(1), SpecialException, ExceptionMatcher{1} )
+Unknown exception
+Matchers.tests.cpp:<line number>
+      </error>
+    </testCase>
+    <testCase name="Exception matchers that fail/Contents are wrong" duration="0">
+      <failure message="CHECK_THROWS_MATCHES(throws(3), SpecialException, ExceptionMatcher{1})">
+FAILED:
+	CHECK_THROWS_MATCHES( throws(3), SpecialException, ExceptionMatcher{1} )
+with expansion:
+	SpecialException::what special exception has value of 1
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="REQUIRE_THROWS_MATCHES(throws(4), SpecialException, ExceptionMatcher{1})">
+FAILED:
+	REQUIRE_THROWS_MATCHES( throws(4), SpecialException, ExceptionMatcher{1} )
+with expansion:
+	SpecialException::what special exception has value of 1
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Exception matchers that succeed" duration="0"/>
+    <testCase name="Floating point matchers: double/Margin" duration="0"/>
+    <testCase name="Floating point matchers: double/ULPs" duration="0"/>
+    <testCase name="Floating point matchers: double/Composed" duration="0"/>
+    <testCase name="Floating point matchers: double/Constructor validation" duration="0"/>
+    <testCase name="Floating point matchers: float/Margin" duration="0"/>
+    <testCase name="Floating point matchers: float/ULPs" duration="0"/>
+    <testCase name="Floating point matchers: float/Composed" duration="0"/>
+    <testCase name="Floating point matchers: float/Constructor validation" duration="0"/>
+    <testCase name="Matchers can be (AllOf) composed with the &amp;&amp; operator" duration="0"/>
+    <testCase name="Matchers can be (AnyOf) composed with the || operator" duration="0"/>
+    <testCase name="Matchers can be composed with both &amp;&amp; and ||" duration="0"/>
+    <testCase name="Matchers can be composed with both &amp;&amp; and || - failing" duration="0">
+      <failure message="CHECK_THAT(testStringForMatching(), (Contains(&quot;string&quot;) || Contains(&quot;different&quot;)) &amp;&amp; Contains(&quot;random&quot;))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), (Contains("string") || Contains("different")) &amp;&amp; Contains("random") )
+with expansion:
+	"this string contains 'abc' as a substring" ( ( contains: "string" or contains: "different" ) and contains: "random" )
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Matchers can be negated (Not) with the ! operator" duration="0"/>
+    <testCase name="Matchers can be negated (Not) with the ! operator - failing" duration="0">
+      <failure message="CHECK_THAT(testStringForMatching(), !Contains(&quot;substring&quot;))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), !Contains("substring") )
+with expansion:
+	"this string contains 'abc' as a substring" not contains: "substring"
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Predicate matcher can accept const char*" duration="0"/>
+    <testCase name="Regex string matcher" duration="0">
+      <failure message="CHECK_THAT(testStringForMatching(), Matches(&quot;this STRING contains 'abc' as a substring&quot;))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), Matches("this STRING contains 'abc' as a substring") )
+with expansion:
+	"this string contains 'abc' as a substring" matches "this STRING contains 'abc' as a substring" case sensitively
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(testStringForMatching(), Matches(&quot;contains 'abc' as a substring&quot;))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), Matches("contains 'abc' as a substring") )
+with expansion:
+	"this string contains 'abc' as a substring" matches "contains 'abc' as a substring" case sensitively
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(testStringForMatching(), Matches(&quot;this string contains 'abc' as a&quot;))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), Matches("this string contains 'abc' as a") )
+with expansion:
+	"this string contains 'abc' as a substring" matches "this string contains 'abc' as a" case sensitively
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Regression test #1" duration="0"/>
+    <testCase name="StartsWith string matcher" duration="0">
+      <failure message="CHECK_THAT(testStringForMatching(), StartsWith(&quot;This String&quot;))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), StartsWith("This String") )
+with expansion:
+	"this string contains 'abc' as a substring" starts with: "This String"
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(testStringForMatching(), StartsWith(&quot;string&quot;, Catch::CaseSensitive::No))">
+FAILED:
+	CHECK_THAT( testStringForMatching(), StartsWith("string", Catch::CaseSensitive::No) )
+with expansion:
+	"this string contains 'abc' as a substring" starts with: "string" (case insensitive)
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="String matchers" duration="0"/>
+    <testCase name="Vector Approx matcher/Empty vector is roughly equal to an empty vector" duration="0"/>
+    <testCase name="Vector Approx matcher/Vectors with elements/A vector is approx equal to itself" duration="0"/>
+    <testCase name="Vector Approx matcher/Vectors with elements/Different length" duration="0"/>
+    <testCase name="Vector Approx matcher/Vectors with elements/Same length, different elements" duration="0"/>
+    <testCase name="Vector Approx matcher -- failing/Empty and non empty vectors are not approx equal" duration="0">
+      <failure message="CHECK_THAT(empty, Approx(t1))">
+FAILED:
+	CHECK_THAT( empty, Approx(t1) )
+with expansion:
+	{  } is approx: { 1.0, 2.0 }
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Vector Approx matcher -- failing/Just different vectors" duration="0">
+      <failure message="CHECK_THAT(v1, Approx(v2))">
+FAILED:
+	CHECK_THAT( v1, Approx(v2) )
+with expansion:
+	{ 2.0, 4.0, 6.0 } is approx: { 1.0, 3.0, 5.0 }
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Vector matchers/Contains (element)" duration="0"/>
+    <testCase name="Vector matchers/Contains (vector)" duration="0"/>
+    <testCase name="Vector matchers/Contains (element), composed" duration="0"/>
+    <testCase name="Vector matchers/Equals" duration="0"/>
+    <testCase name="Vector matchers/UnorderedEquals" duration="0"/>
+    <testCase name="Vector matchers that fail/Contains (element)" duration="0">
+      <failure message="CHECK_THAT(v, VectorContains(-1))">
+FAILED:
+	CHECK_THAT( v, VectorContains(-1) )
+with expansion:
+	{ 1, 2, 3 } Contains: -1
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(empty, VectorContains(1))">
+FAILED:
+	CHECK_THAT( empty, VectorContains(1) )
+with expansion:
+	{  } Contains: 1
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Vector matchers that fail/Contains (vector)" duration="0">
+      <failure message="CHECK_THAT(empty, Contains(v))">
+FAILED:
+	CHECK_THAT( empty, Contains(v) )
+with expansion:
+	{  } Contains: { 1, 2, 3 }
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(v, Contains(v2))">
+FAILED:
+	CHECK_THAT( v, Contains(v2) )
+with expansion:
+	{ 1, 2, 3 } Contains: { 1, 2, 4 }
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Vector matchers that fail/Equals" duration="0">
+      <failure message="CHECK_THAT(v, Equals(v2))">
+FAILED:
+	CHECK_THAT( v, Equals(v2) )
+with expansion:
+	{ 1, 2, 3 } Equals: { 1, 2 }
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(v2, Equals(v))">
+FAILED:
+	CHECK_THAT( v2, Equals(v) )
+with expansion:
+	{ 1, 2 } Equals: { 1, 2, 3 }
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(empty, Equals(v))">
+FAILED:
+	CHECK_THAT( empty, Equals(v) )
+with expansion:
+	{  } Equals: { 1, 2, 3 }
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(v, Equals(empty))">
+FAILED:
+	CHECK_THAT( v, Equals(empty) )
+with expansion:
+	{ 1, 2, 3 } Equals: {  }
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Vector matchers that fail/UnorderedEquals" duration="0">
+      <failure message="CHECK_THAT(v, UnorderedEquals(empty))">
+FAILED:
+	CHECK_THAT( v, UnorderedEquals(empty) )
+with expansion:
+	{ 1, 2, 3 } UnorderedEquals: {  }
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(empty, UnorderedEquals(v))">
+FAILED:
+	CHECK_THAT( empty, UnorderedEquals(v) )
+with expansion:
+	{  } UnorderedEquals: { 1, 2, 3 }
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(permuted, UnorderedEquals(v))">
+FAILED:
+	CHECK_THAT( permuted, UnorderedEquals(v) )
+with expansion:
+	{ 1, 3 } UnorderedEquals: { 1, 2, 3 }
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK_THAT(permuted, UnorderedEquals(v))">
+FAILED:
+	CHECK_THAT( permuted, UnorderedEquals(v) )
+with expansion:
+	{ 3, 1 } UnorderedEquals: { 1, 2, 3 }
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testCase>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/Message.tests.cpp">
+    <testCase name="#1455 - INFO and WARN can start with a linebreak" duration="0"/>
+    <testCase name="CAPTURE can deal with complex expressions" duration="0"/>
+    <testCase name="CAPTURE can deal with complex expressions involving commas" duration="0"/>
+    <testCase name="CAPTURE parses string and character constants" duration="0"/>
+    <testCase name="FAIL aborts the test" duration="0">
+      <failure message="FAIL()">
+FAILED:
+This is a failure
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="FAIL does not require an argument" duration="0">
+      <failure message="FAIL()">
+FAILED:
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="FAIL_CHECK does not abort the test" duration="0">
+      <failure message="FAIL_CHECK()">
+FAILED:
+This is a failure
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="INFO and WARN do not abort tests" duration="0"/>
+    <testCase name="INFO gets logged on failure" duration="0">
+      <failure message="REQUIRE(a == 1)">
+FAILED:
+	REQUIRE( a == 1 )
+with expansion:
+	2 == 1
+this message should be logged
+so should this
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="INFO gets logged on failure, even if captured before successful assertions" duration="0">
+      <failure message="CHECK(a == 1)">
+FAILED:
+	CHECK( a == 1 )
+with expansion:
+	2 == 1
+this message may be logged later
+this message should be logged
+Message.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(a == 0)">
+FAILED:
+	CHECK( a == 0 )
+with expansion:
+	2 == 0
+this message may be logged later
+this message should be logged
+and this, but later
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="INFO is reset for each loop" duration="0">
+      <failure message="REQUIRE(i &lt; 10)">
+FAILED:
+	REQUIRE( i &lt; 10 )
+with expansion:
+	10 &lt; 10
+current counter 10
+i := 10
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Output from all sections is reported/one" duration="0">
+      <failure message="FAIL()">
+FAILED:
+Message from section one
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Output from all sections is reported/two" duration="0">
+      <failure message="FAIL()">
+FAILED:
+Message from section two
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="SUCCEED counts as a test pass" duration="0"/>
+    <testCase name="SUCCEED does not require an argument" duration="0"/>
+    <testCase name="Standard output from all sections is reported/two" duration="0"/>
+    <testCase name="The NO_FAIL macro reports a failure but does not fail the test" duration="0"/>
+    <testCase name="just failure" duration="0">
+      <failure message="FAIL()">
+FAILED:
+Previous info should not be seen
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="just failure after unscoped info" duration="0">
+      <failure message="FAIL()">
+FAILED:
+previous unscoped info SHOULD not be seen
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="mix info, unscoped info and warning" duration="0"/>
+    <testCase name="not prints unscoped info from previous failures" duration="0">
+      <failure message="REQUIRE(false)">
+FAILED:
+	REQUIRE( false )
+this SHOULD be seen
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="print unscoped info if passing unscoped info is printed" duration="0"/>
+    <testCase name="prints unscoped info on failure" duration="0">
+      <failure message="REQUIRE(false)">
+FAILED:
+	REQUIRE( false )
+this SHOULD be seen
+this SHOULD also be seen
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="prints unscoped info only for the first assertion" duration="0">
+      <failure message="CHECK(false)">
+FAILED:
+	CHECK( false )
+this SHOULD be seen only ONCE
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="sends information to INFO" duration="0">
+      <failure message="REQUIRE(false)">
+FAILED:
+	REQUIRE( false )
+hi
+i := 7
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="stacks unscoped info in loops" duration="0">
+      <failure message="CHECK(false)">
+FAILED:
+	CHECK( false )
+Count 1 to 3...
+1
+2
+3
+Message.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(false)">
+FAILED:
+	CHECK( false )
+Count 4 to 6...
+4
+5
+6
+Message.tests.cpp:<line number>
+      </failure>
+    </testCase>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/Misc.tests.cpp">
+    <testCase name="# A test name that starts with a #" duration="0"/>
+    <testCase name="#1175 - Hidden Test" duration="0"/>
+    <testCase name="#835 -- errno should not be touched by Catch" duration="0">
+      <skipped message="CHECK(f() == 0)">
+FAILED:
+	CHECK( f() == 0 )
+with expansion:
+	1 == 0
+Misc.tests.cpp:<line number>
+      </skipped>
+    </testCase>
+    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 0" duration="0"/>
+    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 1" duration="0"/>
+    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 2" duration="0"/>
+    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 3" duration="0"/>
+    <testCase name="#961 -- Dynamically created sections should all be reported/Looped section 4" duration="0"/>
+    <testCase name="A Template product test case - Foo&lt;float>" duration="0"/>
+    <testCase name="A Template product test case - Foo&lt;int>" duration="0"/>
+    <testCase name="A Template product test case - std::vector&lt;float>" duration="0"/>
+    <testCase name="A Template product test case - std::vector&lt;int>" duration="0"/>
+    <testCase name="A Template product test case with array signature - Bar&lt;float, 42>" duration="0"/>
+    <testCase name="A Template product test case with array signature - Bar&lt;int, 9>" duration="0"/>
+    <testCase name="A Template product test case with array signature - std::array&lt;float, 42>" duration="0"/>
+    <testCase name="A Template product test case with array signature - std::array&lt;int, 9>" duration="0"/>
+    <testCase name="A couple of nested sections followed by a failure" duration="0">
+      <failure message="FAIL()">
+FAILED:
+to infinity and beyond
+Misc.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="A couple of nested sections followed by a failure/Outer/Inner" duration="0"/>
+    <testCase name="Factorials are computed" duration="0"/>
+    <testCase name="ManuallyRegistered" duration="0"/>
+    <testCase name="Nice descriptive name" duration="0"/>
+    <testCase name="Product with differing arities - std::tuple&lt;int, double, float>" duration="0"/>
+    <testCase name="Product with differing arities - std::tuple&lt;int, double>" duration="0"/>
+    <testCase name="Product with differing arities - std::tuple&lt;int>" duration="0"/>
+    <testCase name="Sends stuff to stdout and stderr" duration="0"/>
+    <testCase name="Tabs and newlines show in output" duration="0">
+      <failure message="CHECK(s1 == s2)">
+FAILED:
+	CHECK( s1 == s2 )
+with expansion:
+	"if ($b == 10) {
+		$a	= 20;
+}"
+==
+"if ($b == 10) {
+	$a = 20;
+}
+"
+Misc.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 0" duration="0"/>
+    <testCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 1" duration="0"/>
+    <testCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 2" duration="0"/>
+    <testCase name="Template test case with test types specified inside std::tuple - MyTypes - 0" duration="0"/>
+    <testCase name="Template test case with test types specified inside std::tuple - MyTypes - 1" duration="0"/>
+    <testCase name="Template test case with test types specified inside std::tuple - MyTypes - 2" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - float" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - float/resizing bigger changes size and capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - float/resizing smaller changes size but not capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - float/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - float/reserving bigger changes capacity but not size" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - float/reserving smaller does not change size or capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - int" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - int/resizing bigger changes size and capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - int/resizing smaller changes size but not capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - int/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - int/reserving bigger changes capacity but not size" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - int/reserving smaller does not change size or capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::string" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::string/resizing bigger changes size and capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::string/resizing smaller changes size but not capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::string/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::string/reserving bigger changes capacity but not size" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::string/reserving smaller does not change size or capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/resizing bigger changes size and capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/resizing smaller changes size but not capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/reserving bigger changes capacity but not size" duration="0"/>
+    <testCase name="TemplateTest: vectors can be sized and resized - std::tuple&lt;int,float>/reserving smaller does not change size or capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/resizing bigger changes size and capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/resizing smaller changes size but not capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/reserving bigger changes capacity but not size" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - (std::tuple&lt;int, float>), 6/reserving smaller does not change size or capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/resizing bigger changes size and capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/resizing smaller changes size but not capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/reserving bigger changes capacity but not size" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - float,4/reserving smaller does not change size or capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/resizing bigger changes size and capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/resizing smaller changes size but not capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/reserving bigger changes capacity but not size" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - int,5/reserving smaller does not change size or capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/resizing bigger changes size and capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/resizing smaller changes size but not capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/reserving bigger changes capacity but not size" duration="0"/>
+    <testCase name="TemplateTestSig: vectors can be sized and resized - std::string,15/reserving smaller does not change size or capacity" duration="0"/>
+    <testCase name="This test 'should' fail but doesn't" duration="0"/>
+    <testCase name="atomic if" duration="0"/>
+    <testCase name="checkedElse" duration="0"/>
+    <testCase name="checkedElse, failing" duration="0">
+      <failure message="CHECKED_ELSE(flag)">
+FAILED:
+	CHECKED_ELSE( flag )
+with expansion:
+	false
+Misc.tests.cpp:<line number>
+      </failure>
+      <failure message="REQUIRE(testCheckedElse( false ))">
+FAILED:
+	REQUIRE( testCheckedElse( false ) )
+with expansion:
+	false
+Misc.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="checkedIf" duration="0"/>
+    <testCase name="checkedIf, failing" duration="0">
+      <failure message="CHECKED_IF(flag)">
+FAILED:
+	CHECKED_IF( flag )
+with expansion:
+	false
+Misc.tests.cpp:<line number>
+      </failure>
+      <failure message="REQUIRE(testCheckedIf( false ))">
+FAILED:
+	REQUIRE( testCheckedIf( false ) )
+with expansion:
+	false
+Misc.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="even more nested SECTION tests/c/d (leaf)" duration="0"/>
+    <testCase name="even more nested SECTION tests/c/e (leaf)" duration="0"/>
+    <testCase name="even more nested SECTION tests/f (leaf)" duration="0"/>
+    <testCase name="long long" duration="0"/>
+    <testCase name="looped SECTION tests/b is currently: 0" duration="0">
+      <failure message="CHECK(b > a)">
+FAILED:
+	CHECK( b > a )
+with expansion:
+	0 > 1
+Misc.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="looped SECTION tests/b is currently: 1" duration="0">
+      <failure message="CHECK(b > a)">
+FAILED:
+	CHECK( b > a )
+with expansion:
+	1 > 1
+Misc.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="looped SECTION tests/b is currently: 2" duration="0"/>
+    <testCase name="looped SECTION tests/b is currently: 3" duration="0"/>
+    <testCase name="looped SECTION tests/b is currently: 4" duration="0"/>
+    <testCase name="looped SECTION tests/b is currently: 5" duration="0"/>
+    <testCase name="looped SECTION tests/b is currently: 6" duration="0"/>
+    <testCase name="looped SECTION tests/b is currently: 7" duration="0"/>
+    <testCase name="looped SECTION tests/b is currently: 8" duration="0"/>
+    <testCase name="looped SECTION tests/b is currently: 9" duration="0"/>
+    <testCase name="looped tests" duration="0">
+      <failure message="CHECK(( fib[i] % 2 ) == 0)">
+FAILED:
+	CHECK( ( fib[i] % 2 ) == 0 )
+with expansion:
+	1 == 0
+Testing if fib[0] (1) is even
+Misc.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(( fib[i] % 2 ) == 0)">
+FAILED:
+	CHECK( ( fib[i] % 2 ) == 0 )
+with expansion:
+	1 == 0
+Testing if fib[1] (1) is even
+Misc.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(( fib[i] % 2 ) == 0)">
+FAILED:
+	CHECK( ( fib[i] % 2 ) == 0 )
+with expansion:
+	1 == 0
+Testing if fib[3] (3) is even
+Misc.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(( fib[i] % 2 ) == 0)">
+FAILED:
+	CHECK( ( fib[i] % 2 ) == 0 )
+with expansion:
+	1 == 0
+Testing if fib[4] (5) is even
+Misc.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(( fib[i] % 2 ) == 0)">
+FAILED:
+	CHECK( ( fib[i] % 2 ) == 0 )
+with expansion:
+	1 == 0
+Testing if fib[6] (13) is even
+Misc.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(( fib[i] % 2 ) == 0)">
+FAILED:
+	CHECK( ( fib[i] % 2 ) == 0 )
+with expansion:
+	1 == 0
+Testing if fib[7] (21) is even
+Misc.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="more nested SECTION tests/equal/doesn't equal" duration="0">
+      <failure message="REQUIRE(a == b)">
+FAILED:
+	REQUIRE( a == b )
+with expansion:
+	1 == 2
+Misc.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="more nested SECTION tests/doesn't equal/not equal" duration="0"/>
+    <testCase name="more nested SECTION tests/doesn't equal/less than" duration="0"/>
+    <testCase name="nested SECTION tests/doesn't equal" duration="0"/>
+    <testCase name="nested SECTION tests/doesn't equal/not equal" duration="0"/>
+    <testCase name="not allowed" duration="0"/>
+    <testCase name="null strings" duration="0"/>
+    <testCase name="random SECTION tests/doesn't equal" duration="0"/>
+    <testCase name="random SECTION tests/not equal" duration="0"/>
+    <testCase name="send a single char to INFO" duration="0">
+      <failure message="REQUIRE(false)">
+FAILED:
+	REQUIRE( false )
+3
+Misc.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="toString on const wchar_t const pointer returns the string contents" duration="0"/>
+    <testCase name="toString on const wchar_t pointer returns the string contents" duration="0"/>
+    <testCase name="toString on wchar_t const pointer returns the string contents" duration="0"/>
+    <testCase name="toString on wchar_t returns the string contents" duration="0"/>
+    <testCase name="vectors can be sized and resized" duration="0"/>
+    <testCase name="vectors can be sized and resized/resizing bigger changes size and capacity" duration="0"/>
+    <testCase name="vectors can be sized and resized/resizing smaller changes size but not capacity" duration="0"/>
+    <testCase name="vectors can be sized and resized/resizing smaller changes size but not capacity/We can use the 'swap trick' to reset the capacity" duration="0"/>
+    <testCase name="vectors can be sized and resized/reserving bigger changes capacity but not size" duration="0"/>
+    <testCase name="vectors can be sized and resized/reserving smaller does not change size or capacity" duration="0"/>
+    <testCase name="xmlentitycheck/embedded xml: &lt;test>it should be possible to embed xml characters, such as &lt;, &quot; or &amp;, or even whole &lt;xml>documents&lt;/xml> within an attribute&lt;/test>" duration="0"/>
+    <testCase name="xmlentitycheck/encoded chars: these should all be encoded: &amp;&amp;&amp;&quot;&quot;&quot;&lt;&lt;&lt;&amp;&quot;&lt;&lt;&amp;&quot;" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/ToStringChrono.tests.cpp">
+    <testCase name="Stringifying std::chrono::duration helpers" duration="0"/>
+    <testCase name="Stringifying std::chrono::duration with weird ratios" duration="0"/>
+    <testCase name="Stringifying std::chrono::time_point&lt;system_clock>" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/ToStringGeneral.tests.cpp">
+    <testCase name="Capture and info messages/Capture should stringify like assertions" duration="0"/>
+    <testCase name="Capture and info messages/Info should NOT stringify the way assertions do" duration="0"/>
+    <testCase name="Character pretty printing/Specifically escaped" duration="0"/>
+    <testCase name="Character pretty printing/General chars" duration="0"/>
+    <testCase name="Character pretty printing/Low ASCII" duration="0"/>
+    <testCase name="Exception as a value (e.g. in REQUIRE_THROWS_MATCHES) can be stringified" duration="0"/>
+    <testCase name="Precision of floating point stringification can be set/Floats" duration="0"/>
+    <testCase name="Precision of floating point stringification can be set/Double" duration="0"/>
+    <testCase name="Static arrays are convertible to string/Single item" duration="0"/>
+    <testCase name="Static arrays are convertible to string/Multiple" duration="0"/>
+    <testCase name="Static arrays are convertible to string/Non-trivial inner items" duration="0"/>
+    <testCase name="std::map is convertible string/empty" duration="0"/>
+    <testCase name="std::map is convertible string/single item" duration="0"/>
+    <testCase name="std::map is convertible string/several items" duration="0"/>
+    <testCase name="std::set is convertible string/empty" duration="0"/>
+    <testCase name="std::set is convertible string/single item" duration="0"/>
+    <testCase name="std::set is convertible string/several items" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/ToStringPair.tests.cpp">
+    <testCase name="pair&lt;pair&lt;int,const char *,pair&lt;std::string,int> > -> toString" duration="0"/>
+    <testCase name="std::pair&lt;int,const std::string> -> toString" duration="0"/>
+    <testCase name="std::pair&lt;int,std::string> -> toString" duration="0"/>
+    <testCase name="std::vector&lt;std::pair&lt;std::string,int> > -> toString" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/ToStringTuple.tests.cpp">
+    <testCase name="tuple&lt;>" duration="0"/>
+    <testCase name="tuple&lt;float,int>" duration="0"/>
+    <testCase name="tuple&lt;int>" duration="0"/>
+    <testCase name="tuple&lt;0,int,const char *>" duration="0"/>
+    <testCase name="tuple&lt;string,string>" duration="0"/>
+    <testCase name="tuple&lt;tuple&lt;int>,tuple&lt;>,float>" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/ToStringVector.tests.cpp">
+    <testCase name="array&lt;int, N> -> toString" duration="0"/>
+    <testCase name="vec&lt;vec&lt;string,alloc>> -> toString" duration="0"/>
+    <testCase name="vector&lt;bool> -> toString" duration="0"/>
+    <testCase name="vector&lt;int,allocator> -> toString" duration="0"/>
+    <testCase name="vector&lt;int> -> toString" duration="0"/>
+    <testCase name="vector&lt;string> -> toString" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/ToStringWhich.tests.cpp">
+    <testCase name="stringify ranges" duration="0"/>
+    <testCase name="stringify( has_maker )" duration="0"/>
+    <testCase name="stringify( has_maker_and_operator )" duration="0"/>
+    <testCase name="stringify( has_neither )" duration="0"/>
+    <testCase name="stringify( has_operator )" duration="0"/>
+    <testCase name="stringify( has_template_operator )" duration="0"/>
+    <testCase name="stringify( vectors&lt;has_maker> )" duration="0"/>
+    <testCase name="stringify( vectors&lt;has_maker_and_operator> )" duration="0"/>
+    <testCase name="stringify( vectors&lt;has_operator> )" duration="0"/>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/Tricky.tests.cpp">
+    <testCase name="#1514: stderr/stdout is not captured in tests aborted by an exception" duration="0">
+      <failure message="FAIL()">
+FAILED:
+1514
+Tricky.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="(unimplemented) static bools can be evaluated/compare to true" duration="0"/>
+    <testCase name="(unimplemented) static bools can be evaluated/compare to false" duration="0"/>
+    <testCase name="(unimplemented) static bools can be evaluated/negation" duration="0"/>
+    <testCase name="(unimplemented) static bools can be evaluated/double negation" duration="0"/>
+    <testCase name="(unimplemented) static bools can be evaluated/direct" duration="0"/>
+    <testCase name="A failing expression with a non streamable type is still captured" duration="0">
+      <failure message="CHECK(&amp;o1 == &amp;o2)">
+FAILED:
+	CHECK( &amp;o1 == &amp;o2 )
+with expansion:
+	0x<hex digits> == 0x<hex digits>
+Tricky.tests.cpp:<line number>
+      </failure>
+      <failure message="CHECK(o1 == o2)">
+FAILED:
+	CHECK( o1 == o2 )
+with expansion:
+	{?} == {?}
+Tricky.tests.cpp:<line number>
+      </failure>
+    </testCase>
+    <testCase name="An expression with side-effects should only be evaluated once" duration="0"/>
+    <testCase name="Assertions then sections" duration="0"/>
+    <testCase name="Assertions then sections/A section" duration="0"/>
+    <testCase name="Assertions then sections/A section/Another section" duration="0"/>
+    <testCase name="Assertions then sections/A section/Another other section" duration="0"/>
+    <testCase name="Commas in various macros are allowed" duration="0"/>
+    <testCase name="Comparing function pointers" duration="0"/>
+    <testCase name="Objects that evaluated in boolean contexts can be checked" duration="0"/>
+    <testCase name="Test enum bit values" duration="0"/>
+    <testCase name="Where the LHS is not a simple value" duration="0"/>
+    <testCase name="Where there is more to the expression after the RHS" duration="0"/>
+    <testCase name="X/level/0/a" duration="0"/>
+    <testCase name="X/level/0/b" duration="0"/>
+    <testCase name="X/level/1/a" duration="0"/>
+    <testCase name="X/level/1/b" duration="0"/>
+    <testCase name="boolean member" duration="0"/>
+    <testCase name="non streamable - with conv. op" duration="0"/>
+    <testCase name="non-copyable objects" duration="0"/>
+    <testCase name="null_ptr" duration="0"/>
+    <testCase name="pointer to class" duration="0"/>
+    <testCase name="string literals of different sizes can be compared" duration="0">
+      <failure message="REQUIRE(std::string( &quot;first&quot; ) == &quot;second&quot;)">
+FAILED:
+	REQUIRE( std::string( "first" ) == "second" )
+with expansion:
+	"first" == "second"
+Tricky.tests.cpp:<line number>
+      </failure>
+    </testCase>
+  </file>
+  <file path="projects/<exe-name>/UsageTests/VariadicMacros.tests.cpp">
+    <testCase name="Anonymous test case 1" duration="0"/>
+    <testCase name="Test case with one argument" duration="0"/>
+    <testCase name="Variadic macros/Section with one argument" duration="0"/>
+  </file>
+</testExecutions>

--- a/projects/SelfTest/TestMain.cpp
+++ b/projects/SelfTest/TestMain.cpp
@@ -13,6 +13,7 @@
 #include "reporters/catch_reporter_teamcity.hpp"
 #include "reporters/catch_reporter_tap.hpp"
 #include "reporters/catch_reporter_automake.hpp"
+#include "reporters/catch_reporter_sonarqube.hpp"
 
 
 // Some example tag aliases

--- a/scripts/approvalTests.py
+++ b/scripts/approvalTests.py
@@ -204,6 +204,8 @@ approve("junit.sw", ["~[!nonportable]~[!benchmark]~[approvals]", "-s", "-w", "No
 approve("xml.sw", ["~[!nonportable]~[!benchmark]~[approvals]", "-s", "-w", "NoAssertions", "-r", "xml", "--order", "lex", "--rng-seed", "1"])
 # compact reporter, include passes, warn about No Assertions
 approve('compact.sw', ['~[!nonportable]~[!benchmark]~[approvals]', '-s', '-w', 'NoAssertions', '-r', 'compact', '--order', 'lex', "--rng-seed", "1"])
+# sonarqube reporter, include passes, warn about No Assertions
+approve("sonarqube.sw", ["~[!nonportable]~[!benchmark]~[approvals]", "-s", "-w", "NoAssertions", "-r", "sonarqube", "--order", "lex", "--rng-seed", "1"])
 
 if overallResult != 0:
     print("If these differences are expected, run approve.py to approve new baselines.")

--- a/scripts/approvalTests.py
+++ b/scripts/approvalTests.py
@@ -29,6 +29,7 @@ filelocParser = re.compile(r'''
 lineNumberParser = re.compile(r' line="[0-9]*"')
 hexParser = re.compile(r'\b(0[xX][0-9a-fA-F]+)\b')
 durationsParser = re.compile(r' time="[0-9]*\.[0-9]*"')
+sonarqubeDurationParser = re.compile(r' duration="[0-9]+"')
 timestampsParser = re.compile(r'\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}Z')
 versionParser = re.compile(r'Catch v[0-9]+\.[0-9]+\.[0-9]+(-develop\.[0-9]+)?')
 nullParser = re.compile(r'\b(__null|nullptr)\b')
@@ -138,6 +139,7 @@ def filterLine(line, isCompact):
 
     # strip durations and timestamps
     line = durationsParser.sub(' time="{duration}"', line)
+    line = sonarqubeDurationParser.sub(' duration="{duration}"', line)
     line = timestampsParser.sub('{iso8601-timestamp}', line)
     line = specialCaseParser.sub('file:\g<1>', line)
     line = errnoParser.sub('errno', line)

--- a/scripts/releaseCommon.py
+++ b/scripts/releaseCommon.py
@@ -156,7 +156,7 @@ def performUpdates(version):
     # We probably should have some kind of convention to select which reporters need to be copied automagically,
     # but this works for now
     import shutil
-    for rep in ('automake', 'tap', 'teamcity'):
+    for rep in ('automake', 'tap', 'teamcity', 'sonarqube'):
         sourceFile = os.path.join(catchPath, 'include/reporters/catch_reporter_{}.hpp'.format(rep))
         destFile = os.path.join(catchPath, 'single_include', 'catch2', 'catch_reporter_{}.hpp'.format(rep))
         shutil.copyfile(sourceFile, destFile)


### PR DESCRIPTION
Added a `SonarQube` reporter that creates `Generic Execution Test Data` reports

For more information check the following documentation:
- [SonarQube Generic Test Data](https://docs.sonarqube.org/latest/analysis/generic-test/)
- [SonarQube Generic Execution](https://docs.sonarqube.org/latest/analysis/generic-test/#header-2)