### PR TITLE
Added <random> include for std::uniform_int_distribution

### DIFF
--- a/include/internal/benchmark/detail/catch_stats.hpp
+++ b/include/internal/benchmark/detail/catch_stats.hpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <utility>
 #include <cstddef>
+#include <random>
 
 namespace Catch {
     namespace Benchmark {


### PR DESCRIPTION
**Fixes**: C2760	syntax error: unexpected token '>', expected 'expression' internal\benchmark\detail\catch_stats.hpp 69:
`std::uniform_int_distribution<decltype(n)> dist(0, n - 1);`
for a static library with `CATCH_CONFIG_ENABLE_BENCHMARKING` in Visual Studio 2019 16.4.2 (latest non-preview).
