### PR TITLE
catch_reporter_junit added xml attribute status

### DIFF
--- a/include/reporters/catch_reporter_junit.cpp
+++ b/include/reporters/catch_reporter_junit.cpp
@@ -193,6 +193,7 @@ namespace Catch {
                 xml.writeAttribute( "name", name );
             }
             xml.writeAttribute( "time", ::Catch::Detail::stringify( sectionNode.stats.durationInSeconds ) );
+            xml.writeAttribute( "status", "run" );
 
             writeAssertions( sectionNode );
 


### PR DESCRIPTION
## Description

Added "status" xml attribute to testcase section. 
This is done to be compatible with google test junit xml output.
