### PR TITLE
Provide path of the cmake scripts to conan

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -25,3 +25,6 @@ class CatchConan(ConanFile):
 
     def package_id(self):
         self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.builddirs.append("lib/cmake/Catch2")


### PR DESCRIPTION
To make things simple I aim to do:
```
find_package(Catch2 REQUIRED)
include(CTest)
include(Catch)

add_executable(example_tests tests.cpp)
target_link_libraries(example_tests Catch2::Catch2)
catch_discover_tests(example_tests)
```
Using conan's cmake_find_package generator. But `Catch.cmake` can't be found. This commit fixes the conan package.
