### PR TITLE
Escape characters bug patch(v2.9.2)

### DIFF
--- a/include/internal/catch_test_spec_parser.h
+++ b/include/internal/catch_test_spec_parser.h
@@ -22,6 +22,7 @@ namespace Catch {
     class TestSpecParser {
         enum Mode{ None, Name, QuotedName, Tag, EscapedName };
         Mode m_mode = None;
+        Mode lastMode = None;
         bool m_exclusion = false;
         std::size_t m_pos = 0;
         std::string m_arg;
@@ -47,7 +48,9 @@ namespace Catch {
         void endMode();
         void escape();
         bool isControlChar( char c ) const;
-
+        void saveLastMode();
+        void revertBackToLastMode();
+        
         template<typename T>
         void addPattern() {
             std::string token = m_patternName;

--- a/misc/coverage-helper.cpp
+++ b/misc/coverage-helper.cpp
@@ -29,7 +29,8 @@ std::string escape_arg(const std::string& arg) {
             escaped.append(num_backslashes * 2, '\\');
             break;
         } else if (*it == '"') {
-            escaped.append(num_backslashes * 2 + 1, '\\');
+            escaped.append((num_backslashes + 1) * 2, '\\');
+            escaped.push_back('"');
             escaped.push_back(*it);
         } else {
             escaped.append(num_backslashes, '\\');
@@ -97,7 +98,7 @@ int exec_cmd(std::string const& cmd, int log_num, std::string const& path) {
         + ".bin --quiet " + "--sources " + escape_arg(path) + " --cover_children -- " + cmd;
     std::cout << "=== Marker ===: Cmd: " << real_cmd << '\n';
     auto pipe = _popen(real_cmd.c_str(), "r");
-    
+
     if (!pipe) {
         throw std::runtime_error("popen() failed!");
     }
@@ -106,12 +107,12 @@ int exec_cmd(std::string const& cmd, int log_num, std::string const& path) {
             std::cout << buffer.data();
         }
     }
-    
+
     auto ret = _pclose(pipe);
     if (ret == -1) {
         throw std::runtime_error("underlying error in pclose()");
     }
-    
+
     return ret;
 }
 
@@ -127,7 +128,7 @@ int main(int argc, char** argv) {
     assert(sep - begin(args) == 2 && "Structure differs from expected!");
 
     auto num = parse_log_file_arg(args[1]);
-    
+
     auto cmdline = std::accumulate(++sep, end(args), std::string{}, [] (const std::string& lhs, const std::string& rhs) {
         return lhs + ' ' + escape_arg(rhs);
     });

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -429,6 +429,9 @@ set_tests_properties(LibIdentityTest PROPERTIES PASS_REGULAR_EXPRESSION "descrip
 add_test(NAME FilenameAsTagsTest COMMAND $<TARGET_FILE:SelfTest> -\# --list-tags)
 set_tests_properties(FilenameAsTagsTest PROPERTIES PASS_REGULAR_EXPRESSION "\\[#Approx.tests\\]")
 
+add_test(NAME EscapeSpecialCharactersInTestNames COMMAND $<TARGET_FILE:SelfTest> "Test with special\\, characters \"in name")
+set_tests_properties(EscapeSpecialCharactersInTestNames PROPERTIES PASS_REGULAR_EXPRESSION "1 assertion in 1 test case")
+
 
 if (CATCH_USE_VALGRIND)
     add_test(NAME ValgrindRunTests COMMAND valgrind --leak-check=full --error-exitcode=1 $<TARGET_FILE:SelfTest>)

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -1235,6 +1235,7 @@ Misc.tests.cpp:<line number>: passed: v.size() == V for: 15 == 15
 Misc.tests.cpp:<line number>: passed: v.capacity() >= V for: 15 >= 15
 VariadicMacros.tests.cpp:<line number>: passed: with 1 message: 'no assertions'
 Tricky.tests.cpp:<line number>: passed: 0x<hex digits> == bit30and31 for: 3221225472 (0x<hex digits>) == 3221225472
+CmdLine.tests.cpp:<line number>: passed:
 Message.tests.cpp:<line number>: failed - but was ok: 1 == 2
 Misc.tests.cpp:<line number>: passed: with 1 message: 'oops!'
 Exception.tests.cpp:<line number>: failed: unexpected exception with message: 'For some reason someone is throwing a string literal!'

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -1380,6 +1380,6 @@ due to unexpected exception with message:
   Why would you throw a std::string?
 
 ===============================================================================
-test cases:  300 |  226 passed |  70 failed |  4 failed as expected
-assertions: 1568 | 1416 passed | 131 failed | 21 failed as expected
+test cases:  301 |  227 passed |  70 failed |  4 failed as expected
+assertions: 1569 | 1417 passed | 131 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -9322,6 +9322,14 @@ with expansion:
   3221225472 (0x<hex digits>) == 3221225472
 
 -------------------------------------------------------------------------------
+Test with special, characters "in name
+-------------------------------------------------------------------------------
+CmdLine.tests.cpp:<line number>
+...............................................................................
+
+CmdLine.tests.cpp:<line number>: PASSED:
+
+-------------------------------------------------------------------------------
 The NO_FAIL macro reports a failure but does not fail the test
 -------------------------------------------------------------------------------
 Message.tests.cpp:<line number>
@@ -12520,6 +12528,6 @@ Misc.tests.cpp:<line number>
 Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
-test cases:  300 |  210 passed |  86 failed |  4 failed as expected
-assertions: 1585 | 1416 passed | 148 failed | 21 failed as expected
+test cases:  301 |  211 passed |  86 failed |  4 failed as expected
+assertions: 1586 | 1417 passed | 148 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="132" tests="1586" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="132" tests="1587" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="filters" value="~[!nonportable]~[!benchmark]~[approvals]"/>
       <property name="random-seed" value="1"/>
@@ -808,6 +808,7 @@ Misc.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="TemplateTestSig: vectors can be sized and resized - std::string,15/reserving smaller does not change size or capacity" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Test case with one argument" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Test enum bit values" time="{duration}"/>
+    <testcase classname="<exe-name>.global" name="Test with special, characters &quot;in name" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="The NO_FAIL macro reports a failure but does not fail the test" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="This test 'should' fail but doesn't" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Thrown string literals are translated" time="{duration}">

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -11269,6 +11269,9 @@ Message from section two
       </Expression>
       <OverallResult success="true"/>
     </TestCase>
+    <TestCase name="Test with special, characters &quot;in name" tags="[cli][regression]" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+      <OverallResult success="true"/>
+    </TestCase>
     <TestCase name="The NO_FAIL macro reports a failure but does not fail the test" tags="[messages]" filename="projects/<exe-name>/UsageTests/Message.tests.cpp" >
       <Expression success="false" type="CHECK_NOFAIL" filename="projects/<exe-name>/UsageTests/Message.tests.cpp" >
         <Original>
@@ -14912,7 +14915,7 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="1416" failures="149" expectedFailures="21"/>
+    <OverallResults successes="1417" failures="149" expectedFailures="21"/>
   </Group>
-  <OverallResults successes="1416" failures="148" expectedFailures="21"/>
+  <OverallResults successes="1417" failures="148" expectedFailures="21"/>
 </Catch>

--- a/projects/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
@@ -506,3 +506,8 @@ TEST_CASE( "Process can be configured on command line", "[config][command-line]"
         }
     }
 }
+
+TEST_CASE("Test with special, characters \"in name", "[cli][regression]") {
+    // This test case succeeds if we can invoke it from the CLI
+    SUCCEED();
+}


### PR DESCRIPTION
## Description
In Catch v2.9.2 escape characters are not working properly
I modified the finite state machine implemented in include/catch_test_spec_parser.cpp
to correct this problem

## GitHub Issues
Issue #1737