### PR TITLE
catch_compiler_capabilities.h: use proper math define

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -203,7 +203,7 @@
     #define CATCH_CONFIG_COLOUR_NONE
 #endif
 
-#if defined(__UCLIBC__)
+#if !defined(_GLIBCXX_USE_C99_MATH_TR1)
 #define CATCH_INTERNAL_CONFIG_GLOBAL_NEXTAFTER
 #endif
 

--- a/include/internal/catch_matchers_floating.cpp
+++ b/include/internal/catch_matchers_floating.cpp
@@ -59,15 +59,7 @@ namespace {
         return static_cast<uint64_t>(ulpDiff) <= maxUlpDiff;
     }
 
-} //end anonymous namespace
-
 #if defined(CATCH_CONFIG_GLOBAL_NEXTAFTER)
-
-#if defined(__clang__)
-#pragma clang diagnostic push
-// The long double overload is currently unused
-#pragma clang diagnostic ignored "-Wunused-function"
-#endif
 
     float nextafter(float x, float y) {
         return ::nextafterf(x, y);
@@ -77,17 +69,7 @@ namespace {
         return ::nextafter(x, y);
     }
 
-    long double nextafter(long double x, long double y) {
-        return ::nextafterl(x, y);
-    }
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-
 #endif // ^^^ CATCH_CONFIG_GLOBAL_NEXTAFTER ^^^
-
-namespace {
 
 template <typename FP>
 FP step(FP start, FP direction, uint64_t steps) {


### PR DESCRIPTION
C++11 math requires _GLIBCXX_USE_C99_MATH_TR1 to be true with gcc/clang.

Also fixes an issue with uClibc-ng where __UCLIBC__ is defined in features.h but
that is not included here and is thus no-op.

Similar to how boost does it: https://github.com/boostorg/math/blob/5f8561bcfd4f1784e729acd333d3532e30adc477/include/boost/math/tools/roots.hpp#L863