### PR TITLE
Add command line option 'never' to --wait-for-keypress

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -271,7 +271,7 @@ See [The LibIdentify repo for more information and examples](https://github.com/
 
 <a id="wait-for-keypress"></a>
 ## Wait for key before continuing
-<pre>--wait-for-keypress &lt;start|exit|both&gt;</pre>
+<pre>--wait-for-keypress &lt;never|start|exit|both&gt;</pre>
 
 Will cause the executable to print a message and wait until the return/ enter key is pressed before continuing -
 either before running any tests, after running all tests - or both, depending on the argument.

--- a/include/internal/catch_commandline.cpp
+++ b/include/internal/catch_commandline.cpp
@@ -91,10 +91,10 @@ namespace Catch {
             };
         auto const setWaitForKeypress = [&]( std::string const& keypress ) {
                 auto keypressLc = toLower( keypress );
-                if( keypressLc == "start" )
-                    config.waitForKeypress = WaitForKeypress::BeforeStart;
-                else if( keypressLc == "never" )
+                if (keypressLc == "never")
                     config.waitForKeypress = WaitForKeypress::Never;
+                else if( keypressLc == "start" )
+                    config.waitForKeypress = WaitForKeypress::BeforeStart;
                 else if( keypressLc == "exit" )
                     config.waitForKeypress = WaitForKeypress::BeforeExit;
                 else if( keypressLc == "both" )

--- a/include/internal/catch_commandline.cpp
+++ b/include/internal/catch_commandline.cpp
@@ -93,12 +93,14 @@ namespace Catch {
                 auto keypressLc = toLower( keypress );
                 if( keypressLc == "start" )
                     config.waitForKeypress = WaitForKeypress::BeforeStart;
+                else if( keypressLc == "never" )
+                    config.waitForKeypress = WaitForKeypress::Never;
                 else if( keypressLc == "exit" )
                     config.waitForKeypress = WaitForKeypress::BeforeExit;
                 else if( keypressLc == "both" )
                     config.waitForKeypress = WaitForKeypress::BeforeStartAndExit;
                 else
-                    return ParserResult::runtimeError( "keypress argument must be one of: start, exit or both. '" + keypress + "' not recognised" );
+                    return ParserResult::runtimeError( "keypress argument must be one of: never, start, exit or both. '" + keypress + "' not recognised" );
             return ParserResult::ok( ParseResultType::Matched );
             };
         auto const setVerbosity = [&]( std::string const& verbosity ) {
@@ -198,7 +200,7 @@ namespace Catch {
             | Opt( config.libIdentify )
                 ["--libidentify"]
                 ( "report name and version according to libidentify standard" )
-            | Opt( setWaitForKeypress, "start|exit|both" )
+            | Opt( setWaitForKeypress, "never|start|exit|both" )
                 ["--wait-for-keypress"]
                 ( "waits for a keypress before exiting" )
             | Opt( config.benchmarkSamples, "samples" )

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -1088,6 +1088,10 @@ CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "-x", "2"}) for: {?}
 CmdLine.tests.cpp:<line number>: passed: config.abortAfter == 2 for: 2 == 2
 CmdLine.tests.cpp:<line number>: passed: !result for: true
 CmdLine.tests.cpp:<line number>: passed: result.errorMessage(), Contains("convert") && Contains("oops") for: "Unable to convert 'oops' to destination type" ( contains: "convert" and contains: "oops" )
+CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "--wait-for-keypress", "never"}) for: {?}
+CmdLine.tests.cpp:<line number>: passed: config.waitForKeypress == Catch::WaitForKeypress::Never for: 0 == 0
+CmdLine.tests.cpp:<line number>: passed: !result for: true
+CmdLine.tests.cpp:<line number>: passed: result.errorMessage(), Contains("never") && Contains("both") for: "keypress argument must be one of: never, start, exit or both. 'sometimes' not recognised" ( contains: "never" and contains: "both" )
 CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "-e"}) for: {?}
 CmdLine.tests.cpp:<line number>: passed: config.noThrow for: true
 CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "--nothrow"}) for: {?}

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -1088,8 +1088,14 @@ CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "-x", "2"}) for: {?}
 CmdLine.tests.cpp:<line number>: passed: config.abortAfter == 2 for: 2 == 2
 CmdLine.tests.cpp:<line number>: passed: !result for: true
 CmdLine.tests.cpp:<line number>: passed: result.errorMessage(), Contains("convert") && Contains("oops") for: "Unable to convert 'oops' to destination type" ( contains: "convert" and contains: "oops" )
-CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "--wait-for-keypress", "never"}) for: {?}
-CmdLine.tests.cpp:<line number>: passed: config.waitForKeypress == Catch::WaitForKeypress::Never for: 0 == 0
+CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) for: {?}
+CmdLine.tests.cpp:<line number>: passed: config.waitForKeypress == std::get<1>(input) for: 0 == 0
+CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) for: {?}
+CmdLine.tests.cpp:<line number>: passed: config.waitForKeypress == std::get<1>(input) for: 1 == 1
+CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) for: {?}
+CmdLine.tests.cpp:<line number>: passed: config.waitForKeypress == std::get<1>(input) for: 2 == 2
+CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) for: {?}
+CmdLine.tests.cpp:<line number>: passed: config.waitForKeypress == std::get<1>(input) for: 3 == 3
 CmdLine.tests.cpp:<line number>: passed: !result for: true
 CmdLine.tests.cpp:<line number>: passed: result.errorMessage(), Contains("never") && Contains("both") for: "keypress argument must be one of: never, start, exit or both. 'sometimes' not recognised" ( contains: "never" and contains: "both" )
 CmdLine.tests.cpp:<line number>: passed: cli.parse({"test", "-e"}) for: {?}

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -1381,5 +1381,5 @@ due to unexpected exception with message:
 
 ===============================================================================
 test cases:  306 |  232 passed |  70 failed |  4 failed as expected
-assertions: 1670 | 1518 passed | 131 failed | 21 failed as expected
+assertions: 1676 | 1524 passed | 131 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -1381,5 +1381,5 @@ due to unexpected exception with message:
 
 ===============================================================================
 test cases:  306 |  232 passed |  70 failed |  4 failed as expected
-assertions: 1666 | 1514 passed | 131 failed | 21 failed as expected
+assertions: 1670 | 1518 passed | 131 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -7836,6 +7836,45 @@ with expansion:
 
 -------------------------------------------------------------------------------
 Process can be configured on command line
+  abort
+  wait-for-keypress
+  never is an accepted option
+-------------------------------------------------------------------------------
+CmdLine.tests.cpp:<line number>
+...............................................................................
+
+CmdLine.tests.cpp:<line number>: PASSED:
+  CHECK( cli.parse({"test", "--wait-for-keypress", "never"}) )
+with expansion:
+  {?}
+
+CmdLine.tests.cpp:<line number>: PASSED:
+  REQUIRE( config.waitForKeypress == Catch::WaitForKeypress::Never )
+with expansion:
+  0 == 0
+
+-------------------------------------------------------------------------------
+Process can be configured on command line
+  abort
+  wait-for-keypress
+  invalid options are reported
+-------------------------------------------------------------------------------
+CmdLine.tests.cpp:<line number>
+...............................................................................
+
+CmdLine.tests.cpp:<line number>: PASSED:
+  CHECK( !result )
+with expansion:
+  true
+
+CmdLine.tests.cpp:<line number>: PASSED:
+  REQUIRE_THAT( result.errorMessage(), Contains("never") && Contains("both") )
+with expansion:
+  "keypress argument must be one of: never, start, exit or both. 'sometimes'
+  not recognised" ( contains: "never" and contains: "both" )
+
+-------------------------------------------------------------------------------
+Process can be configured on command line
   nothrow
   -e
 -------------------------------------------------------------------------------
@@ -13321,5 +13360,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  306 |  216 passed |  86 failed |  4 failed as expected
-assertions: 1683 | 1514 passed | 148 failed | 21 failed as expected
+assertions: 1687 | 1518 passed | 148 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -7838,20 +7838,77 @@ with expansion:
 Process can be configured on command line
   abort
   wait-for-keypress
-  never is an accepted option
+  Accepted options
 -------------------------------------------------------------------------------
 CmdLine.tests.cpp:<line number>
 ...............................................................................
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  CHECK( cli.parse({"test", "--wait-for-keypress", "never"}) )
+  CHECK( cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) )
 with expansion:
   {?}
 
 CmdLine.tests.cpp:<line number>: PASSED:
-  REQUIRE( config.waitForKeypress == Catch::WaitForKeypress::Never )
+  REQUIRE( config.waitForKeypress == std::get<1>(input) )
 with expansion:
   0 == 0
+
+-------------------------------------------------------------------------------
+Process can be configured on command line
+  abort
+  wait-for-keypress
+  Accepted options
+-------------------------------------------------------------------------------
+CmdLine.tests.cpp:<line number>
+...............................................................................
+
+CmdLine.tests.cpp:<line number>: PASSED:
+  CHECK( cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) )
+with expansion:
+  {?}
+
+CmdLine.tests.cpp:<line number>: PASSED:
+  REQUIRE( config.waitForKeypress == std::get<1>(input) )
+with expansion:
+  1 == 1
+
+-------------------------------------------------------------------------------
+Process can be configured on command line
+  abort
+  wait-for-keypress
+  Accepted options
+-------------------------------------------------------------------------------
+CmdLine.tests.cpp:<line number>
+...............................................................................
+
+CmdLine.tests.cpp:<line number>: PASSED:
+  CHECK( cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) )
+with expansion:
+  {?}
+
+CmdLine.tests.cpp:<line number>: PASSED:
+  REQUIRE( config.waitForKeypress == std::get<1>(input) )
+with expansion:
+  2 == 2
+
+-------------------------------------------------------------------------------
+Process can be configured on command line
+  abort
+  wait-for-keypress
+  Accepted options
+-------------------------------------------------------------------------------
+CmdLine.tests.cpp:<line number>
+...............................................................................
+
+CmdLine.tests.cpp:<line number>: PASSED:
+  CHECK( cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) )
+with expansion:
+  {?}
+
+CmdLine.tests.cpp:<line number>: PASSED:
+  REQUIRE( config.waitForKeypress == std::get<1>(input) )
+with expansion:
+  3 == 3
 
 -------------------------------------------------------------------------------
 Process can be configured on command line
@@ -13360,5 +13417,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  306 |  216 passed |  86 failed |  4 failed as expected
-assertions: 1687 | 1518 passed | 148 failed | 21 failed as expected
+assertions: 1693 | 1524 passed | 148 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="132" tests="1688" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="132" tests="1694" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="filters" value="~[!nonportable]~[!benchmark]~[approvals]"/>
       <property name="random-seed" value="1"/>
@@ -1004,7 +1004,7 @@ Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Process can be configured on command line/abort/-a aborts after first failure" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Process can be configured on command line/abort/-x 2 aborts after two failures" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Process can be configured on command line/abort/-x must be numeric" time="{duration}"/>
-    <testcase classname="<exe-name>.global" name="Process can be configured on command line/abort/wait-for-keypress/never is an accepted option" time="{duration}"/>
+    <testcase classname="<exe-name>.global" name="Process can be configured on command line/abort/wait-for-keypress/Accepted options" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Process can be configured on command line/abort/wait-for-keypress/invalid options are reported" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Process can be configured on command line/nothrow/-e" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Process can be configured on command line/nothrow/--nothrow" time="{duration}"/>

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="132" tests="1684" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="132" tests="1688" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="filters" value="~[!nonportable]~[!benchmark]~[approvals]"/>
       <property name="random-seed" value="1"/>
@@ -1004,6 +1004,8 @@ Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Process can be configured on command line/abort/-a aborts after first failure" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Process can be configured on command line/abort/-x 2 aborts after two failures" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Process can be configured on command line/abort/-x must be numeric" time="{duration}"/>
+    <testcase classname="<exe-name>.global" name="Process can be configured on command line/abort/wait-for-keypress/never is an accepted option" time="{duration}"/>
+    <testcase classname="<exe-name>.global" name="Process can be configured on command line/abort/wait-for-keypress/invalid options are reported" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Process can be configured on command line/nothrow/-e" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Process can be configured on command line/nothrow/--nothrow" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Process can be configured on command line/output filename/-o filename" time="{duration}"/>

--- a/projects/SelfTest/Baselines/sonarqube.sw.approved.txt
+++ b/projects/SelfTest/Baselines/sonarqube.sw.approved.txt
@@ -52,7 +52,7 @@
     <testCase name="Process can be configured on command line/abort/-a aborts after first failure" duration="{duration}"/>
     <testCase name="Process can be configured on command line/abort/-x 2 aborts after two failures" duration="{duration}"/>
     <testCase name="Process can be configured on command line/abort/-x must be numeric" duration="{duration}"/>
-    <testCase name="Process can be configured on command line/abort/wait-for-keypress/never is an accepted option" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/abort/wait-for-keypress/Accepted options" duration="{duration}"/>
     <testCase name="Process can be configured on command line/abort/wait-for-keypress/invalid options are reported" duration="{duration}"/>
     <testCase name="Process can be configured on command line/nothrow/-e" duration="{duration}"/>
     <testCase name="Process can be configured on command line/nothrow/--nothrow" duration="{duration}"/>

--- a/projects/SelfTest/Baselines/sonarqube.sw.approved.txt
+++ b/projects/SelfTest/Baselines/sonarqube.sw.approved.txt
@@ -52,6 +52,8 @@
     <testCase name="Process can be configured on command line/abort/-a aborts after first failure" duration="{duration}"/>
     <testCase name="Process can be configured on command line/abort/-x 2 aborts after two failures" duration="{duration}"/>
     <testCase name="Process can be configured on command line/abort/-x must be numeric" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/abort/wait-for-keypress/never is an accepted option" duration="{duration}"/>
+    <testCase name="Process can be configured on command line/abort/wait-for-keypress/invalid options are reported" duration="{duration}"/>
     <testCase name="Process can be configured on command line/nothrow/-e" duration="{duration}"/>
     <testCase name="Process can be configured on command line/nothrow/--nothrow" duration="{duration}"/>
     <testCase name="Process can be configured on command line/output filename/-o filename" duration="{duration}"/>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -9880,10 +9880,10 @@ Nor would this
       </Section>
       <Section name="abort" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
         <Section name="wait-for-keypress" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
-          <Section name="never is an accepted option" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+          <Section name="Accepted options" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
             <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
               <Original>
-                cli.parse({"test", "--wait-for-keypress", "never"})
+                cli.parse({"test", "--wait-for-keypress", std::get&lt;0>(input)})
               </Original>
               <Expanded>
                 {?}
@@ -9891,10 +9891,85 @@ Nor would this
             </Expression>
             <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
               <Original>
-                config.waitForKeypress == Catch::WaitForKeypress::Never
+                config.waitForKeypress == std::get&lt;1>(input)
               </Original>
               <Expanded>
                 0 == 0
+              </Expanded>
+            </Expression>
+            <OverallResults successes="2" failures="0" expectedFailures="0"/>
+          </Section>
+          <OverallResults successes="2" failures="0" expectedFailures="0"/>
+        </Section>
+        <OverallResults successes="2" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="abort" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+        <Section name="wait-for-keypress" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+          <Section name="Accepted options" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+            <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+              <Original>
+                cli.parse({"test", "--wait-for-keypress", std::get&lt;0>(input)})
+              </Original>
+              <Expanded>
+                {?}
+              </Expanded>
+            </Expression>
+            <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+              <Original>
+                config.waitForKeypress == std::get&lt;1>(input)
+              </Original>
+              <Expanded>
+                1 == 1
+              </Expanded>
+            </Expression>
+            <OverallResults successes="2" failures="0" expectedFailures="0"/>
+          </Section>
+          <OverallResults successes="2" failures="0" expectedFailures="0"/>
+        </Section>
+        <OverallResults successes="2" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="abort" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+        <Section name="wait-for-keypress" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+          <Section name="Accepted options" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+            <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+              <Original>
+                cli.parse({"test", "--wait-for-keypress", std::get&lt;0>(input)})
+              </Original>
+              <Expanded>
+                {?}
+              </Expanded>
+            </Expression>
+            <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+              <Original>
+                config.waitForKeypress == std::get&lt;1>(input)
+              </Original>
+              <Expanded>
+                2 == 2
+              </Expanded>
+            </Expression>
+            <OverallResults successes="2" failures="0" expectedFailures="0"/>
+          </Section>
+          <OverallResults successes="2" failures="0" expectedFailures="0"/>
+        </Section>
+        <OverallResults successes="2" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="abort" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+        <Section name="wait-for-keypress" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+          <Section name="Accepted options" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+            <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+              <Original>
+                cli.parse({"test", "--wait-for-keypress", std::get&lt;0>(input)})
+              </Original>
+              <Expanded>
+                {?}
+              </Expanded>
+            </Expression>
+            <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+              <Original>
+                config.waitForKeypress == std::get&lt;1>(input)
+              </Original>
+              <Expanded>
+                3 == 3
               </Expanded>
             </Expression>
             <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -15962,7 +16037,7 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="1518" failures="149" expectedFailures="21"/>
+    <OverallResults successes="1524" failures="149" expectedFailures="21"/>
   </Group>
-  <OverallResults successes="1518" failures="148" expectedFailures="21"/>
+  <OverallResults successes="1524" failures="148" expectedFailures="21"/>
 </Catch>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -9878,6 +9878,56 @@ Nor would this
         </Section>
         <OverallResults successes="2" failures="0" expectedFailures="0"/>
       </Section>
+      <Section name="abort" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+        <Section name="wait-for-keypress" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+          <Section name="never is an accepted option" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+            <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+              <Original>
+                cli.parse({"test", "--wait-for-keypress", "never"})
+              </Original>
+              <Expanded>
+                {?}
+              </Expanded>
+            </Expression>
+            <Expression success="true" type="REQUIRE" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+              <Original>
+                config.waitForKeypress == Catch::WaitForKeypress::Never
+              </Original>
+              <Expanded>
+                0 == 0
+              </Expanded>
+            </Expression>
+            <OverallResults successes="2" failures="0" expectedFailures="0"/>
+          </Section>
+          <OverallResults successes="2" failures="0" expectedFailures="0"/>
+        </Section>
+        <OverallResults successes="2" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="abort" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+        <Section name="wait-for-keypress" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+          <Section name="invalid options are reported" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+            <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+              <Original>
+                !result
+              </Original>
+              <Expanded>
+                true
+              </Expanded>
+            </Expression>
+            <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
+              <Original>
+                result.errorMessage(), Contains("never") &amp;&amp; Contains("both")
+              </Original>
+              <Expanded>
+                "keypress argument must be one of: never, start, exit or both. 'sometimes' not recognised" ( contains: "never" and contains: "both" )
+              </Expanded>
+            </Expression>
+            <OverallResults successes="2" failures="0" expectedFailures="0"/>
+          </Section>
+          <OverallResults successes="2" failures="0" expectedFailures="0"/>
+        </Section>
+        <OverallResults successes="2" failures="0" expectedFailures="0"/>
+      </Section>
       <Section name="nothrow" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
         <Section name="-e" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
           <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/CmdLine.tests.cpp" >
@@ -15912,7 +15962,7 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="1514" failures="149" expectedFailures="21"/>
+    <OverallResults successes="1518" failures="149" expectedFailures="21"/>
   </Group>
-  <OverallResults successes="1514" failures="148" expectedFailures="21"/>
+  <OverallResults successes="1518" failures="148" expectedFailures="21"/>
 </Catch>

--- a/projects/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
@@ -414,7 +414,24 @@ TEST_CASE( "Process can be configured on command line", "[config][command-line]"
             REQUIRE_THAT(result.errorMessage(), Contains("convert") && Contains("oops"));
 #endif
         }
+
+     SECTION("wait-for-keypress") {
+        SECTION("never is an accepted option") {
+            CHECK(cli.parse({"test", "--wait-for-keypress", "never"}));
+
+            REQUIRE(config.waitForKeypress == Catch::WaitForKeypress::Never);
+        }
+
+        SECTION("invalid options are reported") {
+            auto result = cli.parse({"test", "--wait-for-keypress", "sometimes"});
+            CHECK(!result);
+
+#ifndef CATCH_CONFIG_DISABLE_MATCHERS
+            REQUIRE_THAT(result.errorMessage(), Contains("never") && Contains("both"));
+#endif
+        }
     }
+   }
 
     SECTION("nothrow") {
         SECTION("-e") {

--- a/projects/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
@@ -416,10 +416,16 @@ TEST_CASE( "Process can be configured on command line", "[config][command-line]"
         }
 
      SECTION("wait-for-keypress") {
-        SECTION("never is an accepted option") {
-            CHECK(cli.parse({"test", "--wait-for-keypress", "never"}));
+        SECTION("Accepted options") {
+            auto input = GENERATE(table<char const*, Catch::WaitForKeypress::When>({
+                {"never", Catch::WaitForKeypress::Never},
+                {"start", Catch::WaitForKeypress::BeforeStart},
+                {"exit",  Catch::WaitForKeypress::BeforeExit},
+                {"both",  Catch::WaitForKeypress::BeforeStartAndExit},
+            }));
+            CHECK(cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}));
 
-            REQUIRE(config.waitForKeypress == Catch::WaitForKeypress::Never);
+            REQUIRE(config.waitForKeypress == std::get<1>(input));
         }
 
         SECTION("invalid options are reported") {

--- a/projects/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
@@ -417,11 +417,12 @@ TEST_CASE( "Process can be configured on command line", "[config][command-line]"
 
      SECTION("wait-for-keypress") {
         SECTION("Accepted options") {
+            using tuple_type = std::tuple<char const*, Catch::WaitForKeypress::When>;
             auto input = GENERATE(table<char const*, Catch::WaitForKeypress::When>({
-                {"never", Catch::WaitForKeypress::Never},
-                {"start", Catch::WaitForKeypress::BeforeStart},
-                {"exit",  Catch::WaitForKeypress::BeforeExit},
-                {"both",  Catch::WaitForKeypress::BeforeStartAndExit},
+                tuple_type{"never", Catch::WaitForKeypress::Never},
+                tuple_type{"start", Catch::WaitForKeypress::BeforeStart},
+                tuple_type{"exit",  Catch::WaitForKeypress::BeforeExit},
+                tuple_type{"both",  Catch::WaitForKeypress::BeforeStartAndExit},
             }));
             CHECK(cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}));
 


### PR DESCRIPTION
I want my end-users on Windows to be able to run the tests without navigating to the folder on the command-line and view the results before the Window closes, so I set the default value for the option in the config runner:

``` cpp
session.configData().waitForKeypress = Catch::WaitForKeypress::BeforeExit;
```

On the CI systems, I can't wait for a keypress so I'd like to disabled the prompt by adding `--wait-for-keypress never` to the command line.