### PR TITLE
include <iterator> in catch_stats.hpp

### DIFF
--- a/include/internal/benchmark/detail/catch_stats.hpp
+++ b/include/internal/benchmark/detail/catch_stats.hpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <functional>
 #include <vector>
+#include <iterator>
 #include <numeric>
 #include <tuple>
 #include <cmath>


### PR DESCRIPTION
Needed for `std::back_inserter` on some platforms (in particular, windows) when building `catch_stats.cpp`.