### PR TITLE
Change random test shuffling technique

### DIFF
--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -451,6 +451,8 @@ set_tests_properties(TestsInFile::InvalidTestNames-1 PROPERTIES PASS_REGULAR_EXP
 add_test(NAME TestsInFile::InvalidTestNames-2 COMMAND $<TARGET_FILE:SelfTest> "-f ${CATCH_DIR}/projects/SelfTest/Misc/invalid-test-names.input")
 set_tests_properties(TestsInFile::InvalidTestNames-2 PROPERTIES PASS_REGULAR_EXPRESSION "No tests ran")
 
+add_test(NAME RandomTestOrdering COMMAND ${PYTHON_EXECUTABLE}
+  ${CATCH_DIR}/projects/TestScripts/testRandomOrder.py $<TARGET_FILE:SelfTest>)
 
 if (CATCH_USE_VALGRIND)
     add_test(NAME ValgrindRunTests COMMAND valgrind --leak-check=full --error-exitcode=1 $<TARGET_FILE:SelfTest>)

--- a/projects/TestScripts/testRandomOrder.py
+++ b/projects/TestScripts/testRandomOrder.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+
+def list_tests(self_test_exe, tags, rng_seed):
+    cmd = [self_test_exe, '--list-test-names-only', '--order', 'rand',
+            '--rng-seed', str(rng_seed)]
+    tags_arg = ','.join('[{}]'.format(t) for t in tags)
+    if tags_arg:
+        cmd.append(tags_arg + '~[.]')
+    process = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+    if stderr:
+        raise RuntimeError("Unexpected error output:\n" + process.stderr)
+    result = stdout.split(b'\n')
+    result = [s for s in result if s]
+    if len(result) < 2:
+        raise RuntimeError("Unexpectedly few tests listed (got {})".format(
+            len(result)))
+    return result
+
+def check_is_sublist_of(shorter, longer):
+    assert len(shorter) < len(longer)
+    assert len(set(longer)) == len(longer)
+
+    indexes_in_longer = {s: i for i, s in enumerate(longer)}
+    for s1, s2 in zip(shorter, shorter[1:]):
+        assert indexes_in_longer[s1] < indexes_in_longer[s2], (
+                '{} comes before {} in longer list.\n'
+                'Longer: {}\nShorter: {}'.format(s2, s1, longer, shorter))
+
+def main():
+    self_test_exe, = sys.argv[1:]
+
+    list_one_tag = list_tests(self_test_exe, ['generators'], 1)
+    list_two_tags = list_tests(self_test_exe, ['generators', 'matchers'], 1)
+    list_all = list_tests(self_test_exe, [], 1)
+
+    # First, verify that restricting to a subset yields the same order
+    check_is_sublist_of(list_two_tags, list_all)
+    check_is_sublist_of(list_one_tag, list_two_tags)
+
+    # Second, verify that different seeds yield different orders
+    num_seeds = 100
+    seeds = range(1, num_seeds + 1) # Avoid zero since that's special
+    lists = {tuple(list_tests(self_test_exe, [], seed)) for seed in seeds}
+    assert len(lists) == num_seeds, (
+            'Got {} distict lists from {} seeds'.format(len(lists), num_seeds))
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Description
Previously a random test ordering was obtained by applying `std::shuffle` to the tests in declaration order.  This has two problems:

- It depends on the declaration order, so the order in which the tests will be run will be platform-specific.
- When trying to debug accidental inter-test dependencies, it is helpful to be able to find a minimal subset of tests which exhibits the issue. However, any change to the set of tests being run will completely change the test ordering, making it difficult or impossible to reduce the set of tests being run in any reasonably efficient manner.

Therefore, change the randomization approach to resolve both these issues.

Generate a random value based on the user-provided RNG seed.  Convert every test case to an integer by hashing a combination of that value with the test name.  Sort the test cases by this integer.

The test names and RNG are platform-independent, so this should be consistent across platforms.  Also, removing one test does not change the integer value associated with the remaining tests, so they remain in the same order.

To hash, use the FNV-1a hash, except with the basis being our randomly selected value rather than the fixed basis set in the algorithm.  Cannot use `std::hash`, because it is important that the result be platform-independent.