### PR TITLE
Removed unneeded 'using uchar = unsigned char'

### DIFF
--- a/include/internal/catch_xmlwriter.cpp
+++ b/include/internal/catch_xmlwriter.cpp
@@ -12,8 +12,6 @@
 #include <iomanip>
 #include <type_traits>
 
-using uchar = unsigned char;
-
 namespace Catch {
 
 namespace {
@@ -87,7 +85,7 @@ namespace {
         // (see: http://www.w3.org/TR/xml/#syntax)
 
         for( std::size_t idx = 0; idx < m_str.size(); ++ idx ) {
-            uchar c = m_str[idx];
+            unsigned char c = m_str[idx];
             switch (c) {
             case '<':   os << "&lt;"; break;
             case '&':   os << "&amp;"; break;
@@ -147,7 +145,7 @@ namespace {
                 bool valid = true;
                 uint32_t value = headerValue(c);
                 for (std::size_t n = 1; n < encBytes; ++n) {
-                    uchar nc = m_str[idx + n];
+                    unsigned char nc = m_str[idx + n];
                     valid &= ((nc & 0xC0) == 0x80);
                     value = (value << 6) | (nc & 0x3F);
                 }


### PR DESCRIPTION
## Description
Catch2 was conflicting with my code that had a "#define uchar unsigned char" in its code. I found that Catch2's use of "uchar" was extremely limited (one "using uchar = unsigned char", two subsequent uses of "uchar"). Under the principle that Catch2 should be as light on the land as possible, I edited the three lines involved, re-ran the Catch2 SelfTests (it not surprisingly passed) and created this PR.

## GitHub Issues
None
