### PR TITLE
Suppress clang-tidy warning about vararg usage in assertion macros

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -58,7 +58,7 @@
 #    define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION _Pragma( "clang diagnostic push" )
 #    define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  _Pragma( "clang diagnostic pop" )
 
-#    define CATCH_INTERNAL_IGNORE_BUT_WARN(...) (void)__builtin_constant_p(__VA_ARGS__)
+#    define CATCH_INTERNAL_IGNORE_BUT_WARN(...) (void)__builtin_constant_p(__VA_ARGS__) /* NOLINT(cppcoreguidelines-pro-type-vararg) */
 
 
 #    define CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \


### PR DESCRIPTION
## Description

`CATCH_INTERNAL_IGNORE_BUT_WARN()` introduced with b7b346c (*) triggers clang-tidy warning [cppcoreguidelines-pro-type-vararg](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-vararg.html) for every usage of assertion macros like `CHECK()` and `REQUIRE()`. Silence it via `NOLINT` in the `#if defined(__clang__)` block only, as clang-tidy honors those.

(*) Thanks for that one BTW, uncovered a few warnings in our test code.

## GitHub Issues

n/a (decided to try to file PR instead of creating a ticket)