### PR TITLE
docs: command-line: Add example to specify tests by file name.

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -99,6 +99,7 @@ exclude:notThis         Matches all tests except, 'notThis'
 ~*private*              Matches all tests except those that contain 'private'
 a* ~ab* abc             Matches all tests that start with 'a', except those that
                         start with 'ab', except 'abc', which is included
+-# [#somefile]          Matches all tests from the file 'somefile.cpp'
 </pre>
 
 Names within square brackets are interpreted as tags.


### PR DESCRIPTION
## Description
I've been searching for a way to run all tests from a file for some time. To avoid other users having to connect the dots of tags and the `-#` option add a simple example to the "Specifying which tests to run" section.