### PR TITLE
Switch back to uncolored output after printing filters

### DIFF
--- a/include/reporters/catch_reporter_console.cpp
+++ b/include/reporters/catch_reporter_console.cpp
@@ -685,9 +685,8 @@ void ConsoleReporter::printSummaryDivider() {
 
 void ConsoleReporter::printTestFilters() {
     if (m_config->testSpec().hasFilters()) {
-        stream << Colour(Colour::BrightYellow)
-               << "Filters: " << serializeFilters(m_config->getTestsOrTags())
-               << Colour(Colour::None) << '\n';
+        Colour guard(Colour::BrightYellow);
+        stream << "Filters: " << serializeFilters(m_config->getTestsOrTags()) << '\n';
     }
 }
 

--- a/include/reporters/catch_reporter_console.cpp
+++ b/include/reporters/catch_reporter_console.cpp
@@ -684,8 +684,11 @@ void ConsoleReporter::printSummaryDivider() {
 }
 
 void ConsoleReporter::printTestFilters() {
-    if (m_config->testSpec().hasFilters())
-        stream << Colour(Colour::BrightYellow) << "Filters: " << serializeFilters( m_config->getTestsOrTags() ) << '\n';
+    if (m_config->testSpec().hasFilters()) {
+        stream << Colour(Colour::BrightYellow)
+               << "Filters: " << serializeFilters(m_config->getTestsOrTags())
+               << Colour(Colour::None) << '\n';
+    }
 }
 
 CATCH_REGISTER_REPORTER("console", ConsoleReporter)


### PR DESCRIPTION


<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
After printing the list of filters, switch back from yellow to black before printing a newline to avoid the remaining output to be colored in yellow.

This is especially useful when the output is prefixed. In [Fawkes](https://github.com/fawkesrobotics/fawkes/), our build system prepends the test output with `[TEST]`, which is colored incorrectly:

old:
![image](https://user-images.githubusercontent.com/4573064/74156343-68d4f600-4c16-11ea-87fd-f22632e0636f.png)

with this PR:
![image](https://user-images.githubusercontent.com/4573064/74156393-84400100-4c16-11ea-9d87-ce2120eaefed.png)

This is a purely aesthetic change, but I found it annoying enough to want it to be fixed.