### PR TITLE
Create a SYSTEM library in case Catch2 is included as a subproject.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,11 +90,19 @@ target_compile_features(Catch2
     cxx_variadic_macros
 )
 
-target_include_directories(Catch2
-  INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/single_include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
+if (NOT_SUBPROJECT)
+  target_include_directories(Catch2
+    INTERFACE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/single_include>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+else()
+  target_include_directories(Catch2
+    SYSTEM INTERFACE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/single_include>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+endif()
 
 if (ANDROID)
     target_link_libraries(Catch2 INTERFACE log)


### PR DESCRIPTION
Define the CMake target as a SYSTEM library if Catch2 is included as a subproject. This is necessary to make sure that linting tools (such as `clang-tidy`) do not report errors about Catch2's headers.

In case the library is not included as a subproject keep it as a normal library, since it is not a good idea to silence linters when developing the framework itself.