### PR TITLE
Fix issue #1809.

### DIFF
--- a/include/internal/catch_generators.hpp
+++ b/include/internal/catch_generators.hpp
@@ -57,7 +57,6 @@ namespace Generators {
     class SingleValueGenerator final : public IGenerator<T> {
         T m_value;
     public:
-        SingleValueGenerator(T const& value) : m_value( value ) {}
         SingleValueGenerator(T&& value) : m_value(std::move(value)) {}
 
         T const& get() const override {
@@ -120,21 +119,21 @@ namespace Generators {
             m_generators.emplace_back(std::move(generator));
         }
         void populate(T&& val) {
-            m_generators.emplace_back(value(std::move(val)));
+            m_generators.emplace_back(value(std::forward<T>(val)));
         }
         template<typename U>
         void populate(U&& val) {
-            populate(T(std::move(val)));
+            populate(T(std::forward<U>(val)));
         }
         template<typename U, typename... Gs>
-        void populate(U&& valueOrGenerator, Gs... moreGenerators) {
+        void populate(U&& valueOrGenerator, Gs &&... moreGenerators) {
             populate(std::forward<U>(valueOrGenerator));
             populate(std::forward<Gs>(moreGenerators)...);
         }
 
     public:
         template <typename... Gs>
-        Generators(Gs... moreGenerators) {
+        Generators(Gs &&... moreGenerators) {
             m_generators.reserve(sizeof...(Gs));
             populate(std::forward<Gs>(moreGenerators)...);
         }
@@ -166,7 +165,7 @@ namespace Generators {
     struct as {};
 
     template<typename T, typename... Gs>
-    auto makeGenerators( GeneratorWrapper<T>&& generator, Gs... moreGenerators ) -> Generators<T> {
+    auto makeGenerators( GeneratorWrapper<T>&& generator, Gs &&... moreGenerators ) -> Generators<T> {
         return Generators<T>(std::move(generator), std::forward<Gs>(moreGenerators)...);
     }
     template<typename T>
@@ -174,11 +173,11 @@ namespace Generators {
         return Generators<T>(std::move(generator));
     }
     template<typename T, typename... Gs>
-    auto makeGenerators( T&& val, Gs... moreGenerators ) -> Generators<T> {
+    auto makeGenerators( T&& val, Gs &&... moreGenerators ) -> Generators<T> {
         return makeGenerators( value( std::forward<T>( val ) ), std::forward<Gs>( moreGenerators )... );
     }
     template<typename T, typename U, typename... Gs>
-    auto makeGenerators( as<T>, U&& val, Gs... moreGenerators ) -> Generators<T> {
+    auto makeGenerators( as<T>, U&& val, Gs &&... moreGenerators ) -> Generators<T> {
         return makeGenerators( value( T( std::forward<U>( val ) ) ), std::forward<Gs>( moreGenerators )... );
     }
 

--- a/projects/SelfTest/IntrospectiveTests/GeneratorsImpl.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/GeneratorsImpl.tests.cpp
@@ -181,7 +181,7 @@ TEST_CASE("Generators internals", "[generators][internals]") {
                     const auto step = .1;
 
                     auto gen = range(rangeStart, rangeEnd, step);
-                    auto expected = rangeStart; 
+                    auto expected = rangeStart;
                     while( (rangeEnd - expected) > step ) {
                         INFO( "Current expected value is " << expected )
                         REQUIRE(gen.get() == Approx(expected));
@@ -198,7 +198,7 @@ TEST_CASE("Generators internals", "[generators][internals]") {
                     const auto step = .3;
 
                     auto gen = range(rangeStart, rangeEnd, step);
-                    auto expected = rangeStart; 
+                    auto expected = rangeStart;
                     while( (rangeEnd - expected) > step ) {
                        INFO( "Current expected value is " << expected )
                        REQUIRE(gen.get() == Approx(expected));
@@ -214,7 +214,7 @@ TEST_CASE("Generators internals", "[generators][internals]") {
                     const auto step = .3;
 
                     auto gen = range(rangeStart, rangeEnd, step);
-                    auto expected = rangeStart; 
+                    auto expected = rangeStart;
                     while( (rangeEnd - expected) > step ) {
                        INFO( "Current expected value is " << expected )
                        REQUIRE(gen.get() == Approx(expected));
@@ -223,7 +223,7 @@ TEST_CASE("Generators internals", "[generators][internals]") {
                        expected += step;
                     }
                     REQUIRE_FALSE(gen.next());
-                }                
+                }
             }
         }
         SECTION("Negative manual step") {
@@ -309,6 +309,21 @@ TEST_CASE("GENERATE capture macros", "[generators][internals][approvals]") {
     // neither `GENERATE_COPY` nor plain `GENERATE` would compile here
     auto value2 = GENERATE_REF(Catch::Generators::GeneratorWrapper<int>(std::unique_ptr<Catch::Generators::IGenerator<int>>(new TestGen(nc))));
     REQUIRE(value == value2);
+}
+
+TEST_CASE("#1809 - GENERATE_COPY and SingleValueGenerator does not compile", "[generators][compilation][approvals]") {
+    // Verify Issue #1809 fix, only needs to compile.
+    auto a = GENERATE_COPY(1, 2);
+    (void)a;
+    auto b = GENERATE_COPY(as<long>{}, 1, 2);
+    (void)b;
+    int i = 1;
+    int j = 2;
+    auto c = GENERATE_COPY(i, j);
+    (void)c;
+    auto d = GENERATE_COPY(as<long>{}, i, j);
+    (void)d;
+    SUCCEED();
 }
 
 TEST_CASE("Multiple random generators in one test case output different values", "[generators][internals][approvals]") {


### PR DESCRIPTION
Fix SingleValueGenerator CTor clash. Correct some misuses of move when forward was needed. Correct some missing universal references in method parameter lists. Add IntrospectiveTest to verify fix for issue #1809.

## Description
SingleValueGenerator had 2 clashing CTors thanks to the semantic differences in universal references and rvalue references when used in templates as parameters. 

## GitHub Issues
Closes #1809 
