### PR TITLE
Fixes 1759: Messages in Run Context removed after section ends

### DIFF
--- a/include/internal/catch_run_context.cpp
+++ b/include/internal/catch_run_context.cpp
@@ -217,8 +217,6 @@ namespace Catch {
         }
 
         m_reporter->sectionEnded(SectionStats(endInfo.sectionInfo, assertions, endInfo.durationInSeconds, missingAssertions));
-        m_messages.clear();
-        m_messageScopes.clear();
     }
 
     void RunContext::sectionEndedEarly(SectionEndInfo const & endInfo) {


### PR DESCRIPTION
## Description
When we use Capture, it inserts the variable name and value into RunContext::m_messages
When we apply an assertion, it copies the messages into its assertion results object to be printed later
by one of the reporters.

However, when we destroy a Catch::Section it calls RunContext::sectionEnded and this clears RunContext::m_messages and thus every assertion after the section will not copy anything from m_messages as it has been cleared.

I don't understand what was the purpose of clearing the messages in the first place

## GitHub Issues
This PR resolves Issue #1759