### PR TITLE
Replace Deprecated C-Headers with the C++ ones

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -235,7 +235,6 @@
   #    if defined(__clang__) && (__clang_major__ < 8)
          // work around clang bug with libstdc++ https://bugs.llvm.org/show_bug.cgi?id=31852
          // fix should be in clang 8, workaround in libstdc++ 8.2
-  #      include <ciso646>
   #      if defined(__GLIBCXX__) && defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE < 9)
   #        define CATCH_CONFIG_NO_CPP17_VARIANT
   #      else

--- a/include/internal/catch_debugger.cpp
+++ b/include/internal/catch_debugger.cpp
@@ -14,8 +14,7 @@
 
 #if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
 
-#  include <assert.h>
-#  include <stdbool.h>
+#  include <cassert>
 #  include <sys/types.h>
 #  include <unistd.h>
 #  include <cstddef>

--- a/include/internal/catch_debugger.h
+++ b/include/internal/catch_debugger.h
@@ -39,7 +39,7 @@ namespace Catch {
     #if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
         #define CATCH_TRAP() asm volatile ("int $3") /* NOLINT */
     #else // Fall back to the generic way.
-        #include <signal.h>
+        #include <csignal>
 
         #define CATCH_TRAP() raise(SIGTRAP)
     #endif

--- a/include/internal/catch_fatal_condition.h
+++ b/include/internal/catch_fatal_condition.h
@@ -35,7 +35,7 @@ namespace Catch {
 
 #elif defined ( CATCH_CONFIG_POSIX_SIGNALS )
 
-#include <signal.h>
+#include <csignal>
 
 namespace Catch {
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
I switched out the deprecated C headers for the STL, and replaced them for the C++ ones