### PR TITLE
Refactor CMake for more modern usage

### DIFF
--- a/CMake/Catch2Config.cmake.in
+++ b/CMake/Catch2Config.cmake.in
@@ -1,10 +1,8 @@
 @PACKAGE_INIT@
 
-
 # Avoid repeatedly including the targets
 if(NOT TARGET Catch2::Catch2)
     # Provide path for scripts
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-
     include(${CMAKE_CURRENT_LIST_DIR}/Catch2Targets.cmake)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,35 +1,49 @@
 cmake_minimum_required(VERSION 3.5)
-
-# detect if Catch is being bundled,
-# disable testsuite in that case
-if(NOT DEFINED PROJECT_NAME)
-  set(NOT_SUBPROJECT ON)
-endif()
-
 project(Catch2 LANGUAGES CXX VERSION 2.9.2)
-
-if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
-    message(FATAL_ERROR "Building in-source is not supported! Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
-endif()
 
 # Provide path for scripts
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+include(CMakeDependentOption)
+include(GNUInstallDirs)
 include(CTest)
 
+find_program(CATCH_DPKG_BUILDPACKAGE_FOUND dpkg-buildpackage)
+
+if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
+    message(FATAL_ERROR "Building in-source is not supported!"
+      "Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeFiles/"
+      "and ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
+endif()
+
+cmake_dependent_option(CATCH_BUILD_PACKAGE
+  "Enable Catch2 package building" ON
+  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+cmake_dependent_option(CATCH_BUILD_PACKAGE_DEB
+  "Enable creating a Catch2 .deb" ON
+  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR;CATCH_DPKG_BUILDPACKAGE_FOUND" OFF)
+
+cmake_dependent_option(CATCH_BUILD_TESTING
+  "Build Catch2 SelfTest project" ON
+  "BUILD_TESTING;CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+cmake_dependent_option(CATCH_ENABLE_WERROR
+  "Enable all warnings as errors" ON
+  "BUILD_TESTING;CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+cmake_dependent_option(CATCH_INSTALL_HELPERS
+  "Install Catch2 contrib alonside library" ON
+  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+
+cmake_dependent_option(CATCH_INSTALL_DOCS
+  "Install Catch2 documentation alongside library" ON
+  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+
 option(CATCH_USE_VALGRIND "Perform SelfTests with Valgrind" OFF)
-option(CATCH_BUILD_TESTING "Build SelfTest project" ON)
 option(CATCH_BUILD_EXAMPLES "Build documentation examples" OFF)
 option(CATCH_BUILD_EXTRA_TESTS "Build extra tests" OFF)
 option(CATCH_ENABLE_COVERAGE "Generate coverage for codecov.io" OFF)
-option(CATCH_ENABLE_WERROR "Enable all warnings as errors" ON)
-option(CATCH_INSTALL_DOCS "Install documentation alongside library" ON)
-option(CATCH_INSTALL_HELPERS "Install contrib alongside library" ON)
 
-
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # define some folders
 set(CATCH_DIR ${CMAKE_CURRENT_SOURCE_DIR})
@@ -59,10 +73,13 @@ endif()
 
 # add catch as a 'linkable' target
 add_library(Catch2 INTERFACE)
+# provide a namespaced alias for clients to 'link' against if catch is included
+# as a sub-project
+add_library(Catch2::Catch2 ALIAS Catch2)
 
 
-
-# depend on some obvious c++11 features so the dependency is transitively added dependents
+# depend on some obvious c++11 features so the dependency is transitively
+# added to dependents
 target_compile_features(Catch2
   INTERFACE
     cxx_alignas
@@ -88,142 +105,100 @@ target_compile_features(Catch2
 
 target_include_directories(Catch2
   INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/single_include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/single_include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-if (ANDROID)
-    target_link_libraries(Catch2 INTERFACE log)
-endif()
+target_link_libraries(Catch2 INTERFACE $<$<PLATFORM_ID:Android>:log>)
 
-# provide a namespaced alias for clients to 'link' against if catch is included as a sub-project
-add_library(Catch2::Catch2 ALIAS Catch2)
+if (NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  return()
+endif()
 
 # Only perform the installation steps when Catch is not being used as
 # a subproject via `add_subdirectory`, or the destinations will break,
 # see https://github.com/catchorg/Catch2/issues/1373
-if (NOT_SUBPROJECT)
-    set(CATCH_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Catch2")
+set(CATCH_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Catch2")
 
-    configure_package_config_file(
-        ${CMAKE_CURRENT_LIST_DIR}/CMake/Catch2Config.cmake.in
-        ${CMAKE_CURRENT_BINARY_DIR}/Catch2Config.cmake
-        INSTALL_DESTINATION
-          ${CATCH_CMAKE_CONFIG_DESTINATION}
-    )
-
-
-    # create and install an export set for catch target as Catch2::Catch
-    install(
-      TARGETS
-        Catch2
-      EXPORT
-        Catch2Targets
-      DESTINATION
-        ${CMAKE_INSTALL_LIBDIR}
-    )
+configure_file(CMake/catch2.pc.in catch2.pc @ONLY)
+configure_package_config_file(
+  ${PROJECT_SOURCE_DIR}/CMake/Catch2Config.cmake.in
+  ${PROJECT_BINARY_DIR}/Catch2Config.cmake
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  NO_SET_AND_CHECK_MACRO
+  INSTALL_DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}")
 
 
-    install(
-      EXPORT
-        Catch2Targets
-      NAMESPACE
-        Catch2::
-      DESTINATION
-        ${CATCH_CMAKE_CONFIG_DESTINATION}
-    )
+# create and install an export set for catch target as Catch2::Catch
+install(TARGETS Catch2 EXPORT Catch2Targets)
+install(EXPORT Catch2Targets
+  NAMESPACE Catch2::
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}")
 
-    # By default, FooConfigVersion is tied to architecture that it was
-    # generated on. Because Catch2 is header-only, it is arch-independent
-    # and thus Catch2ConfigVersion should not be tied to the architecture
-    # it was generated on.
-    #
-    # CMake does not provide a direct customization point for this in
-    # `write_basic_package_version_file`, but it can be accomplished
-    # indirectly by temporarily redefining `CMAKE_SIZEOF_VOID_P` to an
-    # empty string. Note that just undefining the variable could be
-    # insufficient in cases where the variable was already in CMake cache
-    set(CATCH2_CMAKE_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
-    set(CMAKE_SIZEOF_VOID_P "")
-    write_basic_package_version_file(
-      "${CMAKE_CURRENT_BINARY_DIR}/Catch2ConfigVersion.cmake"
-      COMPATIBILITY
-        SameMajorVersion
-    )
-    set(CMAKE_SIZEOF_VOID_P ${CATCH2_CMAKE_SIZEOF_VOID_P})
+# By default, FooConfigVersion is tied to architecture that it was
+# generated on. Because Catch2 is header-only, it is arch-independent
+# and thus Catch2ConfigVersion should not be tied to the architecture
+# it was generated on.
+#
+# CMake does not provide a direct customization point for this in
+# `write_basic_package_version_file`, but it can be accomplished
+# indirectly by temporarily redefining `CMAKE_SIZEOF_VOID_P` to an
+# empty string. Note that just undefining the variable could be
+# insufficient in cases where the variable was already in CMake cache
+# XXX: CMake 3.14 adds an ARCH_INDEPENDENT option that can replace this
+set(CATCH2_CMAKE_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
+set(CMAKE_SIZEOF_VOID_P "")
+write_basic_package_version_file(
+  "${PROJECT_BINARY_DIR}/Catch2ConfigVersion.cmake"
+  COMPATIBILITY SameMajorVersion)
+set(CMAKE_SIZEOF_VOID_P ${CATCH2_CMAKE_SIZEOF_VOID_P})
 
-    install(
-      DIRECTORY
-        "single_include/"
-      DESTINATION
-        "${CMAKE_INSTALL_INCLUDEDIR}"
-    )
+install(DIRECTORY "single_include/" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(
+  FILES
+    "${PROJECT_BINARY_DIR}/Catch2Config.cmake"
+    "${PROJECT_BINARY_DIR}/Catch2ConfigVersion.cmake"
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
+)
 
-    install(
-      FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/Catch2Config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/Catch2ConfigVersion.cmake"
-      DESTINATION
-        ${CATCH_CMAKE_CONFIG_DESTINATION}
-    )
+# Install documentation
+if(CATCH_INSTALL_DOCS)
+  install(DIRECTORY docs/ DESTINATION "${CMAKE_INSTALL_DOCDIR}")
+endif()
 
-    # Install documentation
-    if(CATCH_INSTALL_DOCS)
-      install(
-        DIRECTORY
-          docs/
-        DESTINATION
-          "${CMAKE_INSTALL_DOCDIR}"
-      )
-    endif()
+if(CATCH_INSTALL_HELPERS)
+  # Install CMake scripts
+  install(DIRECTORY contrib/
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
+    FILES_MATCHING PATTERN "*.cmake")
+  
+  # Install debugger helpers
+  install(DIRECTORY contrib/
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/Catch2
+    FILES_MATCHING PATTERN "*init")
+endif()
 
-    if(CATCH_INSTALL_HELPERS)
-    # Install CMake scripts
-    install(
-      FILES
-        "contrib/ParseAndAddCatchTests.cmake"
-        "contrib/Catch.cmake"
-        "contrib/CatchAddTests.cmake"
-      DESTINATION
-        ${CATCH_CMAKE_CONFIG_DESTINATION}
-    )
+install(FILES "${PROJECT_BINARY_DIR}/catch2.pc"
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig)
 
-    # Install debugger helpers
-    install(
-      FILES
-        "contrib/gdbinit"
-        "contrib/lldbinit"
-      DESTINATION
-        ${CMAKE_INSTALL_DATAROOTDIR}/Catch2
-    )
-    endif()
+if (NOT CATCH_BUILD_PACKAGE)
+  return()
+endif()
 
-    ## Provide some pkg-config integration
-    set(PKGCONFIG_INSTALL_DIR
-        "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig"
-        CACHE PATH "Path where catch2.pc is installed"
-    )
-    configure_file(
-      ${CMAKE_CURRENT_SOURCE_DIR}/CMake/catch2.pc.in
-      ${CMAKE_CURRENT_BINARY_DIR}/catch2.pc
-      @ONLY
-    )
-    install(
-      FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/catch2.pc"
-      DESTINATION
-        ${PKGCONFIG_INSTALL_DIR}
-    )
+if (CATCH_BUILD_PACKAGE_DEB)
+  list(APPEND binary-generators "DEB")
+endif()
 
-    # CPack/CMake started taking the package version from project version 3.12
-    # So we need to set the version manually for older CMake versions
-    if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
-        set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
-    endif()
+if (CMAKE_VERSION VERSION_LESS 3.12)
+  set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
+endif()
 
-    set(CPACK_PACKAGE_CONTACT "https://github.com/catchorg/Catch2/")
+set(CPACK_GENERATOR ${binary-generators})
+set(CPACK_PACKAGE_CONTACT "https://github.com/catchorg/Catch2/")
 
+set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}")
+set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILENAME}")
 
-    include( CPack )
+list(APPEND CPACK_SOURCE_IGNORE_FILES /.git/ /build/ .gitignore [.]DS_Store)
 
-endif(NOT_SUBPROJECT)
+include(CPack)


### PR DESCRIPTION
## Description

Hello! I've run into a few small issues with Catch2 that prevent me from `FetchContent` downloading it directly, and just using `add_subdirectory`. This PR also fixes a few issues regarding file install locations, CPack source packages, and removes an unnecessary `if()` when compiling for Android

Use `cmake_dependent_option` to disable a few options if it's being used as a subdirectory

Reorganize file so that properties, includes, options are all at the top

Catch2 will now link to Android's log library via a generator expression.

Left a note if the minimum version for Catch2 is ever 3.14

Simplified install locations

`CATCH_INSTALL_HELPERS` will now use pattern matching for files instead of listing them out each time.

Building a CPack source package will no longer include a build, .git, or other "garbage" files