### PR TITLE
iOS break into debugger

### DIFF
--- a/include/internal/catch_console_colour.cpp
+++ b/include/internal/catch_console_colour.cpp
@@ -167,7 +167,7 @@ namespace {
 
     bool useColourOnPlatform() {
         return
-#ifdef CATCH_PLATFORM_MAC
+#if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
             !isDebuggerActive() &&
 #endif
 #if !(defined(__DJGPP__) && defined(__STRICT_ANSI__))

--- a/include/internal/catch_debugger.cpp
+++ b/include/internal/catch_debugger.cpp
@@ -12,7 +12,7 @@
 #include "catch_stream.h"
 #include "catch_platform.h"
 
-#ifdef CATCH_PLATFORM_MAC
+#if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
 
 #  include <assert.h>
 #  include <stdbool.h>

--- a/include/internal/catch_debugger.cpp
+++ b/include/internal/catch_debugger.cpp
@@ -12,7 +12,7 @@
 #include "catch_stream.h"
 #include "catch_platform.h"
 
-#if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
+#if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
 
 #  include <assert.h>
 #  include <stdbool.h>

--- a/include/internal/catch_debugger.h
+++ b/include/internal/catch_debugger.h
@@ -19,6 +19,17 @@ namespace Catch {
 
     #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
 
+#elif defined(CATCH_PLATFORM_IPHONE)
+
+    // use inline assembler
+    #if defined(__i386__) || defined(__x86_64__)
+        #define CATCH_TRAP()  __asm__("int $3")
+    #elif defined(__aarch64__)
+        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+    #elif defined(__arm__)
+        #define CATCH_TRAP()  __asm__(".inst 0xe7f001f0")
+    #endif
+
 #elif defined(CATCH_PLATFORM_LINUX)
     // If we can use inline assembler, do it because this allows us to break
     // directly at the location of the failing check instead of breaking inside


### PR DESCRIPTION

## Description
<!--
Catch2's "--break" command line option does not work on iOS, because Catch2 lacks, one, the code to detect the debugger, and two, to trigger a trap on iOS. With this PR that shortcoming is mitigated.
-->



