### PR TITLE
Fixed typo in "benchmark name" column width calculation.

### DIFF
--- a/include/reporters/catch_reporter_console.cpp
+++ b/include/reporters/catch_reporter_console.cpp
@@ -362,7 +362,7 @@ ConsoleReporter::ConsoleReporter(ReporterConfig const& config)
         else
         {
             return{
-                { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 32, ColumnInfo::Left },
+                { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left },
                 { "samples      mean       std dev", 14, ColumnInfo::Right },
                 { "iterations   low mean   low std dev", 14, ColumnInfo::Right },
                 { "estimated    high mean  high std dev", 14, ColumnInfo::Right }

--- a/projects/ExtraTests/CMakeLists.txt
+++ b/projects/ExtraTests/CMakeLists.txt
@@ -123,7 +123,7 @@ add_test(NAME BenchmarkingMacros COMMAND BenchmarkingMacros -r console -s)
 set_tests_properties(
     BenchmarkingMacros
   PROPERTIES
-    PASS_REGULAR_EXPRESSION "benchmark name                                  samples       iterations    estimated"
+    PASS_REGULAR_EXPRESSION "benchmark name[\\r\\n\\t ]+samples[\\r\\n\\t ]+iterations[\\r\\n\\t ]+estimated"
 )
 
 # This test touches windows.h, so it should only be compiled under msvc


### PR DESCRIPTION
## Description
The width for the "benchmark name" column in full analysis mode is too large, which makes the output spill beyond `CATCH_CONFIG_CONSOLE_WIDTH`. 

The width was set to `CATCH_CONFIG_CONSOLE_WIDTH - 32`, but the other three columns are each 14 wide, for a total of 42, not 32, thus giving a total line length of `CATCH_CONFIG_CONSOLE_WIDTH + 10`, when it should obviously not exceed `CATCH_CONFIG_CONSOLE_WIDTH`. (My guess is that `32` was a typo for `42`.)

The best solution I see is setting the width of the "benchmark name" column to `CATCH_CONFIG_CONSOLE_WIDTH - 43`, the same as it is in the no analysis case. This PR does that.

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
Fixes #1885.