### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -220,6 +220,19 @@ when configuring the build, and then modify your calls to
 [find_package](https://cmake.org/cmake/help/latest/command/find_package.html)
 accordingly.
 
+## Installing Catch2 from VCPKG
+
+Alternatively, you can build and install Catch2 using [vcpkg](https://github.com/microsoft/vcpkg/) dependency manager:
+```
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install catch2
+```
+
+The catch2 port in vcpkg is kept up to date by microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ---
 

--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -6,6 +6,7 @@
 [Automatic test registration](#automatic-test-registration)<br>
 [CMake project options](#cmake-project-options)<br>
 [Installing Catch2 from git repository](#installing-catch2-from-git-repository)<br>
+[Installing Catch2 from vcpkg](#installing-catch2-from-vcpkg)<br>
 
 Because we use CMake to build Catch2, we also provide a couple of
 integration points for our users.
@@ -220,7 +221,7 @@ when configuring the build, and then modify your calls to
 [find_package](https://cmake.org/cmake/help/latest/command/find_package.html)
 accordingly.
 
-## Installing Catch2 from VCPKG
+## Installing Catch2 from vcpkg
 
 Alternatively, you can build and install Catch2 using [vcpkg](https://github.com/microsoft/vcpkg/) dependency manager:
 ```


### PR DESCRIPTION
Catch2 is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build Catch2, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for Catch2 and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.