### PR TITLE
Fix compile error when using CATCH_CONFIG_GLOBAL_NEXTAFTER

### DIFF
--- a/include/internal/catch_matchers_floating.cpp
+++ b/include/internal/catch_matchers_floating.cpp
@@ -82,7 +82,7 @@ bool almostEqualUlps(FP lhs, FP rhs, int maxUlpDiff) {
 
 #if defined(CATCH_CONFIG_GLOBAL_NEXTAFTER)
 
-namespace Catch {
+namespace Impl {
     float nextafter(float x, float y) {
         return ::nextafterf(x, y);
     }
@@ -94,7 +94,7 @@ namespace Catch {
     long double nextafter(long double x, long double y) {
         return ::nextafterl(x, y);
     }
-} // end namespace Catch
+} // end namespace Impl
 
 #endif
 
@@ -102,7 +102,7 @@ template <typename FP>
 FP step(FP start, FP direction, int steps) {
     for (int i = 0; i < steps; ++i) {
 #if defined(CATCH_CONFIG_GLOBAL_NEXTAFTER)
-        start = Catch::nextafter(start, direction);
+        start = Impl::nextafter(start, direction);
 #else
         start = std::nextafter(start, direction);
 #endif


### PR DESCRIPTION
The function `std::nextafter` is not available when compiling for android (ndk r10e). This is essentially the same problem reported in https://github.com/catchorg/Catch2/pull/1739. 

The fix that was added (b7bdaf8a88f0174a2c1b7135acc18e02fd011f12) adds a good workaround when using the config `CATCH_CONFIG_GLOBAL_NEXTAFTER`. However, when compiling with that flag enabled I get errors like this: 

```
../tests/../external/catch/single_include/catch2/catch.hpp:12703:29: error: reference to 'Catch' is ambiguous
            auto reporter = Catch::getRegistryHub().getReporterRegistry().create(reporterName, config);
                            ^
../tests/../external/catch/single_include/catch2/catch.hpp:12697:11: note: candidate found by name lookup is 'Catch'
namespace Catch {
          ^
../tests/../external/catch/single_include/catch2/catch.hpp:11106:11: note: candidate found by name lookup is '(anonymous namespace)::Catch'
namespace Catch {
          ^
```

Looks like adding the namespace Catch inside an anonymous namespace causes conflicts which the compiler doesn't know how to resolve. This patch just changes the namespace name so that there is no ambiguity and the fix compiles properly.