### PR TITLE
Fix error when period of steady_clock is not nano

### DIFF
--- a/include/internal/benchmark/catch_benchmark.hpp
+++ b/include/internal/benchmark/catch_benchmark.hpp
@@ -79,7 +79,7 @@ namespace Catch {
                     });
 
                     auto analysis = Detail::analyse(*cfg, env, samples.begin(), samples.end());
-                    BenchmarkStats<std::chrono::duration<double, std::nano>> stats{ info, analysis.samples, analysis.mean, analysis.standard_deviation, analysis.outliers, analysis.outlier_variance };
+                    BenchmarkStats<FloatDuration<Clock>> stats{ info, analysis.samples, analysis.mean, analysis.standard_deviation, analysis.outliers, analysis.outlier_variance };
                     getResultCapture().benchmarkEnded(stats);
 
                 } CATCH_CATCH_ALL{


### PR DESCRIPTION
## Description

On systems where std::chrono::steady_clock::period is not std::nano, benchmark tests fail to compile due to trying to convert analysis.samples from a vector of duration<double, clock::period> to a vector of std::chrono::duration<double, std::nano>.

To fix this, we instead construct a BenchmarkStats that matches the period of the clock. Once it's constructed, BenchmarkStats's conversion operator will handle converting to other durations.