### PR TITLE
Remove usage of __builtin_constant_p under IBM XL

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -58,7 +58,20 @@
 #    define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION _Pragma( "clang diagnostic push" )
 #    define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  _Pragma( "clang diagnostic pop" )
 
+// As of this writing, IBM XL's implementation of __builtin_constant_p has a bug
+// which results in calls to destructors being emitted for each temporary,
+// without a matching initialization. In practice, this can result in something
+// like `std::string::~string` being called on an uninitialized value.
+//
+// For example, this code will likely segfault under IBM XL:
+// ```
+// REQUIRE(std::string("12") + "34" == "1234")
+// ```
+//
+// Therefore, `CATCH_INTERNAL_IGNORE_BUT_WARN` is not implemented.
+#  if !defined(__ibmxl__)
 #    define CATCH_INTERNAL_IGNORE_BUT_WARN(...) (void)__builtin_constant_p(__VA_ARGS__) /* NOLINT(cppcoreguidelines-pro-type-vararg) */
+#  endif
 
 
 #    define CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \


### PR DESCRIPTION
# Description

This change eliminates use of the `__builtin_constant_p` intrinsic for IBM XL compilers that use the clang front end. Under XL, code is generated to call destructors for temporaries in expressions passed to `__builtin_constant_p`, but the code to initialize those temporaries is not emitted. For example, IBM XL will generate a call to `std::string::~string` for the following code:

```c++
__builtin_constant_p(std::string("12") + "34");
```

This often results in a segfault in the case of `std::string::~string`, as `free` will likely be called on an invalid address.

Concretely, this code would result in a segfault:
```c++
REQUIRE(std::string("12") + "34" == "1234");
```

Previously, this the tests would fail when building with IBM XL 16.1.1.7. Now they all pass.

The bug has been reported to IBM. I will re-enable this for future versions of IBM XL when the problem is fixed.