### PR TITLE
Don't use std version of nextafter

### DIFF
--- a/include/internal/catch_matchers_floating.cpp
+++ b/include/internal/catch_matchers_floating.cpp
@@ -80,7 +80,11 @@ bool almostEqualUlps(FP lhs, FP rhs, int maxUlpDiff) {
 template <typename FP>
 FP step(FP start, FP direction, int steps) {
     for (int i = 0; i < steps; ++i) {
+#ifndef __UCLIBC__
         start = std::nextafter(start, direction);
+#else
+        start = ::nextafterf(start, direction);
+#endif
     }
     return start;
 }


### PR DESCRIPTION
nextafter is C++11. std version is not available with either uClibc++ or uClibc-ng.

Fixes this: https://downloads.openwrt.org/releases/faillogs-19.07/arc_arc700/packages/measurement-kit/compile.txt