### PR TITLE
Updating documentation of open-source projects using Catch2

### DIFF
--- a/docs/opensource-users.md
+++ b/docs/opensource-users.md
@@ -86,6 +86,9 @@ A small, single-header-only, library for wrapping and composing columns of text.
 ### [thor](https://github.com/xorz57/thor)
 Wrapper Library for CUDA.
 
+### [toml++](https://github.com/marzer/tomlplusplus)
+A header-only TOML parser and serializer for modern C++.
+
 ### [Trompeloeil](https://github.com/rollbear/trompeloeil)
 A thread-safe header-only mocking framework for C++14.
 

--- a/docs/opensource-users.md
+++ b/docs/opensource-users.md
@@ -20,17 +20,20 @@ Listing a project here does not imply endorsement and the plan is to keep these 
 ### [ApprovalTests.cpp](https://github.com/approvals/ApprovalTests.cpp)
 C++11 implementation of Approval Tests, for quick, convenient testing of legacy code.
 
+### [args](https://github.com/Taywee/args)
+A simple header-only C++ argument parser library.
+
 ### [Azmq](https://github.com/zeromq/azmq)
 Boost Asio style bindings for ZeroMQ.
 
 ### [Cataclysm: Dark Days Ahead](https://github.com/CleverRaven/Cataclysm-DDA)
 Post-apocalyptic survival RPG.
 
-### [ChakraCore](https://github.com/Microsoft/ChakraCore)
-The core part of the Chakra JavaScript engine that powers Microsoft Edge.
-
 ### [ChaiScript](https://github.com/ChaiScript/ChaiScript)
 A, header-only, embedded scripting language designed from the ground up to directly target C++ and take advantage of modern C++ development techniques.
+
+### [ChakraCore](https://github.com/Microsoft/ChakraCore)
+The core part of the Chakra JavaScript engine that powers Microsoft Edge.
 
 ### [Clara](https://github.com/philsquared/Clara)
 A, single-header-only, type-safe, command line parser - which also prints formatted usage strings.
@@ -65,9 +68,6 @@ A small C++ library wrapper for the native C ODBC API.
 ### [Nonius](https://github.com/libnonius/nonius)
 A header-only framework for benchmarking small snippets of C++ code.
 
-### [SOCI](https://github.com/SOCI/soci)
-The C++ Database Access Library.
-
 ### [polymorphic_value](https://github.com/jbcoe/polymorphic_value)
 A polymorphic value-type for C++.
 
@@ -77,17 +77,17 @@ A C++ client library for Consul. Consul is a distributed tool for discovering an
 ### [Reactive-Extensions/ RxCpp](https://github.com/Reactive-Extensions/RxCpp)
 A library of algorithms for values-distributed-in-time.
 
-### [thor](https://github.com/xorz57/thor)
-Wrapper Library for CUDA.
+### [SOCI](https://github.com/SOCI/soci)
+The C++ Database Access Library.
 
 ### [TextFlowCpp](https://github.com/philsquared/textflowcpp)
 A small, single-header-only, library for wrapping and composing columns of text.
 
+### [thor](https://github.com/xorz57/thor)
+Wrapper Library for CUDA.
+
 ### [Trompeloeil](https://github.com/rollbear/trompeloeil)
 A thread-safe header-only mocking framework for C++14.
-
-### [args](https://github.com/Taywee/args)
-A simple header-only C++ argument parser library.
 
 ## Applications & Tools
 
@@ -103,6 +103,9 @@ MAME originally stood for Multiple Arcade Machine Emulator.
 ### [Newsbeuter](https://github.com/akrennmair/newsbeuter)
 Newsbeuter is an open-source RSS/Atom feed reader for text terminals.
 
+### [PopHead](https://github.com/SPC-Some-Polish-Coders/PopHead)
+A 2D, Zombie, RPG game which is being made on our own engine.
+
 ### [raspigcd](https://github.com/pantadeusz/raspigcd)
 Low level CLI app and library for execution of GCODE on Raspberry Pi without any additional microcontrolers (just RPi + Stepsticks).
 
@@ -111,9 +114,6 @@ SpECTRE is a code for multi-scale, multi-physics problems in astrophysics and gr
 
 ### [Standardese](https://github.com/foonathan/standardese)
 Standardese aims to be a nextgen Doxygen.
-
-### [PopHead](https://github.com/SPC-Some-Polish-Coders/PopHead)
-A 2D, Zombie, RPG game which is being made on our own engine.
 
 ---
 


### PR DESCRIPTION
## Description
Updating documentation of open-source projects using Catch2:
- Fixed alphabetical ordering
- Added an additional project ([toml++](https://github.com/marzer/tomlplusplus))

## GitHub Issues
Not related to any specific issue.
