### PR TITLE
Patch:Failure to pass special chars through input file

### DIFF
--- a/include/internal/catch_test_spec_parser.h
+++ b/include/internal/catch_test_spec_parser.h
@@ -25,6 +25,7 @@ namespace Catch {
         Mode lastMode = None;
         bool m_exclusion = false;
         std::size_t m_pos = 0;
+        std::size_t m_realPatternPos = 0;
         std::string m_arg;
         std::string m_substring;
         std::string m_patternName;

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -433,6 +433,12 @@ set_tests_properties(FilenameAsTagsTest PROPERTIES PASS_REGULAR_EXPRESSION "\\[#
 add_test(NAME EscapeSpecialCharactersInTestNames COMMAND $<TARGET_FILE:SelfTest> "Test with special\\, characters \"in name")
 set_tests_properties(EscapeSpecialCharactersInTestNames PROPERTIES PASS_REGULAR_EXPRESSION "1 assertion in 1 test case")
 
+add_test(NAME SpecialCharactersInTestNamesFromFile COMMAND $<TARGET_FILE:SelfTest> "-f ${CATCH_DIR}/projects/SelfTest/Misc/special-characters-in-file.input")
+set_tests_properties(SpecialCharactersInTestNamesFromFile PROPERTIES PASS_REGULAR_EXPRESSION "1 assertion in 1 test case")
+
+add_test(NAME RunningTestsFromFile COMMAND $<TARGET_FILE:SelfTest> "-f ${CATCH_DIR}/projects/SelfTest/Misc/plain-old-tests.input")
+set_tests_properties(RunningTestsFromFile PROPERTIES PASS_REGULAR_EXPRESSION "6 assertions in 2 test cases")
+
 
 if (CATCH_USE_VALGRIND)
     add_test(NAME ValgrindRunTests COMMAND valgrind --leak-check=full --error-exitcode=1 $<TARGET_FILE:SelfTest>)

--- a/projects/SelfTest/Misc/plain-old-tests.input
+++ b/projects/SelfTest/Misc/plain-old-tests.input
@@ -1,0 +1,2 @@
+random SECTION tests
+nested SECTION tests

--- a/projects/SelfTest/Misc/special-characters-in-file.input
+++ b/projects/SelfTest/Misc/special-characters-in-file.input
@@ -1,0 +1,1 @@
+Test with special\, characters \"in name


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
When Catch parses quoted test name, it may insert wrong positions of escape characters into
TestSpecParser::m_escapeChars, because the quotes are not added to the pattern itself
I added a simple data member to TestSpecParser that will track the right location of those characters in the pattern.


## GitHub Issues
This PR resolves Issue #1767 

