### PR TITLE
Eliminate copying of TestCaseInfo and reduce allocations during test case registration

### DIFF
--- a/examples/210-Evt-EventListeners.cpp
+++ b/examples/210-Evt-EventListeners.cpp
@@ -170,7 +170,7 @@ void print( std::ostream& os, int const level, std::string const& title, Catch::
 
 void print( std::ostream& os, int const level, std::string const& title, Catch::TestCaseStats const& info ) {
     os << ws(level  ) << title << ":\n";
-    print( os, level+1 , "- testInfo", info.testInfo );
+    print( os, level+1 , "- testInfo", *info.testInfo );
     print( os, level+1 , "- totals"  , info.totals   );
     os << ws(level+1) << "- stdOut: "   << info.stdOut << "\n"
        << ws(level+1) << "- stdErr: "   << info.stdErr << "\n"

--- a/examples/210-Evt-EventListeners.cpp
+++ b/examples/210-Evt-EventListeners.cpp
@@ -21,6 +21,10 @@ std::string ws(int const level) {
     return std::string( 2 * level, ' ' );
 }
 
+std::ostream& operator<<(std::ostream& out, Catch::Tag t) {
+    return out << "original: " << t.original << "lower cased: " << t.lowerCased;
+}
+
 template< typename T >
 std::ostream& operator<<( std::ostream& os, std::vector<T> const& v ) {
     os << "{ ";
@@ -119,31 +123,36 @@ void print( std::ostream& os, int const level, std::string const& title, Catch::
     os << ws(level+1) << "- aborting: " << info.aborting << "\n";
 }
 
-// struct TestCaseInfo {
-//     enum SpecialProperties{
-//         None = 0,
-//         IsHidden = 1 << 1,
-//         ShouldFail = 1 << 2,
-//         MayFail = 1 << 3,
-//         Throws = 1 << 4,
-//         NonPortable = 1 << 5,
-//         Benchmark = 1 << 6
-//     };
+//    struct Tag {
+//        StringRef original, lowerCased;
+//    };
 //
-//     bool isHidden() const;
-//     bool throws() const;
-//     bool okToFail() const;
-//     bool expectedToFail() const;
 //
-//     std::string tagsAsString() const;
+//    enum class TestCaseProperties : uint8_t {
+//        None = 0,
+//        IsHidden = 1 << 1,
+//        ShouldFail = 1 << 2,
+//        MayFail = 1 << 3,
+//        Throws = 1 << 4,
+//        NonPortable = 1 << 5,
+//        Benchmark = 1 << 6
+//    };
 //
-//     std::string name;
-//     std::string className;
-//     std::vector<std::string> tags;
-//     std::vector<std::string> lcaseTags;
-//     SourceLineInfo lineInfo;
-//     SpecialProperties properties;
-// };
+//
+//    struct TestCaseInfo : NonCopyable {
+//
+//        bool isHidden() const;
+//        bool throws() const;
+//        bool okToFail() const;
+//        bool expectedToFail() const;
+//
+//
+//        std::string name;
+//        std::string className;
+//        std::vector<Tag> tags;
+//        SourceLineInfo lineInfo;
+//        TestCaseProperties properties = TestCaseProperties::None;
+//    };
 
 void print( std::ostream& os, int const level, std::string const& title, Catch::TestCaseInfo const& info ) {
     os << ws(level  ) << title << ":\n"
@@ -154,10 +163,9 @@ void print( std::ostream& os, int const level, std::string const& title, Catch::
        << ws(level+1) << "- tagsAsString(): '"  << info.tagsAsString() << "'\n"
        << ws(level+1) << "- name: '"            << info.name << "'\n"
        << ws(level+1) << "- className: '"       << info.className << "'\n"
-       << ws(level+1) << "- tags: "             << info.tags << "\n"
-       << ws(level+1) << "- lcaseTags: "        << info.lcaseTags << "\n";
+       << ws(level+1) << "- tags: "             << info.tags << "\n";
     print( os, level+1 , "- lineInfo", info.lineInfo );
-    os << ws(level+1) << "- properties (flags): 0x" << std::hex << info.properties << std::dec << "\n";
+    os << ws(level+1) << "- properties (flags): 0x" << std::hex << static_cast<uint32_t>(info.properties) << std::dec << "\n";
 }
 
 // struct TestCaseStats {

--- a/include/internal/catch_interfaces_registry_hub.h
+++ b/include/internal/catch_interfaces_registry_hub.h
@@ -15,13 +15,15 @@
 
 namespace Catch {
 
-    class TestCase;
+    class TestCaseHandle;
+    struct TestCaseInfo;
     struct ITestCaseRegistry;
     struct IExceptionTranslatorRegistry;
     struct IExceptionTranslator;
     struct IReporterRegistry;
     struct IReporterFactory;
     struct ITagAliasRegistry;
+    struct ITestInvoker;
     struct IMutableEnumValuesRegistry;
 
     class StartupExceptionRegistry;
@@ -44,7 +46,7 @@ namespace Catch {
         virtual ~IMutableRegistryHub();
         virtual void registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) = 0;
         virtual void registerListener( IReporterFactoryPtr const& factory ) = 0;
-        virtual void registerTest( TestCase const& testInfo ) = 0;
+        virtual void registerTest(std::unique_ptr<TestCaseInfo>&& testInfo, std::unique_ptr<ITestInvoker>&& invoker) = 0;
         virtual void registerTranslator( const IExceptionTranslator* translator ) = 0;
         virtual void registerTagAlias( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) = 0;
         virtual void registerStartupException() noexcept = 0;

--- a/include/internal/catch_interfaces_reporter.cpp
+++ b/include/internal/catch_interfaces_reporter.cpp
@@ -76,7 +76,7 @@ namespace Catch {
                                    std::string const& _stdOut,
                                    std::string const& _stdErr,
                                    bool _aborting )
-    : testInfo( _testInfo ),
+    : testInfo( &_testInfo ),
         totals( _totals ),
         stdOut( _stdOut ),
         stdErr( _stdErr ),
@@ -141,14 +141,15 @@ namespace Catch {
         Catch::cout() << std::endl;
     }
 
-    void IStreamingReporter::listTests(std::vector<TestCase> const& tests, Config const& config) {
+    void IStreamingReporter::listTests(std::vector<TestCaseHandle> const& tests, Config const& config) {
         if (config.hasTestFilters())
             Catch::cout() << "Matching test cases:\n";
         else {
             Catch::cout() << "All available test cases:\n";
         }
 
-        for (auto const& testCaseInfo : tests) {
+        for (auto const& test : tests) {
+            auto const& testCaseInfo = test.getTestCaseInfo();
             Colour::Code colour = testCaseInfo.isHidden()
                 ? Colour::SecondaryText
                 : Colour::None;

--- a/include/internal/catch_interfaces_reporter.h
+++ b/include/internal/catch_interfaces_reporter.h
@@ -128,7 +128,7 @@ namespace Catch {
         TestCaseStats& operator = ( TestCaseStats && )     = default;
         virtual ~TestCaseStats();
 
-        TestCaseInfo testInfo;
+        TestCaseInfo const * testInfo;
         Totals totals;
         std::string stdOut;
         std::string stdErr;
@@ -217,7 +217,7 @@ namespace Catch {
         virtual void noMatchingTestCases( std::string const& spec ) = 0;
 
         virtual void reportInvalidArguments(std::string const&) {}
-        
+
         virtual void testRunStarting( TestRunInfo const& testRunInfo ) = 0;
         virtual void testGroupStarting( GroupInfo const& groupInfo ) = 0;
 
@@ -250,7 +250,7 @@ namespace Catch {
 
         // Listing support
         virtual void listReporters(std::vector<ReporterDescription> const& descriptions, Config const& config);
-        virtual void listTests(std::vector<TestCase> const& tests, Config const& config);
+        virtual void listTests(std::vector<TestCaseHandle> const& tests, Config const& config);
         virtual void listTags(std::vector<TagInfo> const& tags, Config const& config);
 
     };

--- a/include/internal/catch_interfaces_testcase.h
+++ b/include/internal/catch_interfaces_testcase.h
@@ -19,19 +19,19 @@ namespace Catch {
         virtual ~ITestInvoker();
     };
 
-    class TestCase;
+    class TestCaseHandle;
     struct IConfig;
 
     struct ITestCaseRegistry {
         virtual ~ITestCaseRegistry();
-        virtual std::vector<TestCase> const& getAllTests() const = 0;
-        virtual std::vector<TestCase> const& getAllTestsSorted( IConfig const& config ) const = 0;
+        virtual std::vector<TestCaseHandle> const& getAllTests() const = 0;
+        virtual std::vector<TestCaseHandle> const& getAllTestsSorted( IConfig const& config ) const = 0;
     };
 
-    bool isThrowSafe( TestCase const& testCase, IConfig const& config );
-    bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config );
-    std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config );
-    std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config );
+    bool isThrowSafe( TestCaseHandle const& testCase, IConfig const& config );
+    bool matchTest( TestCaseHandle const& testCase, TestSpec const& testSpec, IConfig const& config );
+    std::vector<TestCaseHandle> filterTests( std::vector<TestCaseHandle> const& testCases, TestSpec const& testSpec, IConfig const& config );
+    std::vector<TestCaseHandle> const& getAllTestCasesSorted( IConfig const& config );
 
 }
 

--- a/include/internal/catch_interfaces_testcase.h
+++ b/include/internal/catch_interfaces_testcase.h
@@ -9,10 +9,12 @@
 #define TWOBLUECUBES_CATCH_INTERFACES_TESTCASE_H_INCLUDED
 
 #include <vector>
+#include <memory>
 
 namespace Catch {
 
     class TestSpec;
+    struct TestCaseInfo;
 
     struct ITestInvoker {
         virtual void invoke () const = 0;
@@ -24,6 +26,7 @@ namespace Catch {
 
     struct ITestCaseRegistry {
         virtual ~ITestCaseRegistry();
+        virtual std::vector<std::unique_ptr<TestCaseInfo>> const& getAllInfos() const = 0;
         virtual std::vector<TestCaseHandle> const& getAllTests() const = 0;
         virtual std::vector<TestCaseHandle> const& getAllTestsSorted( IConfig const& config ) const = 0;
     };

--- a/include/internal/catch_list.cpp
+++ b/include/internal/catch_list.cpp
@@ -36,7 +36,7 @@ namespace Catch {
 
         void listTags(IStreamingReporter& reporter, Config const& config) {
             TestSpec testSpec = config.testSpec();
-            std::vector<TestCase> matchedTestCases = filterTests(getAllTestCasesSorted(config), testSpec, config);
+            std::vector<TestCaseHandle> matchedTestCases = filterTests(getAllTestCasesSorted(config), testSpec, config);
 
             std::map<std::string, TagInfo> tagCounts;
             for (auto const& testCase : matchedTestCases) {

--- a/include/internal/catch_list.cpp
+++ b/include/internal/catch_list.cpp
@@ -38,14 +38,13 @@ namespace Catch {
             TestSpec testSpec = config.testSpec();
             std::vector<TestCaseHandle> matchedTestCases = filterTests(getAllTestCasesSorted(config), testSpec, config);
 
-            std::map<std::string, TagInfo> tagCounts;
+            std::map<StringRef, TagInfo> tagCounts;
             for (auto const& testCase : matchedTestCases) {
                 for (auto const& tagName : testCase.getTestCaseInfo().tags) {
-                    std::string lcaseTagName = toLower(tagName);
-                    auto countIt = tagCounts.find(lcaseTagName);
-                    if (countIt == tagCounts.end())
-                        countIt = tagCounts.insert(std::make_pair(lcaseTagName, TagInfo())).first;
-                    countIt->second.add(tagName);
+                    auto it = tagCounts.find(tagName.lowerCased);
+                    if (it == tagCounts.end())
+                        it = tagCounts.insert(std::make_pair(tagName.lowerCased, TagInfo())).first;
+                    it->second.add(tagName.original);
                 }
             }
 
@@ -71,16 +70,16 @@ namespace Catch {
 
     } // end anonymous namespace
 
-    void TagInfo::add( std::string const& spelling ) {
+    void TagInfo::add( StringRef spelling ) {
         ++count;
         spellings.insert( spelling );
     }
 
     std::string TagInfo::all() const {
-        size_t size = 0;
+        // 2 per tag for brackets '[' and ']'
+        size_t size =  spellings.size() * 2;
         for (auto const& spelling : spellings) {
-            // Add 2 for the brackes
-            size += spelling.size() + 2;
+            size += spelling.size();
         }
 
         std::string out; out.reserve(size);

--- a/include/internal/catch_list.h
+++ b/include/internal/catch_list.h
@@ -23,10 +23,10 @@ namespace Catch {
     };
 
     struct TagInfo {
-        void add(std::string const& spelling);
+        void add(StringRef spelling);
         std::string all() const;
 
-        std::set<std::string> spellings;
+        std::set<StringRef> spellings;
         std::size_t count = 0;
     };
 

--- a/include/internal/catch_objc.hpp
+++ b/include/internal/catch_objc.hpp
@@ -93,7 +93,7 @@ namespace Catch {
                         std::string desc = Detail::getAnnotation( cls, "Description", testCaseName );
                         const char* className = class_getName( cls );
 
-                        getMutableRegistryHub().registerTest( makeTestCase( new OcMethod( cls, selector ), className, NameAndTags( name.c_str(), desc.c_str() ), SourceLineInfo("",0) ) );
+                        getMutableRegistryHub().registerTest( makeTestCaseInfo( new OcMethod( cls, selector ), className, NameAndTags( name.c_str(), desc.c_str() ), SourceLineInfo("",0) ) );
                         noTestMethods++;
                     }
                 }

--- a/include/internal/catch_registry_hub.cpp
+++ b/include/internal/catch_registry_hub.cpp
@@ -49,8 +49,8 @@ namespace Catch {
             void registerListener( IReporterFactoryPtr const& factory ) override {
                 m_reporterRegistry.registerListener( factory );
             }
-            void registerTest( TestCase const& testInfo ) override {
-                m_testCaseRegistry.registerTest( testInfo );
+            void registerTest( std::unique_ptr<TestCaseInfo>&& testInfo, std::unique_ptr<ITestInvoker>&& invoker ) override {
+                m_testCaseRegistry.registerTest( std::move(testInfo), std::move(invoker) );
             }
             void registerTranslator( const IExceptionTranslator* translator ) override {
                 m_exceptionTranslatorRegistry.registerTranslator( translator );

--- a/include/internal/catch_run_context.cpp
+++ b/include/internal/catch_run_context.cpp
@@ -93,7 +93,7 @@ namespace Catch {
         m_reporter->testGroupEnded(TestGroupStats(GroupInfo(testSpec, groupIndex, groupsCount), totals, aborting()));
     }
 
-    Totals RunContext::runTest(TestCase const& testCase) {
+    Totals RunContext::runTest(TestCaseHandle const& testCase) {
         Totals prevTotals = m_totals;
 
         std::string redirectedCout;

--- a/include/internal/catch_run_context.h
+++ b/include/internal/catch_run_context.h
@@ -44,7 +44,7 @@ namespace Catch {
         void testGroupStarting( std::string const& testSpec, std::size_t groupIndex, std::size_t groupsCount );
         void testGroupEnded( std::string const& testSpec, Totals const& totals, std::size_t groupIndex, std::size_t groupsCount );
 
-        Totals runTest(TestCase const& testCase);
+        Totals runTest(TestCaseHandle const& testCase);
 
         IConfigPtr config() const;
         IStreamingReporter& reporter() const;
@@ -133,7 +133,7 @@ namespace Catch {
 
         TestRunInfo m_runInfo;
         IMutableContext& m_context;
-        TestCase const* m_activeTestCase = nullptr;
+        TestCaseHandle const* m_activeTestCase = nullptr;
         ITracker* m_testCaseTracker = nullptr;
         Option<AssertionResult> m_lastResult;
 

--- a/include/internal/catch_session.cpp
+++ b/include/internal/catch_session.cpp
@@ -116,26 +116,9 @@ namespace Catch {
             TestSpec::Matches m_matches;
         };
 
-        void applyFilenamesAsTags(Catch::IConfig const& config) {
-            for (auto const& testCase : getAllTestCasesSorted(config)) {
-                // Yeah, sue me. This will be removed soon.
-                auto& testInfo = const_cast<TestCaseInfo&>(testCase.getTestCaseInfo());
-
-                std::string filename = testInfo.lineInfo.file;
-                auto lastSlash = filename.find_last_of("\\/");
-                if (lastSlash != std::string::npos) {
-                    filename.erase(0, lastSlash);
-                    filename[0] = '#';
-                }
-
-                auto lastDot = filename.find_last_of('.');
-                if (lastDot != std::string::npos) {
-                    filename.erase(lastDot);
-                }
-
-                auto tags = testInfo.tags;
-                tags.push_back(std::move(filename));
-                setTags(testInfo, tags);
+        void applyFilenamesAsTags() {
+            for (auto const& testInfo : getRegistryHub().getTestCaseRegistry().getAllInfos()) {
+                testInfo->addFilenameTag();
             }
         }
 
@@ -285,8 +268,9 @@ namespace Catch {
 
             seedRng( *m_config );
 
-            if( m_configData.filenamesAsTags )
-                applyFilenamesAsTags( *m_config );
+            if (m_configData.filenamesAsTags) {
+                applyFilenamesAsTags();
+            }
 
             // Create reporter(s) so we can route listings through them
             auto reporter = makeReporter(m_config);

--- a/include/internal/catch_session.cpp
+++ b/include/internal/catch_session.cpp
@@ -72,7 +72,7 @@ namespace Catch {
 
                 if (m_matches.empty() && invalidArgs.empty()) {
                     for (auto const& test : allTestCases)
-                        if (!test.isHidden())
+                        if (!test.getTestCaseInfo().isHidden())
                             m_tests.emplace(&test);
                 } else {
                     for (auto const& match : m_matches)
@@ -88,7 +88,7 @@ namespace Catch {
                     if (!m_context.aborting())
                         totals += m_context.runTest(*testCase);
                     else
-                        m_context.reporter().skipTest(*testCase);
+                        m_context.reporter().skipTest(testCase->getTestCaseInfo());
                 }
 
                 for (auto const& match : m_matches) {
@@ -108,7 +108,7 @@ namespace Catch {
             }
 
         private:
-            using Tests = std::set<TestCase const*>;
+            using Tests = std::set<TestCaseHandle const*>;
 
             std::shared_ptr<Config> m_config;
             RunContext m_context;
@@ -117,11 +117,11 @@ namespace Catch {
         };
 
         void applyFilenamesAsTags(Catch::IConfig const& config) {
-            auto& tests = const_cast<std::vector<TestCase>&>(getAllTestCasesSorted(config));
-            for (auto& testCase : tests) {
-                auto tags = testCase.tags;
+            for (auto const& testCase : getAllTestCasesSorted(config)) {
+                // Yeah, sue me. This will be removed soon.
+                auto& testInfo = const_cast<TestCaseInfo&>(testCase.getTestCaseInfo());
 
-                std::string filename = testCase.lineInfo.file;
+                std::string filename = testInfo.lineInfo.file;
                 auto lastSlash = filename.find_last_of("\\/");
                 if (lastSlash != std::string::npos) {
                     filename.erase(0, lastSlash);
@@ -133,8 +133,9 @@ namespace Catch {
                     filename.erase(lastDot);
                 }
 
+                auto tags = testInfo.tags;
                 tags.push_back(std::move(filename));
-                setTags(testCase, tags);
+                setTags(testInfo, tags);
             }
         }
 

--- a/include/internal/catch_stringref.cpp
+++ b/include/internal/catch_stringref.cpp
@@ -38,6 +38,13 @@ namespace Catch {
             && (std::memcmp( m_start, other.m_start, m_size ) == 0);
     }
 
+    bool StringRef::operator<(StringRef const& rhs) const noexcept {
+        if (m_size < rhs.m_size) {
+            return strncmp(m_start, rhs.m_start, m_size) <= 0;
+        }
+        return strncmp(m_start, rhs.m_start, rhs.m_size) < 0;
+    }
+
     auto operator << ( std::ostream& os, StringRef const& str ) -> std::ostream& {
         return os.write(str.data(), str.size());
     }

--- a/include/internal/catch_stringref.h
+++ b/include/internal/catch_stringref.h
@@ -58,6 +58,8 @@ namespace Catch {
             return m_start[index];
         }
 
+        bool operator<(StringRef const& rhs) const noexcept;
+
     public: // named queries
         constexpr auto empty() const noexcept -> bool {
             return m_size == 0;
@@ -90,7 +92,6 @@ namespace Catch {
 
     auto operator += ( std::string& lhs, StringRef const& sr ) -> std::string&;
     auto operator << ( std::ostream& os, StringRef const& sr ) -> std::ostream&;
-
 
     constexpr auto operator "" _sr( char const* rawChars, std::size_t size ) noexcept -> StringRef {
         return StringRef( rawChars, size );

--- a/include/internal/catch_test_case_info.cpp
+++ b/include/internal/catch_test_case_info.cpp
@@ -53,10 +53,10 @@ namespace Catch {
         }
     }
 
-    TestCase makeTestCase(  ITestInvoker* _testCase,
-                            std::string const& _className,
-                            NameAndTags const& nameAndTags,
-                            SourceLineInfo const& _lineInfo )
+    std::unique_ptr<TestCaseInfo>
+        makeTestCaseInfo(std::string const& _className,
+                     NameAndTags const& nameAndTags,
+                     SourceLineInfo const& _lineInfo )
     {
         bool isHidden = false;
 
@@ -95,8 +95,8 @@ namespace Catch {
             tags.push_back( "." );
         }
 
-        TestCaseInfo info( static_cast<std::string>(nameAndTags.name), _className, tags, _lineInfo );
-        return TestCase( _testCase, std::move(info) );
+        return std::make_unique<TestCaseInfo>(static_cast<std::string>(nameAndTags.name),
+                                              _className, tags, _lineInfo);
     }
 
     void setTags( TestCaseInfo& testCaseInfo, std::vector<std::string> tags ) {
@@ -155,26 +155,18 @@ namespace Catch {
     }
 
 
-    TestCase::TestCase( ITestInvoker* testCase, TestCaseInfo&& info ) : TestCaseInfo( std::move(info) ), test( testCase ) {}
-
-
-    void TestCase::invoke() const {
-        test->invoke();
+    bool TestCaseHandle::operator == ( TestCaseHandle const& rhs ) const {
+        return m_invoker == rhs.m_invoker
+            && m_info->name == rhs.m_info->name
+            && m_info->className == rhs.m_info->className;
     }
 
-    bool TestCase::operator == ( TestCase const& other ) const {
-        return  test.get() == other.test.get() &&
-                name == other.name &&
-                className == other.className;
+    bool TestCaseHandle::operator < ( TestCaseHandle const& rhs ) const {
+        return m_info->name < rhs.m_info->name;
     }
 
-    bool TestCase::operator < ( TestCase const& other ) const {
-        return name < other.name;
-    }
-
-    TestCaseInfo const& TestCase::getTestCaseInfo() const
-    {
-        return *this;
+    TestCaseInfo const& TestCaseHandle::getTestCaseInfo() const {
+        return *m_info;
     }
 
 } // end namespace Catch

--- a/include/internal/catch_test_case_info.h
+++ b/include/internal/catch_test_case_info.h
@@ -9,6 +9,7 @@
 #define TWOBLUECUBES_CATCH_TEST_CASE_INFO_H_INCLUDED
 
 #include "catch_common.h"
+#include "catch_stringref.h"
 #include "catch_test_registry.h"
 
 #include <string>
@@ -22,39 +23,54 @@
 
 namespace Catch {
 
+    struct Tag {
+        Tag(StringRef original_, StringRef lowerCased_):
+            original(original_), lowerCased(lowerCased_)
+        {}
+        StringRef original, lowerCased;
+    };
+
     struct ITestInvoker;
 
+    enum class TestCaseProperties : uint8_t {
+        None = 0,
+        IsHidden = 1 << 1,
+        ShouldFail = 1 << 2,
+        MayFail = 1 << 3,
+        Throws = 1 << 4,
+        NonPortable = 1 << 5,
+        Benchmark = 1 << 6
+    };
+
+
     struct TestCaseInfo : NonCopyable {
-        enum SpecialProperties{
-            None = 0,
-            IsHidden = 1 << 1,
-            ShouldFail = 1 << 2,
-            MayFail = 1 << 3,
-            Throws = 1 << 4,
-            NonPortable = 1 << 5,
-            Benchmark = 1 << 6
-        };
 
-        TestCaseInfo(   std::string const& _name,
-                        std::string const& _className,
-                        std::vector<std::string> const& _tags,
-                        SourceLineInfo const& _lineInfo );
-
-        friend void setTags( TestCaseInfo& testCaseInfo, std::vector<std::string> tags );
+        TestCaseInfo(std::string const& _className,
+                     NameAndTags const& _tags,
+                     SourceLineInfo const& _lineInfo);
 
         bool isHidden() const;
         bool throws() const;
         bool okToFail() const;
         bool expectedToFail() const;
 
+        // Adds the tag(s) with test's filename (for the -# flag)
+        void addFilenameTag();
+
+
         std::string tagsAsString() const;
 
         std::string name;
         std::string className;
-        std::vector<std::string> tags;
-        std::vector<std::string> lcaseTags;
+    private:
+        std::string backingTags, backingLCaseTags;
+        // Internally we copy tags to the backing storage and then add
+        // refs to this storage to the tags vector.
+        void internalAppendTag(StringRef tagString);
+    public:
+        std::vector<Tag> tags;
         SourceLineInfo lineInfo;
-        SpecialProperties properties;
+        TestCaseProperties properties = TestCaseProperties::None;
     };
 
     class TestCaseHandle {

--- a/include/internal/catch_test_case_info.h
+++ b/include/internal/catch_test_case_info.h
@@ -24,7 +24,7 @@ namespace Catch {
 
     struct ITestInvoker;
 
-    struct TestCaseInfo {
+    struct TestCaseInfo : NonCopyable {
         enum SpecialProperties{
             None = 0,
             IsHidden = 1 << 1,
@@ -57,24 +57,24 @@ namespace Catch {
         SpecialProperties properties;
     };
 
-    class TestCase : public TestCaseInfo {
+    class TestCaseHandle {
+        TestCaseInfo* m_info;
+        ITestInvoker* m_invoker;
     public:
+        TestCaseHandle(TestCaseInfo* info, ITestInvoker* invoker) :
+            m_info(info), m_invoker(invoker) {}
 
-        TestCase( ITestInvoker* testCase, TestCaseInfo&& info );
-
-        void invoke() const;
+        void invoke() const {
+            m_invoker->invoke();
+        }
 
         TestCaseInfo const& getTestCaseInfo() const;
 
-        bool operator == ( TestCase const& other ) const;
-        bool operator < ( TestCase const& other ) const;
-
-    private:
-        std::shared_ptr<ITestInvoker> test;
+        bool operator== ( TestCaseHandle const& rhs ) const;
+        bool operator < ( TestCaseHandle const& rhs ) const;
     };
 
-    TestCase makeTestCase(  ITestInvoker* testCase,
-                            std::string const& className,
+    std::unique_ptr<TestCaseInfo> makeTestCaseInfo(  std::string const& className,
                             NameAndTags const& nameAndTags,
                             SourceLineInfo const& lineInfo );
 }

--- a/include/internal/catch_test_case_registry_impl.cpp
+++ b/include/internal/catch_test_case_registry_impl.cpp
@@ -78,6 +78,10 @@ namespace Catch {
         m_invokers.push_back(std::move(testInvoker));
     }
 
+    std::vector<std::unique_ptr<TestCaseInfo>> const& TestRegistry::getAllInfos() const {
+        return m_infos;
+    }
+
     std::vector<TestCaseHandle> const& TestRegistry::getAllTests() const {
         return m_handles;
     }

--- a/include/internal/catch_test_case_registry_impl.h
+++ b/include/internal/catch_test_case_registry_impl.h
@@ -37,6 +37,7 @@ namespace Catch {
 
         virtual void registerTest( std::unique_ptr<TestCaseInfo> testInfo, std::unique_ptr<ITestInvoker> testInvoker );
 
+        std::vector<std::unique_ptr<TestCaseInfo>> const& getAllInfos() const override;
         std::vector<TestCaseHandle> const& getAllTests() const override;
         std::vector<TestCaseHandle> const& getAllTestsSorted( IConfig const& config ) const override;
 

--- a/include/internal/catch_test_registry.h
+++ b/include/internal/catch_test_registry.h
@@ -15,6 +15,8 @@
 #include "catch_preprocessor.hpp"
 #include "catch_meta.hpp"
 
+#include <memory>
+
 namespace Catch {
 
 template<typename C>
@@ -29,11 +31,11 @@ public:
     }
 };
 
-auto makeTestInvoker( void(*testAsFunction)() ) noexcept -> ITestInvoker*;
+std::unique_ptr<ITestInvoker> makeTestInvoker( void(*testAsFunction)() );
 
 template<typename C>
-auto makeTestInvoker( void (C::*testAsMethod)() ) noexcept -> ITestInvoker* {
-    return new(std::nothrow) TestInvokerAsMethod<C>( testAsMethod );
+std::unique_ptr<ITestInvoker> makeTestInvoker( void (C::*testAsMethod)() ) {
+    return std::make_unique<TestInvokerAsMethod<C>>( testAsMethod );
 }
 
 struct NameAndTags {
@@ -45,7 +47,7 @@ struct NameAndTags {
 };
 
 struct AutoReg : NonCopyable {
-    AutoReg( ITestInvoker* invoker, SourceLineInfo const& lineInfo, StringRef const& classOrMethod, NameAndTags const& nameAndTags ) noexcept;
+    AutoReg( std::unique_ptr<ITestInvoker> invoker, SourceLineInfo const& lineInfo, StringRef const& classOrMethod, NameAndTags const& nameAndTags ) noexcept;
 };
 
 } // end namespace Catch

--- a/include/internal/catch_test_spec.cpp
+++ b/include/internal/catch_test_spec.cpp
@@ -43,9 +43,11 @@ namespace Catch {
     {}
 
     bool TestSpec::TagPattern::matches( TestCaseInfo const& testCase ) const {
-        return std::find(begin(testCase.lcaseTags),
-                         end(testCase.lcaseTags),
-                         m_tag) != end(testCase.lcaseTags);
+        return std::find_if(begin(testCase.tags),
+                            end(testCase.tags),
+                            [&](Tag const& tag) {
+                                return tag.lowerCased == m_tag;
+                            }) != end(testCase.tags);
     }
 
     bool TestSpec::Filter::matches( TestCaseInfo const& testCase ) const {

--- a/include/internal/catch_test_spec.cpp
+++ b/include/internal/catch_test_spec.cpp
@@ -84,13 +84,13 @@ namespace Catch {
         return std::any_of( m_filters.begin(), m_filters.end(), [&]( Filter const& f ){ return f.matches( testCase ); } );
     }
 
-    TestSpec::Matches TestSpec::matchesByFilter( std::vector<TestCase> const& testCases, IConfig const& config ) const
+    TestSpec::Matches TestSpec::matchesByFilter( std::vector<TestCaseHandle> const& testCases, IConfig const& config ) const
     {
         Matches matches( m_filters.size() );
         std::transform( m_filters.begin(), m_filters.end(), matches.begin(), [&]( Filter const& filter ){
-            std::vector<TestCase const*> currentMatches;
+            std::vector<TestCaseHandle const*> currentMatches;
             for( auto const& test : testCases )
-                if( isThrowSafe( test, config ) && filter.matches( test ) )
+                if( isThrowSafe( test, config ) && filter.matches( test.getTestCaseInfo() ) )
                     currentMatches.emplace_back( &test );
             return FilterMatch{ filter.name(), currentMatches };
         } );

--- a/include/internal/catch_test_spec.h
+++ b/include/internal/catch_test_spec.h
@@ -63,14 +63,14 @@ namespace Catch {
     public:
         struct FilterMatch {
             std::string name;
-            std::vector<TestCase const*> tests;
+            std::vector<TestCaseHandle const*> tests;
         };
         using Matches = std::vector<FilterMatch>;
         using vectorStrings = std::vector<std::string>;
 
         bool hasFilters() const;
         bool matches( TestCaseInfo const& testCase ) const;
-        Matches matchesByFilter( std::vector<TestCase> const& testCases, IConfig const& config ) const;
+        Matches matchesByFilter( std::vector<TestCaseHandle> const& testCases, IConfig const& config ) const;
         const vectorStrings & getInvalidArgs() const;
 
     private:

--- a/include/reporters/catch_reporter_automake.hpp
+++ b/include/reporters/catch_reporter_automake.hpp
@@ -41,7 +41,7 @@ namespace Catch {
             } else {
                 stream << "FAIL";
             }
-            stream << ' ' << _testCaseStats.testInfo.name << '\n';
+            stream << ' ' << _testCaseStats.testInfo->name << '\n';
             StreamingReporterBase::testCaseEnded( _testCaseStats );
         }
 

--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -45,7 +45,7 @@ namespace Catch {
         void noMatchingTestCases(std::string const&) override {}
 
         void reportInvalidArguments(std::string const&) override {}
-        
+
         void testRunStarting(TestRunInfo const& _testRunInfo) override {
             currentTestRunInfo = _testRunInfo;
         }
@@ -55,7 +55,7 @@ namespace Catch {
         }
 
         void testCaseStarting(TestCaseInfo const& _testInfo) override  {
-            currentTestCaseInfo = _testInfo;
+            currentTestCaseInfo = &_testInfo;
         }
         void sectionStarting(SectionInfo const& _sectionInfo) override {
             m_sectionStack.push_back(_sectionInfo);
@@ -65,13 +65,13 @@ namespace Catch {
             m_sectionStack.pop_back();
         }
         void testCaseEnded(TestCaseStats const& /* _testCaseStats */) override {
-            currentTestCaseInfo.reset();
+            currentTestCaseInfo = nullptr;
         }
         void testGroupEnded(TestGroupStats const& /* _testGroupStats */) override {
             currentGroupInfo.reset();
         }
         void testRunEnded(TestRunStats const& /* _testRunStats */) override {
-            currentTestCaseInfo.reset();
+            currentTestCaseInfo = nullptr;
             currentGroupInfo.reset();
             currentTestRunInfo.reset();
         }
@@ -86,7 +86,7 @@ namespace Catch {
 
         LazyStat<TestRunInfo> currentTestRunInfo;
         LazyStat<GroupInfo> currentGroupInfo;
-        LazyStat<TestCaseInfo> currentTestCaseInfo;
+        TestCaseInfo const* currentTestCaseInfo;
 
         std::vector<SectionInfo> m_sectionStack;
         ReporterPreferences m_reporterPrefs;
@@ -261,7 +261,7 @@ namespace Catch {
 
         // Event listeners should not use the default listing impl
         void listReporters(std::vector<ReporterDescription> const&, Config const&) override {}
-        void listTests(std::vector<TestCase> const&, Config const&) override {}
+        void listTests(std::vector<TestCaseHandle> const&, Config const&) override {}
         void listTags(std::vector<TagInfo> const&, Config const&) override {}
     };
 

--- a/include/reporters/catch_reporter_junit.cpp
+++ b/include/reporters/catch_reporter_junit.cpp
@@ -159,10 +159,10 @@ namespace Catch {
         assert( testCaseNode.children.size() == 1 );
         SectionNode const& rootSection = *testCaseNode.children.front();
 
-        std::string className = stats.testInfo.className;
+        std::string className = stats.testInfo->className;
 
         if( className.empty() ) {
-            className = fileNameTag(stats.testInfo.tags);
+            className = fileNameTag(stats.testInfo->tags);
             if ( className.empty() )
                 className = "global";
         }

--- a/include/reporters/catch_reporter_junit.cpp
+++ b/include/reporters/catch_reporter_junit.cpp
@@ -48,12 +48,17 @@ namespace Catch {
             return std::string(timeStamp);
         }
 
-        std::string fileNameTag(const std::vector<std::string> &tags) {
+        std::string fileNameTag(std::vector<Tag> const& tags) {
             auto it = std::find_if(begin(tags),
                                    end(tags),
-                                   [] (std::string const& tag) {return tag.front() == '#'; });
-            if (it != tags.end())
-                return it->substr(1);
+                                   [] (Tag const& tag) {
+                                       return tag.original.size() > 0
+                                           && tag.original[0] == '#'; });
+            if (it != tags.end()) {
+                return static_cast<std::string>(
+                    it->original.substr(1, it->original.size() - 1)
+                );
+            }
             return std::string();
         }
     } // anonymous namespace

--- a/include/reporters/catch_reporter_listening.cpp
+++ b/include/reporters/catch_reporter_listening.cpp
@@ -163,7 +163,7 @@ namespace Catch {
         m_reporter->listReporters(descriptions, config);
     }
 
-    void ListeningReporter::listTests(std::vector<TestCase> const& tests, Config const& config) {
+    void ListeningReporter::listTests(std::vector<TestCaseHandle> const& tests, Config const& config) {
         for (auto const& listener : m_listeners) {
             listener->listTests(tests, config);
         }

--- a/include/reporters/catch_reporter_listening.h
+++ b/include/reporters/catch_reporter_listening.h
@@ -55,7 +55,7 @@ namespace Catch {
         bool isMulti() const override;
 
         void listReporters(std::vector<ReporterDescription> const& descriptions, Config const& config) override;
-        void listTests(std::vector<TestCase> const& tests, Config const& config) override;
+        void listTests(std::vector<TestCaseHandle> const& tests, Config const& config) override;
         void listTags(std::vector<TagInfo> const& tags, Config const& config) override;
 
 

--- a/include/reporters/catch_reporter_sonarqube.hpp
+++ b/include/reporters/catch_reporter_sonarqube.hpp
@@ -58,7 +58,7 @@ namespace Catch {
         void writeGroup(TestGroupNode const& groupNode) {
             std::map<std::string, TestGroupNode::ChildNodes> testsPerFile;
             for(auto const& child : groupNode.children)
-                testsPerFile[child->value.testInfo.lineInfo.file].push_back(child);
+                testsPerFile[child->value.testInfo->lineInfo.file].push_back(child);
 
             for(auto const& kv : testsPerFile)
                 writeTestFile(kv.first.c_str(), kv.second);
@@ -77,7 +77,7 @@ namespace Catch {
             // test case itself. That section may have 0-n nested sections
             assert(testCaseNode.children.size() == 1);
             SectionNode const& rootSection = *testCaseNode.children.front();
-            writeSection("", rootSection, testCaseNode.value.testInfo.okToFail());
+            writeSection("", rootSection, testCaseNode.value.testInfo->okToFail());
         }
 
         void writeSection(std::string const& rootName, SectionNode const& sectionNode, bool okToFail) {

--- a/include/reporters/catch_reporter_teamcity.hpp
+++ b/include/reporters/catch_reporter_teamcity.hpp
@@ -152,16 +152,17 @@ namespace Catch {
 
         void testCaseEnded( TestCaseStats const& testCaseStats ) override {
             StreamingReporterBase::testCaseEnded( testCaseStats );
+            auto const& testCaseInfo = *testCaseStats.testInfo;
             if( !testCaseStats.stdOut.empty() )
                 stream << "##teamcity[testStdOut name='"
-                    << escape( testCaseStats.testInfo.name )
+                    << escape( testCaseInfo.name )
                     << "' out='" << escape( testCaseStats.stdOut ) << "']\n";
             if( !testCaseStats.stdErr.empty() )
                 stream << "##teamcity[testStdErr name='"
-                    << escape( testCaseStats.testInfo.name )
+                    << escape(testCaseInfo.name )
                     << "' out='" << escape( testCaseStats.stdErr ) << "']\n";
             stream << "##teamcity[testFinished name='"
-                    << escape( testCaseStats.testInfo.name ) << "' duration='"
+                    << escape(testCaseInfo.name ) << "' duration='"
                     << m_testTimer.getElapsedMilliseconds() << "']\n";
             stream.flush();
         }

--- a/include/reporters/catch_reporter_xml.cpp
+++ b/include/reporters/catch_reporter_xml.cpp
@@ -277,7 +277,7 @@ namespace Catch {
         }
     }
 
-    void XmlReporter::listTests(std::vector<TestCase> const& tests, Config const&) {
+    void XmlReporter::listTests(std::vector<TestCaseHandle> const& tests, Config const&) {
         auto outerTag = m_xml.scopedElement("MatchingTests");
         for (auto const& test : tests) {
             auto innerTag = m_xml.scopedElement("TestCase");

--- a/include/reporters/catch_reporter_xml.cpp
+++ b/include/reporters/catch_reporter_xml.cpp
@@ -312,7 +312,7 @@ namespace Catch {
             auto aliasTag = m_xml.scopedElement("Aliases");
             for (auto const& alias : tag.spellings) {
                 m_xml.startElement("Alias", XmlFormatting::Indent)
-                     .writeText(alias, XmlFormatting::None)
+                     .writeText(static_cast<std::string>(alias), XmlFormatting::None)
                      .endElement(XmlFormatting::Newline);
             }
         }

--- a/include/reporters/catch_reporter_xml.h
+++ b/include/reporters/catch_reporter_xml.h
@@ -58,7 +58,7 @@ namespace Catch {
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
         void listReporters(std::vector<ReporterDescription> const& descriptions, Config const& config) override;
-        void listTests(std::vector<TestCase> const& tests, Config const& config) override;
+        void listTests(std::vector<TestCaseHandle> const& tests, Config const& config) override;
         void listTags(std::vector<TagInfo> const& tags, Config const& config) override;
 
     private:

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -883,150 +883,150 @@ RandomNumberGeneration.tests.cpp:<line number>: passed: rng() == 0x<hex digits> 
 Message.tests.cpp:<line number>: failed: explicitly with 1 message: 'Message from section one'
 Message.tests.cpp:<line number>: failed: explicitly with 1 message: 'Message from section two'
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches(tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: parseTestSpec( "*a" ).matches( tcA ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: parseTestSpec( "*a" ).matches( *tcA ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: parseTestSpec( "a*" ).matches( tcA ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: parseTestSpec( "a*" ).matches( *tcA ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: parseTestSpec( "*a*" ).matches( tcA ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: parseTestSpec( "*a*" ).matches( *tcA ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == true for: true == true
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == false for: false == false
 CmdLine.tests.cpp:<line number>: passed: spec.hasFilters() == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcA ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcB ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcC ) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: spec.matches( tcD ) == true for: true == true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( fakeTestCase( "  aardvark " ) ) for: true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( fakeTestCase( "  aardvark" ) ) for: true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( fakeTestCase( " aardvark " ) ) for: true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( fakeTestCase( "aardvark " ) ) for: true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( fakeTestCase( "aardvark" ) ) for: true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( fakeTestCase( "  aardvark " ) ) for: true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( fakeTestCase( "  aardvark" ) ) for: true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( fakeTestCase( " aardvark " ) ) for: true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( fakeTestCase( "aardvark " ) ) for: true
-CmdLine.tests.cpp:<line number>: passed: spec.matches( fakeTestCase( "aardvark" ) ) for: true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcA ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcB ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcC ) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *tcD ) == true for: true == true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *fakeTestCase( "  aardvark " ) ) for: true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *fakeTestCase( "  aardvark" ) ) for: true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *fakeTestCase( " aardvark " ) ) for: true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *fakeTestCase( "aardvark " ) ) for: true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *fakeTestCase( "aardvark" ) ) for: true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *fakeTestCase( "  aardvark " ) ) for: true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *fakeTestCase( "  aardvark" ) ) for: true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *fakeTestCase( " aardvark " ) ) for: true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *fakeTestCase( "aardvark " ) ) for: true
+CmdLine.tests.cpp:<line number>: passed: spec.matches( *fakeTestCase( "aardvark" ) ) for: true
 Condition.tests.cpp:<line number>: passed: p == 0 for: 0 == 0
 Condition.tests.cpp:<line number>: passed: p == pNULL for: 0 == 0
 Condition.tests.cpp:<line number>: passed: p != 0 for: 0x<hex digits> != 0
@@ -1051,16 +1051,16 @@ CmdLine.tests.cpp:<line number>: passed: config.reporterName == "console" for: "
 CmdLine.tests.cpp:<line number>: passed: !(cfg.hasTestFilters()) for: !false
 CmdLine.tests.cpp:<line number>: passed: result for: {?}
 CmdLine.tests.cpp:<line number>: passed: cfg.hasTestFilters() for: true
-CmdLine.tests.cpp:<line number>: passed: cfg.testSpec().matches(fakeTestCase("notIncluded")) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: cfg.testSpec().matches(fakeTestCase("test1")) for: true
+CmdLine.tests.cpp:<line number>: passed: cfg.testSpec().matches(*fakeTestCase("notIncluded")) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: cfg.testSpec().matches(*fakeTestCase("test1")) for: true
 CmdLine.tests.cpp:<line number>: passed: result for: {?}
 CmdLine.tests.cpp:<line number>: passed: cfg.hasTestFilters() for: true
-CmdLine.tests.cpp:<line number>: passed: cfg.testSpec().matches(fakeTestCase("test1")) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: cfg.testSpec().matches(fakeTestCase("alwaysIncluded")) for: true
+CmdLine.tests.cpp:<line number>: passed: cfg.testSpec().matches(*fakeTestCase("test1")) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: cfg.testSpec().matches(*fakeTestCase("alwaysIncluded")) for: true
 CmdLine.tests.cpp:<line number>: passed: result for: {?}
 CmdLine.tests.cpp:<line number>: passed: cfg.hasTestFilters() for: true
-CmdLine.tests.cpp:<line number>: passed: cfg.testSpec().matches(fakeTestCase("test1")) == false for: false == false
-CmdLine.tests.cpp:<line number>: passed: cfg.testSpec().matches(fakeTestCase("alwaysIncluded")) for: true
+CmdLine.tests.cpp:<line number>: passed: cfg.testSpec().matches(*fakeTestCase("test1")) == false for: false == false
+CmdLine.tests.cpp:<line number>: passed: cfg.testSpec().matches(*fakeTestCase("alwaysIncluded")) for: true
 CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "-r", "console"}) for: {?}
 CmdLine.tests.cpp:<line number>: passed: config.reporterName == "console" for: "console" == "console"
 CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "-r", "xml"}) for: {?}
@@ -1662,7 +1662,7 @@ StringManip.tests.cpp:<line number>: passed: Catch::replaceInPlace(s, "'", "|'")
 StringManip.tests.cpp:<line number>: passed: s == "didn|'t" for: "didn|'t" == "didn|'t"
 Misc.tests.cpp:<line number>: failed: false with 1 message: '3'
 Message.tests.cpp:<line number>: failed: false with 2 messages: 'hi' and 'i := 7'
-Tag.tests.cpp:<line number>: passed: testcase.tags, Catch::VectorContains(std::string("magic-tag")) && Catch::VectorContains(std::string(".")) for: { ".", "magic-tag" } ( Contains: "magic-tag" and Contains: "." )
+Tag.tests.cpp:<line number>: passed: testcase->tags, Catch::VectorContains(std::string("magic-tag")) && Catch::VectorContains(std::string(".")) for: { ".", "magic-tag" } ( Contains: "magic-tag" and Contains: "." )
 StringManip.tests.cpp:<line number>: passed: splitStringRef("", ','), Equals(std::vector<StringRef>()) for: {  } Equals: {  }
 StringManip.tests.cpp:<line number>: passed: splitStringRef("abc", ','), Equals(std::vector<StringRef>{"abc"}) for: { abc } Equals: { abc }
 StringManip.tests.cpp:<line number>: passed: splitStringRef("abc,def", ','), Equals(std::vector<StringRef>{"abc", "def"}) for: { abc, def } Equals: { abc, def }

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -1662,7 +1662,7 @@ StringManip.tests.cpp:<line number>: passed: Catch::replaceInPlace(s, "'", "|'")
 StringManip.tests.cpp:<line number>: passed: s == "didn|'t" for: "didn|'t" == "didn|'t"
 Misc.tests.cpp:<line number>: failed: false with 1 message: '3'
 Message.tests.cpp:<line number>: failed: false with 2 messages: 'hi' and 'i := 7'
-Tag.tests.cpp:<line number>: passed: testcase->tags, Catch::VectorContains(std::string("magic-tag")) && Catch::VectorContains(std::string(".")) for: { ".", "magic-tag" } ( Contains: "magic-tag" and Contains: "." )
+Tag.tests.cpp:<line number>: passed: tags, Catch::VectorContains("magic-tag"_catch_sr) && Catch::VectorContains("."_catch_sr) for: { ., magic-tag } ( Contains: magic-tag and Contains: . )
 StringManip.tests.cpp:<line number>: passed: splitStringRef("", ','), Equals(std::vector<StringRef>()) for: {  } Equals: {  }
 StringManip.tests.cpp:<line number>: passed: splitStringRef("abc", ','), Equals(std::vector<StringRef>{"abc"}) for: { abc } Equals: { abc }
 StringManip.tests.cpp:<line number>: passed: splitStringRef("abc,def", ','), Equals(std::vector<StringRef>{"abc", "def"}) for: { abc, def } Equals: { abc, def }

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -6418,12 +6418,12 @@ with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
@@ -6440,12 +6440,12 @@ with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches(tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
@@ -6462,12 +6462,12 @@ with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
@@ -6484,12 +6484,12 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == true )
+  CHECK( spec.matches( *tcB ) == true )
 with expansion:
   true == true
 
@@ -6506,12 +6506,12 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == true )
+  CHECK( spec.matches( *tcB ) == true )
 with expansion:
   true == true
 
@@ -6528,17 +6528,17 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == true )
+  CHECK( spec.matches( *tcB ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == false )
+  CHECK( spec.matches( *tcC ) == false )
 with expansion:
   false == false
 
@@ -6555,27 +6555,27 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == true )
+  CHECK( spec.matches( *tcC ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == false )
+  CHECK( spec.matches( *tcD ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( parseTestSpec( "*a" ).matches( tcA ) == true )
+  CHECK( parseTestSpec( "*a" ).matches( *tcA ) == true )
 with expansion:
   true == true
 
@@ -6592,27 +6592,27 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == true )
+  CHECK( spec.matches( *tcC ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == false )
+  CHECK( spec.matches( *tcD ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( parseTestSpec( "a*" ).matches( tcA ) == true )
+  CHECK( parseTestSpec( "a*" ).matches( *tcA ) == true )
 with expansion:
   true == true
 
@@ -6629,27 +6629,27 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == true )
+  CHECK( spec.matches( *tcC ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == true )
+  CHECK( spec.matches( *tcD ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( parseTestSpec( "*a*" ).matches( tcA ) == true )
+  CHECK( parseTestSpec( "*a*" ).matches( *tcA ) == true )
 with expansion:
   true == true
 
@@ -6666,12 +6666,12 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == true )
+  CHECK( spec.matches( *tcA ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
@@ -6688,12 +6688,12 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == true )
+  CHECK( spec.matches( *tcA ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
@@ -6710,12 +6710,12 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == true )
+  CHECK( spec.matches( *tcA ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
@@ -6732,22 +6732,22 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == true )
+  CHECK( spec.matches( *tcC ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == true )
+  CHECK( spec.matches( *tcD ) == true )
 with expansion:
   true == true
 
@@ -6764,22 +6764,22 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == true )
+  CHECK( spec.matches( *tcA ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == true )
+  CHECK( spec.matches( *tcB ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == true )
+  CHECK( spec.matches( *tcC ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == true )
+  CHECK( spec.matches( *tcD ) == true )
 with expansion:
   true == true
 
@@ -6796,17 +6796,17 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == true )
+  CHECK( spec.matches( *tcB ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == false )
+  CHECK( spec.matches( *tcC ) == false )
 with expansion:
   false == false
 
@@ -6823,17 +6823,17 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == true )
+  CHECK( spec.matches( *tcB ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == true )
+  CHECK( spec.matches( *tcC ) == true )
 with expansion:
   true == true
 
@@ -6850,17 +6850,17 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == true )
+  CHECK( spec.matches( *tcC ) == true )
 with expansion:
   true == true
 
@@ -6877,17 +6877,17 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == true )
+  CHECK( spec.matches( *tcC ) == true )
 with expansion:
   true == true
 
@@ -6904,22 +6904,22 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == true )
+  CHECK( spec.matches( *tcC ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == false )
+  CHECK( spec.matches( *tcD ) == false )
 with expansion:
   false == false
 
@@ -6936,17 +6936,17 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == true )
+  CHECK( spec.matches( *tcA ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == false )
+  CHECK( spec.matches( *tcC ) == false )
 with expansion:
   false == false
 
@@ -6963,17 +6963,17 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == true )
+  CHECK( spec.matches( *tcB ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == false )
+  CHECK( spec.matches( *tcC ) == false )
 with expansion:
   false == false
 
@@ -6990,22 +6990,22 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == false )
+  CHECK( spec.matches( *tcC ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == true )
+  CHECK( spec.matches( *tcD ) == true )
 with expansion:
   true == true
 
@@ -7022,22 +7022,22 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == false )
+  CHECK( spec.matches( *tcC ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == true )
+  CHECK( spec.matches( *tcD ) == true )
 with expansion:
   true == true
 
@@ -7054,22 +7054,22 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == true )
+  CHECK( spec.matches( *tcA ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == false )
+  CHECK( spec.matches( *tcC ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == true )
+  CHECK( spec.matches( *tcD ) == true )
 with expansion:
   true == true
 
@@ -7086,22 +7086,22 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == true )
+  CHECK( spec.matches( *tcA ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == true )
+  CHECK( spec.matches( *tcB ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == false )
+  CHECK( spec.matches( *tcC ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == false )
+  CHECK( spec.matches( *tcD ) == false )
 with expansion:
   false == false
 
@@ -7118,22 +7118,22 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == true )
+  CHECK( spec.matches( *tcA ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == true )
+  CHECK( spec.matches( *tcB ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == true )
+  CHECK( spec.matches( *tcC ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == false )
+  CHECK( spec.matches( *tcD ) == false )
 with expansion:
   false == false
 
@@ -7150,22 +7150,22 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == true )
+  CHECK( spec.matches( *tcA ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == true )
+  CHECK( spec.matches( *tcB ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == true )
+  CHECK( spec.matches( *tcC ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == false )
+  CHECK( spec.matches( *tcD ) == false )
 with expansion:
   false == false
 
@@ -7182,22 +7182,22 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == true )
+  CHECK( spec.matches( *tcC ) == true )
 with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == false )
+  CHECK( spec.matches( *tcD ) == false )
 with expansion:
   false == false
 
@@ -7214,22 +7214,22 @@ with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == false )
+  CHECK( spec.matches( *tcC ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == false )
+  CHECK( spec.matches( *tcD ) == false )
 with expansion:
   false == false
 
@@ -7246,22 +7246,22 @@ with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == false )
+  CHECK( spec.matches( *tcC ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == false )
+  CHECK( spec.matches( *tcD ) == false )
 with expansion:
   false == false
 
@@ -7278,22 +7278,22 @@ with expansion:
   true == true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcA ) == false )
+  CHECK( spec.matches( *tcA ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcB ) == false )
+  CHECK( spec.matches( *tcB ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcC ) == false )
+  CHECK( spec.matches( *tcC ) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( tcD ) == true )
+  CHECK( spec.matches( *tcD ) == true )
 with expansion:
   true == true
 
@@ -7305,27 +7305,27 @@ CmdLine.tests.cpp:<line number>
 ...............................................................................
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( fakeTestCase( "  aardvark " ) ) )
+  CHECK( spec.matches( *fakeTestCase( "  aardvark " ) ) )
 with expansion:
   true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( fakeTestCase( "  aardvark" ) ) )
+  CHECK( spec.matches( *fakeTestCase( "  aardvark" ) ) )
 with expansion:
   true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( fakeTestCase( " aardvark " ) ) )
+  CHECK( spec.matches( *fakeTestCase( " aardvark " ) ) )
 with expansion:
   true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( fakeTestCase( "aardvark " ) ) )
+  CHECK( spec.matches( *fakeTestCase( "aardvark " ) ) )
 with expansion:
   true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( fakeTestCase( "aardvark" ) ) )
+  CHECK( spec.matches( *fakeTestCase( "aardvark" ) ) )
 with expansion:
   true
 
@@ -7337,27 +7337,27 @@ CmdLine.tests.cpp:<line number>
 ...............................................................................
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( fakeTestCase( "  aardvark " ) ) )
+  CHECK( spec.matches( *fakeTestCase( "  aardvark " ) ) )
 with expansion:
   true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( fakeTestCase( "  aardvark" ) ) )
+  CHECK( spec.matches( *fakeTestCase( "  aardvark" ) ) )
 with expansion:
   true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( fakeTestCase( " aardvark " ) ) )
+  CHECK( spec.matches( *fakeTestCase( " aardvark " ) ) )
 with expansion:
   true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( fakeTestCase( "aardvark " ) ) )
+  CHECK( spec.matches( *fakeTestCase( "aardvark " ) ) )
 with expansion:
   true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( spec.matches( fakeTestCase( "aardvark" ) ) )
+  CHECK( spec.matches( *fakeTestCase( "aardvark" ) ) )
 with expansion:
   true
 
@@ -7530,12 +7530,12 @@ with expansion:
   true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  REQUIRE( cfg.testSpec().matches(fakeTestCase("notIncluded")) == false )
+  REQUIRE( cfg.testSpec().matches(*fakeTestCase("notIncluded")) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  REQUIRE( cfg.testSpec().matches(fakeTestCase("test1")) )
+  REQUIRE( cfg.testSpec().matches(*fakeTestCase("test1")) )
 with expansion:
   true
 
@@ -7558,12 +7558,12 @@ with expansion:
   true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  REQUIRE( cfg.testSpec().matches(fakeTestCase("test1")) == false )
+  REQUIRE( cfg.testSpec().matches(*fakeTestCase("test1")) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  REQUIRE( cfg.testSpec().matches(fakeTestCase("alwaysIncluded")) )
+  REQUIRE( cfg.testSpec().matches(*fakeTestCase("alwaysIncluded")) )
 with expansion:
   true
 
@@ -7586,12 +7586,12 @@ with expansion:
   true
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  REQUIRE( cfg.testSpec().matches(fakeTestCase("test1")) == false )
+  REQUIRE( cfg.testSpec().matches(*fakeTestCase("test1")) == false )
 with expansion:
   false == false
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  REQUIRE( cfg.testSpec().matches(fakeTestCase("alwaysIncluded")) )
+  REQUIRE( cfg.testSpec().matches(*fakeTestCase("alwaysIncluded")) )
 with expansion:
   true
 
@@ -12341,7 +12341,7 @@ Tag.tests.cpp:<line number>
 ...............................................................................
 
 Tag.tests.cpp:<line number>: PASSED:
-  REQUIRE_THAT( testcase.tags, Catch::VectorContains(std::string("magic-tag")) && Catch::VectorContains(std::string(".")) )
+  REQUIRE_THAT( testcase->tags, Catch::VectorContains(std::string("magic-tag")) && Catch::VectorContains(std::string(".")) )
 with expansion:
   { ".", "magic-tag" } ( Contains: "magic-tag" and Contains: "." )
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -12341,9 +12341,9 @@ Tag.tests.cpp:<line number>
 ...............................................................................
 
 Tag.tests.cpp:<line number>: PASSED:
-  REQUIRE_THAT( testcase->tags, Catch::VectorContains(std::string("magic-tag")) && Catch::VectorContains(std::string(".")) )
+  REQUIRE_THAT( tags, Catch::VectorContains("magic-tag"_catch_sr) && Catch::VectorContains("."_catch_sr) )
 with expansion:
-  { ".", "magic-tag" } ( Contains: "magic-tag" and Contains: "." )
+  { ., magic-tag } ( Contains: magic-tag and Contains: . )
 
 -------------------------------------------------------------------------------
 splitString

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -8031,7 +8031,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8039,7 +8039,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8058,7 +8058,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches(tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8066,7 +8066,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8085,7 +8085,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8093,7 +8093,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8112,7 +8112,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8120,7 +8120,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == true
+            spec.matches( *tcB ) == true
           </Original>
           <Expanded>
             true == true
@@ -8139,7 +8139,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8147,7 +8147,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == true
+            spec.matches( *tcB ) == true
           </Original>
           <Expanded>
             true == true
@@ -8166,7 +8166,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8174,7 +8174,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == true
+            spec.matches( *tcB ) == true
           </Original>
           <Expanded>
             true == true
@@ -8182,7 +8182,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == false
+            spec.matches( *tcC ) == false
           </Original>
           <Expanded>
             false == false
@@ -8201,7 +8201,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8209,7 +8209,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8217,7 +8217,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == true
+            spec.matches( *tcC ) == true
           </Original>
           <Expanded>
             true == true
@@ -8225,7 +8225,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == false
+            spec.matches( *tcD ) == false
           </Original>
           <Expanded>
             false == false
@@ -8233,7 +8233,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            parseTestSpec( "*a" ).matches( tcA ) == true
+            parseTestSpec( "*a" ).matches( *tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -8252,7 +8252,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8260,7 +8260,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8268,7 +8268,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == true
+            spec.matches( *tcC ) == true
           </Original>
           <Expanded>
             true == true
@@ -8276,7 +8276,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == false
+            spec.matches( *tcD ) == false
           </Original>
           <Expanded>
             false == false
@@ -8284,7 +8284,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            parseTestSpec( "a*" ).matches( tcA ) == true
+            parseTestSpec( "a*" ).matches( *tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -8303,7 +8303,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8311,7 +8311,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8319,7 +8319,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == true
+            spec.matches( *tcC ) == true
           </Original>
           <Expanded>
             true == true
@@ -8327,7 +8327,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == true
+            spec.matches( *tcD ) == true
           </Original>
           <Expanded>
             true == true
@@ -8335,7 +8335,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            parseTestSpec( "*a*" ).matches( tcA ) == true
+            parseTestSpec( "*a*" ).matches( *tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -8354,7 +8354,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == true
+            spec.matches( *tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -8362,7 +8362,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8381,7 +8381,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == true
+            spec.matches( *tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -8389,7 +8389,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8408,7 +8408,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == true
+            spec.matches( *tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -8416,7 +8416,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8435,7 +8435,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8443,7 +8443,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8451,7 +8451,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == true
+            spec.matches( *tcC ) == true
           </Original>
           <Expanded>
             true == true
@@ -8459,7 +8459,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == true
+            spec.matches( *tcD ) == true
           </Original>
           <Expanded>
             true == true
@@ -8478,7 +8478,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == true
+            spec.matches( *tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -8486,7 +8486,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == true
+            spec.matches( *tcB ) == true
           </Original>
           <Expanded>
             true == true
@@ -8494,7 +8494,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == true
+            spec.matches( *tcC ) == true
           </Original>
           <Expanded>
             true == true
@@ -8502,7 +8502,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == true
+            spec.matches( *tcD ) == true
           </Original>
           <Expanded>
             true == true
@@ -8521,7 +8521,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8529,7 +8529,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == true
+            spec.matches( *tcB ) == true
           </Original>
           <Expanded>
             true == true
@@ -8537,7 +8537,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == false
+            spec.matches( *tcC ) == false
           </Original>
           <Expanded>
             false == false
@@ -8556,7 +8556,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8564,7 +8564,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == true
+            spec.matches( *tcB ) == true
           </Original>
           <Expanded>
             true == true
@@ -8572,7 +8572,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == true
+            spec.matches( *tcC ) == true
           </Original>
           <Expanded>
             true == true
@@ -8591,7 +8591,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8599,7 +8599,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8607,7 +8607,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == true
+            spec.matches( *tcC ) == true
           </Original>
           <Expanded>
             true == true
@@ -8626,7 +8626,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8634,7 +8634,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8642,7 +8642,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == true
+            spec.matches( *tcC ) == true
           </Original>
           <Expanded>
             true == true
@@ -8661,7 +8661,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8669,7 +8669,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8677,7 +8677,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == true
+            spec.matches( *tcC ) == true
           </Original>
           <Expanded>
             true == true
@@ -8685,7 +8685,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == false
+            spec.matches( *tcD ) == false
           </Original>
           <Expanded>
             false == false
@@ -8704,7 +8704,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == true
+            spec.matches( *tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -8712,7 +8712,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8720,7 +8720,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == false
+            spec.matches( *tcC ) == false
           </Original>
           <Expanded>
             false == false
@@ -8739,7 +8739,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8747,7 +8747,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == true
+            spec.matches( *tcB ) == true
           </Original>
           <Expanded>
             true == true
@@ -8755,7 +8755,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == false
+            spec.matches( *tcC ) == false
           </Original>
           <Expanded>
             false == false
@@ -8774,7 +8774,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8782,7 +8782,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8790,7 +8790,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == false
+            spec.matches( *tcC ) == false
           </Original>
           <Expanded>
             false == false
@@ -8798,7 +8798,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == true
+            spec.matches( *tcD ) == true
           </Original>
           <Expanded>
             true == true
@@ -8817,7 +8817,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -8825,7 +8825,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8833,7 +8833,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == false
+            spec.matches( *tcC ) == false
           </Original>
           <Expanded>
             false == false
@@ -8841,7 +8841,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == true
+            spec.matches( *tcD ) == true
           </Original>
           <Expanded>
             true == true
@@ -8860,7 +8860,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == true
+            spec.matches( *tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -8868,7 +8868,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -8876,7 +8876,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == false
+            spec.matches( *tcC ) == false
           </Original>
           <Expanded>
             false == false
@@ -8884,7 +8884,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == true
+            spec.matches( *tcD ) == true
           </Original>
           <Expanded>
             true == true
@@ -8903,7 +8903,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == true
+            spec.matches( *tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -8911,7 +8911,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == true
+            spec.matches( *tcB ) == true
           </Original>
           <Expanded>
             true == true
@@ -8919,7 +8919,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == false
+            spec.matches( *tcC ) == false
           </Original>
           <Expanded>
             false == false
@@ -8927,7 +8927,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == false
+            spec.matches( *tcD ) == false
           </Original>
           <Expanded>
             false == false
@@ -8946,7 +8946,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == true
+            spec.matches( *tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -8954,7 +8954,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == true
+            spec.matches( *tcB ) == true
           </Original>
           <Expanded>
             true == true
@@ -8962,7 +8962,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == true
+            spec.matches( *tcC ) == true
           </Original>
           <Expanded>
             true == true
@@ -8970,7 +8970,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == false
+            spec.matches( *tcD ) == false
           </Original>
           <Expanded>
             false == false
@@ -8989,7 +8989,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == true
+            spec.matches( *tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -8997,7 +8997,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == true
+            spec.matches( *tcB ) == true
           </Original>
           <Expanded>
             true == true
@@ -9005,7 +9005,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == true
+            spec.matches( *tcC ) == true
           </Original>
           <Expanded>
             true == true
@@ -9013,7 +9013,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == false
+            spec.matches( *tcD ) == false
           </Original>
           <Expanded>
             false == false
@@ -9032,7 +9032,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -9040,7 +9040,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -9048,7 +9048,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == true
+            spec.matches( *tcC ) == true
           </Original>
           <Expanded>
             true == true
@@ -9056,7 +9056,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == false
+            spec.matches( *tcD ) == false
           </Original>
           <Expanded>
             false == false
@@ -9075,7 +9075,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -9083,7 +9083,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -9091,7 +9091,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == false
+            spec.matches( *tcC ) == false
           </Original>
           <Expanded>
             false == false
@@ -9099,7 +9099,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == false
+            spec.matches( *tcD ) == false
           </Original>
           <Expanded>
             false == false
@@ -9118,7 +9118,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -9126,7 +9126,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -9134,7 +9134,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == false
+            spec.matches( *tcC ) == false
           </Original>
           <Expanded>
             false == false
@@ -9142,7 +9142,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == false
+            spec.matches( *tcD ) == false
           </Original>
           <Expanded>
             false == false
@@ -9161,7 +9161,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcA ) == false
+            spec.matches( *tcA ) == false
           </Original>
           <Expanded>
             false == false
@@ -9169,7 +9169,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcB ) == false
+            spec.matches( *tcB ) == false
           </Original>
           <Expanded>
             false == false
@@ -9177,7 +9177,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcC ) == false
+            spec.matches( *tcC ) == false
           </Original>
           <Expanded>
             false == false
@@ -9185,7 +9185,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( tcD ) == true
+            spec.matches( *tcD ) == true
           </Original>
           <Expanded>
             true == true
@@ -9196,7 +9196,7 @@ Nor would this
       <Section name="Leading and trailing spaces in test spec" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( fakeTestCase( "  aardvark " ) )
+            spec.matches( *fakeTestCase( "  aardvark " ) )
           </Original>
           <Expanded>
             true
@@ -9204,7 +9204,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( fakeTestCase( "  aardvark" ) )
+            spec.matches( *fakeTestCase( "  aardvark" ) )
           </Original>
           <Expanded>
             true
@@ -9212,7 +9212,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( fakeTestCase( " aardvark " ) )
+            spec.matches( *fakeTestCase( " aardvark " ) )
           </Original>
           <Expanded>
             true
@@ -9220,7 +9220,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( fakeTestCase( "aardvark " ) )
+            spec.matches( *fakeTestCase( "aardvark " ) )
           </Original>
           <Expanded>
             true
@@ -9228,7 +9228,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( fakeTestCase( "aardvark" ) )
+            spec.matches( *fakeTestCase( "aardvark" ) )
           </Original>
           <Expanded>
             true
@@ -9239,7 +9239,7 @@ Nor would this
       <Section name="Leading and trailing spaces in test name" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( fakeTestCase( "  aardvark " ) )
+            spec.matches( *fakeTestCase( "  aardvark " ) )
           </Original>
           <Expanded>
             true
@@ -9247,7 +9247,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( fakeTestCase( "  aardvark" ) )
+            spec.matches( *fakeTestCase( "  aardvark" ) )
           </Original>
           <Expanded>
             true
@@ -9255,7 +9255,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( fakeTestCase( " aardvark " ) )
+            spec.matches( *fakeTestCase( " aardvark " ) )
           </Original>
           <Expanded>
             true
@@ -9263,7 +9263,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( fakeTestCase( "aardvark " ) )
+            spec.matches( *fakeTestCase( "aardvark " ) )
           </Original>
           <Expanded>
             true
@@ -9271,7 +9271,7 @@ Nor would this
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Original>
-            spec.matches( fakeTestCase( "aardvark" ) )
+            spec.matches( *fakeTestCase( "aardvark" ) )
           </Original>
           <Expanded>
             true
@@ -9499,7 +9499,7 @@ Nor would this
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
             <Original>
-              cfg.testSpec().matches(fakeTestCase("notIncluded")) == false
+              cfg.testSpec().matches(*fakeTestCase("notIncluded")) == false
             </Original>
             <Expanded>
               false == false
@@ -9507,7 +9507,7 @@ Nor would this
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
             <Original>
-              cfg.testSpec().matches(fakeTestCase("test1"))
+              cfg.testSpec().matches(*fakeTestCase("test1"))
             </Original>
             <Expanded>
               true
@@ -9537,7 +9537,7 @@ Nor would this
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
             <Original>
-              cfg.testSpec().matches(fakeTestCase("test1")) == false
+              cfg.testSpec().matches(*fakeTestCase("test1")) == false
             </Original>
             <Expanded>
               false == false
@@ -9545,7 +9545,7 @@ Nor would this
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
             <Original>
-              cfg.testSpec().matches(fakeTestCase("alwaysIncluded"))
+              cfg.testSpec().matches(*fakeTestCase("alwaysIncluded"))
             </Original>
             <Expanded>
               true
@@ -9575,7 +9575,7 @@ Nor would this
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
             <Original>
-              cfg.testSpec().matches(fakeTestCase("test1")) == false
+              cfg.testSpec().matches(*fakeTestCase("test1")) == false
             </Original>
             <Expanded>
               false == false
@@ -9583,7 +9583,7 @@ Nor would this
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
             <Original>
-              cfg.testSpec().matches(fakeTestCase("alwaysIncluded"))
+              cfg.testSpec().matches(*fakeTestCase("alwaysIncluded"))
             </Original>
             <Expanded>
               true
@@ -14861,7 +14861,7 @@ loose text artifact
     <TestCase name="shortened hide tags are split apart" filename="projects/<exe-name>/IntrospectiveTests/Tag.tests.cpp" >
       <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/IntrospectiveTests/Tag.tests.cpp" >
         <Original>
-          testcase.tags, Catch::VectorContains(std::string("magic-tag")) &amp;&amp; Catch::VectorContains(std::string("."))
+          testcase->tags, Catch::VectorContains(std::string("magic-tag")) &amp;&amp; Catch::VectorContains(std::string("."))
         </Original>
         <Expanded>
           { ".", "magic-tag" } ( Contains: "magic-tag" and Contains: "." )

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -1730,7 +1730,7 @@ Nor would this
       </Failure>
       <OverallResult success="false"/>
     </TestCase>
-    <TestCase name="A failing expression with a non streamable type is still captured" tags="[.][Tricky][failing]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
+    <TestCase name="A failing expression with a non streamable type is still captured" tags="[.][failing][Tricky]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
       <Expression success="false" type="CHECK" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
         <Original>
           &amp;o1 == &amp;o2
@@ -2510,7 +2510,7 @@ Nor would this
       </Expression>
       <OverallResult success="true"/>
     </TestCase>
-    <TestCase name="Comparing function pointers" tags="[Tricky][function pointer]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
+    <TestCase name="Comparing function pointers" tags="[function pointer][Tricky]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
       <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
         <Original>
           a
@@ -10985,7 +10985,7 @@ Message from section two
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <TestCase name="StringRef at compilation time" tags="[StringRef][Strings][constexpr]" filename="projects/<exe-name>/IntrospectiveTests/String.tests.cpp" >
+    <TestCase name="StringRef at compilation time" tags="[constexpr][StringRef][Strings]" filename="projects/<exe-name>/IntrospectiveTests/String.tests.cpp" >
       <Section name="Simple constructors" filename="projects/<exe-name>/IntrospectiveTests/String.tests.cpp" >
         <OverallResults successes="5" failures="0" expectedFailures="0"/>
       </Section>
@@ -13709,13 +13709,13 @@ There is no extra whitespace here
     <TestCase name="When unchecked exceptions are thrown, but caught, they do not affect the test" tags="[!throws]" filename="projects/<exe-name>/UsageTests/Exception.tests.cpp" >
       <OverallResult success="false"/>
     </TestCase>
-    <TestCase name="Where the LHS is not a simple value" tags="[.][Tricky][failing]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
+    <TestCase name="Where the LHS is not a simple value" tags="[.][failing][Tricky]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
       <Warning>
         Uncomment the code in this test to check that it gives a sensible compiler error
       </Warning>
       <OverallResult success="false"/>
     </TestCase>
-    <TestCase name="Where there is more to the expression after the RHS" tags="[.][Tricky][failing]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
+    <TestCase name="Where there is more to the expression after the RHS" tags="[.][failing][Tricky]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
       <Warning>
         Uncomment the code in this test to check that it gives a sensible compiler error
       </Warning>
@@ -13724,7 +13724,7 @@ There is no extra whitespace here
     <TestCase name="X/level/0/a" tags="[Tricky]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
       <OverallResult success="true"/>
     </TestCase>
-    <TestCase name="X/level/0/b" tags="[Tricky][fizz]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
+    <TestCase name="X/level/0/b" tags="[fizz][Tricky]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
       <OverallResult success="true"/>
     </TestCase>
     <TestCase name="X/level/1/a" tags="[Tricky]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
@@ -14504,7 +14504,7 @@ loose text artifact
       </Expression>
       <OverallResult success="true"/>
     </TestCase>
-    <TestCase name="parseEnums" tags="[Strings][enums]" filename="projects/<exe-name>/IntrospectiveTests/ToString.tests.cpp" >
+    <TestCase name="parseEnums" tags="[enums][Strings]" filename="projects/<exe-name>/IntrospectiveTests/ToString.tests.cpp" >
       <Section name="No enums" filename="projects/<exe-name>/IntrospectiveTests/ToString.tests.cpp" >
         <Expression success="true" type="CHECK_THAT" filename="projects/<exe-name>/IntrospectiveTests/ToString.tests.cpp" >
           <Original>
@@ -14861,10 +14861,10 @@ loose text artifact
     <TestCase name="shortened hide tags are split apart" filename="projects/<exe-name>/IntrospectiveTests/Tag.tests.cpp" >
       <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/IntrospectiveTests/Tag.tests.cpp" >
         <Original>
-          testcase->tags, Catch::VectorContains(std::string("magic-tag")) &amp;&amp; Catch::VectorContains(std::string("."))
+          tags, Catch::VectorContains("magic-tag"_catch_sr) &amp;&amp; Catch::VectorContains("."_catch_sr)
         </Original>
         <Expanded>
-          { ".", "magic-tag" } ( Contains: "magic-tag" and Contains: "." )
+          { ., magic-tag } ( Contains: magic-tag and Contains: . )
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -15050,7 +15050,7 @@ loose text artifact
       </Expression>
       <OverallResult success="true"/>
     </TestCase>
-    <TestCase name="string literals of different sizes can be compared" tags="[.][Tricky][failing]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
+    <TestCase name="string literals of different sizes can be compared" tags="[.][failing][Tricky]" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
       <Expression success="false" type="REQUIRE" filename="projects/<exe-name>/UsageTests/Tricky.tests.cpp" >
         <Original>
           std::string( "first" ) == "second"

--- a/projects/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
@@ -8,6 +8,7 @@
 
 #include "catch.hpp"
 #include "internal/catch_test_spec_parser.h"
+#include "internal/catch_test_case_info.h"
 #include "internal/catch_config.hpp"
 #include "internal/catch_commandline.h"
 
@@ -15,269 +16,271 @@
 #   pragma clang diagnostic ignored "-Wc++98-compat"
 #endif
 
-inline Catch::TestCase fakeTestCase(const char* name, const char* desc = "") { return Catch::makeTestCase(nullptr, "", { name, desc }, CATCH_INTERNAL_LINEINFO); }
+namespace {
+    auto fakeTestCase(const char* name, const char* desc = "") { return Catch::makeTestCaseInfo("", { name, desc }, CATCH_INTERNAL_LINEINFO); }
+}
 
 TEST_CASE( "Parse test names and tags" ) {
 
     using Catch::parseTestSpec;
     using Catch::TestSpec;
 
-    Catch::TestCase tcA = fakeTestCase( "a" );
-    Catch::TestCase tcB = fakeTestCase( "b", "[one][x]" );
-    Catch::TestCase tcC = fakeTestCase( "longer name with spaces", "[two][three][.][x]" );
-    Catch::TestCase tcD = fakeTestCase( "zlonger name with spacesz" );
+    auto tcA = fakeTestCase( "a" );
+    auto tcB = fakeTestCase( "b", "[one][x]" );
+    auto tcC = fakeTestCase( "longer name with spaces", "[two][three][.][x]" );
+    auto tcD = fakeTestCase( "zlonger name with spacesz" );
 
     SECTION( "Empty test spec should have no filters" ) {
         TestSpec spec;
         CHECK( spec.hasFilters() == false );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
     }
 
     SECTION( "Test spec from empty string should have no filters" ) {
         TestSpec spec = parseTestSpec( "" );
         CHECK( spec.hasFilters() == false );
-        CHECK( spec.matches(tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
     }
 
     SECTION( "Test spec from just a comma should have no filters" ) {
         TestSpec spec = parseTestSpec( "," );
         CHECK( spec.hasFilters() == false );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
     }
 
     SECTION( "Test spec from name should have one filter" ) {
         TestSpec spec = parseTestSpec( "b" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == true );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == true );
     }
 
     SECTION( "Test spec from quoted name should have one filter" ) {
         TestSpec spec = parseTestSpec( "\"b\"" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == true );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == true );
     }
 
     SECTION( "Test spec from name should have one filter" ) {
         TestSpec spec = parseTestSpec( "b" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == true );
-        CHECK( spec.matches( tcC ) == false );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == true );
+        CHECK( spec.matches( *tcC ) == false );
     }
 
     SECTION( "Wildcard at the start" ) {
         TestSpec spec = parseTestSpec( "*spaces" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == true );
-        CHECK( spec.matches( tcD ) == false );
-        CHECK( parseTestSpec( "*a" ).matches( tcA ) == true );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == true );
+        CHECK( spec.matches( *tcD ) == false );
+        CHECK( parseTestSpec( "*a" ).matches( *tcA ) == true );
     }
     SECTION( "Wildcard at the end" ) {
         TestSpec spec = parseTestSpec( "long*" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == true );
-        CHECK( spec.matches( tcD ) == false );
-        CHECK( parseTestSpec( "a*" ).matches( tcA ) == true );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == true );
+        CHECK( spec.matches( *tcD ) == false );
+        CHECK( parseTestSpec( "a*" ).matches( *tcA ) == true );
     }
     SECTION( "Wildcard at both ends" ) {
         TestSpec spec = parseTestSpec( "*name*" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == true );
-        CHECK( spec.matches( tcD ) == true );
-        CHECK( parseTestSpec( "*a*" ).matches( tcA ) == true );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == true );
+        CHECK( spec.matches( *tcD ) == true );
+        CHECK( parseTestSpec( "*a*" ).matches( *tcA ) == true );
     }
     SECTION( "Redundant wildcard at the start" ) {
         TestSpec spec = parseTestSpec( "*a" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == true );
-        CHECK( spec.matches( tcB ) == false );
+        CHECK( spec.matches( *tcA ) == true );
+        CHECK( spec.matches( *tcB ) == false );
     }
     SECTION( "Redundant wildcard at the end" ) {
         TestSpec spec = parseTestSpec( "a*" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == true );
-        CHECK( spec.matches( tcB ) == false );
+        CHECK( spec.matches( *tcA ) == true );
+        CHECK( spec.matches( *tcB ) == false );
     }
     SECTION( "Redundant wildcard at both ends" ) {
         TestSpec spec = parseTestSpec( "*a*" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == true );
-        CHECK( spec.matches( tcB ) == false );
+        CHECK( spec.matches( *tcA ) == true );
+        CHECK( spec.matches( *tcB ) == false );
     }
     SECTION( "Wildcard at both ends, redundant at start" ) {
         TestSpec spec = parseTestSpec( "*longer*" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == true );
-        CHECK( spec.matches( tcD ) == true );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == true );
+        CHECK( spec.matches( *tcD ) == true );
     }
     SECTION( "Just wildcard" ) {
         TestSpec spec = parseTestSpec( "*" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == true );
-        CHECK( spec.matches( tcB ) == true );
-        CHECK( spec.matches( tcC ) == true );
-        CHECK( spec.matches( tcD ) == true );
+        CHECK( spec.matches( *tcA ) == true );
+        CHECK( spec.matches( *tcB ) == true );
+        CHECK( spec.matches( *tcC ) == true );
+        CHECK( spec.matches( *tcD ) == true );
     }
 
     SECTION( "Single tag" ) {
         TestSpec spec = parseTestSpec( "[one]" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == true );
-        CHECK( spec.matches( tcC ) == false );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == true );
+        CHECK( spec.matches( *tcC ) == false );
     }
     SECTION( "Single tag, two matches" ) {
         TestSpec spec = parseTestSpec( "[x]" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == true );
-        CHECK( spec.matches( tcC ) == true );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == true );
+        CHECK( spec.matches( *tcC ) == true );
     }
     SECTION( "Two tags" ) {
         TestSpec spec = parseTestSpec( "[two][x]" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == true );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == true );
     }
     SECTION( "Two tags, spare separated" ) {
         TestSpec spec = parseTestSpec( "[two] [x]" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == true );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == true );
     }
     SECTION( "Wildcarded name and tag" ) {
         TestSpec spec = parseTestSpec( "*name*[x]" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == true );
-        CHECK( spec.matches( tcD ) == false );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == true );
+        CHECK( spec.matches( *tcD ) == false );
     }
     SECTION( "Single tag exclusion" ) {
         TestSpec spec = parseTestSpec( "~[one]" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == true );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == false );
+        CHECK( spec.matches( *tcA ) == true );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == false );
     }
     SECTION( "One tag exclusion and one tag inclusion" ) {
         TestSpec spec = parseTestSpec( "~[two][x]" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == true );
-        CHECK( spec.matches( tcC ) == false );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == true );
+        CHECK( spec.matches( *tcC ) == false );
     }
     SECTION( "One tag exclusion and one wldcarded name inclusion" ) {
         TestSpec spec = parseTestSpec( "~[two]*name*" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == false );
-        CHECK( spec.matches( tcD ) == true );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == false );
+        CHECK( spec.matches( *tcD ) == true );
     }
     SECTION( "One tag exclusion, using exclude:, and one wldcarded name inclusion" ) {
         TestSpec spec = parseTestSpec( "exclude:[two]*name*" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == false );
-        CHECK( spec.matches( tcD ) == true );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == false );
+        CHECK( spec.matches( *tcD ) == true );
     }
     SECTION( "name exclusion" ) {
         TestSpec spec = parseTestSpec( "~b" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == true );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == false );
-        CHECK( spec.matches( tcD ) == true );
+        CHECK( spec.matches( *tcA ) == true );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == false );
+        CHECK( spec.matches( *tcD ) == true );
     }
     SECTION( "wildcarded name exclusion" ) {
         TestSpec spec = parseTestSpec( "~*name*" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == true );
-        CHECK( spec.matches( tcB ) == true );
-        CHECK( spec.matches( tcC ) == false );
-        CHECK( spec.matches( tcD ) == false );
+        CHECK( spec.matches( *tcA ) == true );
+        CHECK( spec.matches( *tcB ) == true );
+        CHECK( spec.matches( *tcC ) == false );
+        CHECK( spec.matches( *tcD ) == false );
     }
     SECTION( "wildcarded name exclusion with tag inclusion" ) {
         TestSpec spec = parseTestSpec( "~*name*,[three]" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == true );
-        CHECK( spec.matches( tcB ) == true );
-        CHECK( spec.matches( tcC ) == true );
-        CHECK( spec.matches( tcD ) == false );
+        CHECK( spec.matches( *tcA ) == true );
+        CHECK( spec.matches( *tcB ) == true );
+        CHECK( spec.matches( *tcC ) == true );
+        CHECK( spec.matches( *tcD ) == false );
     }
     SECTION( "wildcarded name exclusion, using exclude:, with tag inclusion" ) {
         TestSpec spec = parseTestSpec( "exclude:*name*,[three]" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == true );
-        CHECK( spec.matches( tcB ) == true );
-        CHECK( spec.matches( tcC ) == true );
-        CHECK( spec.matches( tcD ) == false );
+        CHECK( spec.matches( *tcA ) == true );
+        CHECK( spec.matches( *tcB ) == true );
+        CHECK( spec.matches( *tcC ) == true );
+        CHECK( spec.matches( *tcD ) == false );
     }
     SECTION( "two wildcarded names" ) {
         TestSpec spec = parseTestSpec( "\"longer*\"\"*spaces\"" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == true );
-        CHECK( spec.matches( tcD ) == false );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == true );
+        CHECK( spec.matches( *tcD ) == false );
     }
     SECTION( "empty tag" ) {
         TestSpec spec = parseTestSpec( "[]" );
         CHECK( spec.hasFilters() == false );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == false );
-        CHECK( spec.matches( tcD ) == false );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == false );
+        CHECK( spec.matches( *tcD ) == false );
     }
     SECTION( "empty quoted name" ) {
         TestSpec spec = parseTestSpec( "\"\"" );
         CHECK( spec.hasFilters() == false );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == false );
-        CHECK( spec.matches( tcD ) == false );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == false );
+        CHECK( spec.matches( *tcD ) == false );
     }
     SECTION( "quoted string followed by tag exclusion" ) {
         TestSpec spec = parseTestSpec( "\"*name*\"~[.]" );
         CHECK( spec.hasFilters() == true );
-        CHECK( spec.matches( tcA ) == false );
-        CHECK( spec.matches( tcB ) == false );
-        CHECK( spec.matches( tcC ) == false );
-        CHECK( spec.matches( tcD ) == true );
+        CHECK( spec.matches( *tcA ) == false );
+        CHECK( spec.matches( *tcB ) == false );
+        CHECK( spec.matches( *tcC ) == false );
+        CHECK( spec.matches( *tcD ) == true );
     }
     SECTION( "Leading and trailing spaces in test spec" ) {
         TestSpec spec = parseTestSpec( "\"  aardvark \"" );
-        CHECK( spec.matches( fakeTestCase( "  aardvark " ) ) );
-        CHECK( spec.matches( fakeTestCase( "  aardvark" ) ) );
-        CHECK( spec.matches( fakeTestCase( " aardvark " ) ) );
-        CHECK( spec.matches( fakeTestCase( "aardvark " ) ) );
-        CHECK( spec.matches( fakeTestCase( "aardvark" ) ) );
+        CHECK( spec.matches( *fakeTestCase( "  aardvark " ) ) );
+        CHECK( spec.matches( *fakeTestCase( "  aardvark" ) ) );
+        CHECK( spec.matches( *fakeTestCase( " aardvark " ) ) );
+        CHECK( spec.matches( *fakeTestCase( "aardvark " ) ) );
+        CHECK( spec.matches( *fakeTestCase( "aardvark" ) ) );
 
     }
     SECTION( "Leading and trailing spaces in test name" ) {
         TestSpec spec = parseTestSpec( "aardvark" );
-        CHECK( spec.matches( fakeTestCase( "  aardvark " ) ) );
-        CHECK( spec.matches( fakeTestCase( "  aardvark" ) ) );
-        CHECK( spec.matches( fakeTestCase( " aardvark " ) ) );
-        CHECK( spec.matches( fakeTestCase( "aardvark " ) ) );
-        CHECK( spec.matches( fakeTestCase( "aardvark" ) ) );
+        CHECK( spec.matches( *fakeTestCase( "  aardvark " ) ) );
+        CHECK( spec.matches( *fakeTestCase( "  aardvark" ) ) );
+        CHECK( spec.matches( *fakeTestCase( " aardvark " ) ) );
+        CHECK( spec.matches( *fakeTestCase( "aardvark " ) ) );
+        CHECK( spec.matches( *fakeTestCase( "aardvark" ) ) );
 
     }
 }
@@ -317,8 +320,8 @@ TEST_CASE( "Process can be configured on command line", "[config][command-line]"
 
             Catch::Config cfg(config);
             REQUIRE(cfg.hasTestFilters());
-            REQUIRE(cfg.testSpec().matches(fakeTestCase("notIncluded")) == false);
-            REQUIRE(cfg.testSpec().matches(fakeTestCase("test1")));
+            REQUIRE(cfg.testSpec().matches(*fakeTestCase("notIncluded")) == false);
+            REQUIRE(cfg.testSpec().matches(*fakeTestCase("test1")));
         }
         SECTION("Specify one test case exclusion using exclude:") {
             auto result = cli.parse({"test", "exclude:test1"});
@@ -326,8 +329,8 @@ TEST_CASE( "Process can be configured on command line", "[config][command-line]"
 
             Catch::Config cfg(config);
             REQUIRE(cfg.hasTestFilters());
-            REQUIRE(cfg.testSpec().matches(fakeTestCase("test1")) == false);
-            REQUIRE(cfg.testSpec().matches(fakeTestCase("alwaysIncluded")));
+            REQUIRE(cfg.testSpec().matches(*fakeTestCase("test1")) == false);
+            REQUIRE(cfg.testSpec().matches(*fakeTestCase("alwaysIncluded")));
         }
 
         SECTION("Specify one test case exclusion using ~") {
@@ -336,8 +339,8 @@ TEST_CASE( "Process can be configured on command line", "[config][command-line]"
 
             Catch::Config cfg(config);
             REQUIRE(cfg.hasTestFilters());
-            REQUIRE(cfg.testSpec().matches(fakeTestCase("test1")) == false);
-            REQUIRE(cfg.testSpec().matches(fakeTestCase("alwaysIncluded")));
+            REQUIRE(cfg.testSpec().matches(*fakeTestCase("test1")) == false);
+            REQUIRE(cfg.testSpec().matches(*fakeTestCase("alwaysIncluded")));
         }
 
     }

--- a/projects/SelfTest/IntrospectiveTests/Tag.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/Tag.tests.cpp
@@ -42,6 +42,6 @@ TEST_CASE( "Tag alias can be registered against tag patterns" ) {
 }
 
 TEST_CASE("shortened hide tags are split apart") {
-    auto testcase = Catch::makeTestCase(nullptr, "", {"fake test name", "[.magic-tag]"}, CATCH_INTERNAL_LINEINFO);
-    REQUIRE_THAT(testcase.tags, Catch::VectorContains(std::string("magic-tag")) && Catch::VectorContains(std::string(".")));
+    auto testcase = Catch::makeTestCaseInfo("", {"fake test name", "[.magic-tag]"}, CATCH_INTERNAL_LINEINFO);
+    REQUIRE_THAT(testcase->tags, Catch::VectorContains(std::string("magic-tag")) && Catch::VectorContains(std::string(".")));
 }

--- a/projects/SelfTest/IntrospectiveTests/Tag.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/Tag.tests.cpp
@@ -42,6 +42,12 @@ TEST_CASE( "Tag alias can be registered against tag patterns" ) {
 }
 
 TEST_CASE("shortened hide tags are split apart") {
+    using Catch::StringRef;
     auto testcase = Catch::makeTestCaseInfo("", {"fake test name", "[.magic-tag]"}, CATCH_INTERNAL_LINEINFO);
-    REQUIRE_THAT(testcase->tags, Catch::VectorContains(std::string("magic-tag")) && Catch::VectorContains(std::string(".")));
+    // Transform ...
+    std::vector<StringRef> tags;
+    for (auto const& tag : testcase->tags) {
+        tags.push_back(tag.original);
+    }
+    REQUIRE_THAT(tags, Catch::VectorContains("magic-tag"_catch_sr) && Catch::VectorContains("."_catch_sr));
 }


### PR DESCRIPTION
## Description

This PR refactors handling of `TEST_CASE`s so that the test case name and tags are not copied around all the time. The tag handling is also refactored to decrease the total number of allocations when registering test cases.

