### PR TITLE
Add new command-line option to specify a threshold for test duration printing

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -222,6 +222,10 @@ available warnings
 
 When set to ```yes``` Catch will report the duration of each test case, in milliseconds. Note that it does this regardless of whether a test case passes or fails. Note, also, the certain reporters (e.g. Junit) always report test case durations regardless of this option being set or not.
 
+<pre>-D, --min-duration &lt;value></pre>
+
+When set, Catch will report the duration of each test case that took more than &lt;value> seconds, in milliseconds.
+
 <a id="input-file"></a>
 ## Load test names to run from a file
 <pre>-f, --input-file &lt;filename></pre>

--- a/include/internal/catch_commandline.cpp
+++ b/include/internal/catch_commandline.cpp
@@ -170,6 +170,9 @@ namespace Catch {
             | Opt( [&]( bool flag ) { config.showDurations = flag ? ShowDurations::Always : ShowDurations::Never; }, "yes|no" )
                 ["-d"]["--durations"]
                 ( "show test durations" )
+            | Opt( config.minDuration, "seconds" )
+                ["-D"]["--min-duration"]
+                ( "show test durations for tests taking at least the given number of seconds" )
             | Opt( loadTestNamesFromFile, "filename" )
                 ["-f"]["--input-file"]
                 ( "load test names to run from a file" )

--- a/include/internal/catch_config.cpp
+++ b/include/internal/catch_config.cpp
@@ -64,6 +64,7 @@ namespace Catch {
     bool Config::warnAboutMissingAssertions() const    { return !!(m_data.warnings & WarnAbout::NoAssertions); }
     bool Config::warnAboutNoTests() const              { return !!(m_data.warnings & WarnAbout::NoTests); }
     ShowDurations::OrNot Config::showDurations() const { return m_data.showDurations; }
+    double Config::minDuration() const                 { return m_data.minDuration; }
     RunTests::InWhatOrder Config::runOrder() const     { return m_data.runOrder; }
     unsigned int Config::rngSeed() const               { return m_data.rngSeed; }
     UseColour::YesOrNo Config::useColour() const       { return m_data.useColour; }

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -52,6 +52,7 @@ namespace Catch {
         Verbosity verbosity = Verbosity::Normal;
         WarnAbout::What warnings = WarnAbout::Nothing;
         ShowDurations::OrNot showDurations = ShowDurations::DefaultForReporter;
+        double minDuration = -1;
         RunTests::InWhatOrder runOrder = RunTests::InDeclarationOrder;
         UseColour::YesOrNo useColour = UseColour::Auto;
         WaitForKeypress::When waitForKeypress = WaitForKeypress::Never;
@@ -103,6 +104,7 @@ namespace Catch {
         bool warnAboutMissingAssertions() const override;
         bool warnAboutNoTests() const override;
         ShowDurations::OrNot showDurations() const override;
+        double minDuration() const override;
         RunTests::InWhatOrder runOrder() const override;
         unsigned int rngSeed() const override;
         UseColour::YesOrNo useColour() const override;

--- a/include/internal/catch_interfaces_config.h
+++ b/include/internal/catch_interfaces_config.h
@@ -69,6 +69,7 @@ namespace Catch {
         virtual int abortAfter() const = 0;
         virtual bool showInvisibles() const = 0;
         virtual ShowDurations::OrNot showDurations() const = 0;
+        virtual double minDuration() const = 0;
         virtual TestSpec const& testSpec() const = 0;
         virtual bool hasTestFilters() const = 0;
         virtual std::vector<std::string> const& getTestsOrTags() const = 0;

--- a/include/reporters/catch_reporter_bases.cpp
+++ b/include/reporters/catch_reporter_bases.cpp
@@ -41,6 +41,13 @@ namespace Catch {
         return std::string(buffer);
     }
 
+    bool shouldShowDuration( IConfig const& config, double duration ) {
+      if( config.showDurations() == ShowDurations::Always )
+        return true;
+      double min = config.minDuration();
+      return min >= 0 && duration >= min;
+    }
+
     std::string serializeFilters( std::vector<std::string> const& container ) {
         ReusableStringStream oss;
         bool first = true;

--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -25,6 +25,8 @@ namespace Catch {
     // Returns double formatted as %.3f (format expected on output)
     std::string getFormattedDuration( double duration );
 
+    bool shouldShowDuration( IConfig const &, double duration );
+
     std::string serializeFilters( std::vector<std::string> const& container );
 
     template<typename DerivedT>

--- a/include/reporters/catch_reporter_compact.cpp
+++ b/include/reporters/catch_reporter_compact.cpp
@@ -275,8 +275,9 @@ private:
         }
 
         void CompactReporter::sectionEnded(SectionStats const& _sectionStats) {
-            if (m_config->showDurations() == ShowDurations::Always) {
-                stream << getFormattedDuration(_sectionStats.durationInSeconds) << " s: " << _sectionStats.sectionInfo.name << std::endl;
+            double dur = _sectionStats.durationInSeconds;
+            if ( shouldShowDuration( *m_config, dur ) ) {
+                stream << getFormattedDuration( dur ) << " s: " << _sectionStats.sectionInfo.name << std::endl;
             }
         }
 

--- a/include/reporters/catch_reporter_console.cpp
+++ b/include/reporters/catch_reporter_console.cpp
@@ -418,8 +418,9 @@ void ConsoleReporter::sectionEnded(SectionStats const& _sectionStats) {
             stream << "\nNo assertions in test case";
         stream << " '" << _sectionStats.sectionInfo.name << "'\n" << std::endl;
     }
-    if (m_config->showDurations() == ShowDurations::Always) {
-        stream << getFormattedDuration(_sectionStats.durationInSeconds) << " s: " << _sectionStats.sectionInfo.name << std::endl;
+    double dur = _sectionStats.durationInSeconds;
+    if (shouldShowDuration(*m_config, dur)) {
+        stream << getFormattedDuration(dur) << " s: " << _sectionStats.sectionInfo.name << std::endl;
     }
     if (m_headerPrinted) {
         m_headerPrinted = false;

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEST_SOURCES
         ${SELF_TEST_DIR}/IntrospectiveTests/StringManip.tests.cpp
         ${SELF_TEST_DIR}/IntrospectiveTests/Xml.tests.cpp
         ${SELF_TEST_DIR}/IntrospectiveTests/ToString.tests.cpp
+        ${SELF_TEST_DIR}/TimingTests/Sleep.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/Approx.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/BDD.tests.cpp
         ${SELF_TEST_DIR}/UsageTests/Benchmark.tests.cpp

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -454,6 +454,9 @@ set_tests_properties(TestsInFile::InvalidTestNames-2 PROPERTIES PASS_REGULAR_EXP
 add_test(NAME RandomTestOrdering COMMAND ${PYTHON_EXECUTABLE}
   ${CATCH_DIR}/projects/TestScripts/testRandomOrder.py $<TARGET_FILE:SelfTest>)
 
+add_test(NAME TestTimeThreshold COMMAND ${PYTHON_EXECUTABLE}
+  ${CATCH_DIR}/projects/TestScripts/testTimeThreshold.py $<TARGET_FILE:SelfTest>)
+
 if (CATCH_USE_VALGRIND)
     add_test(NAME ValgrindRunTests COMMAND valgrind --leak-check=full --error-exitcode=1 $<TARGET_FILE:SelfTest>)
     add_test(NAME ValgrindListTests COMMAND valgrind --leak-check=full --error-exitcode=1 $<TARGET_FILE:SelfTest> --list-tests --verbosity high)

--- a/projects/SelfTest/TimingTests/Sleep.tests.cpp
+++ b/projects/SelfTest/TimingTests/Sleep.tests.cpp
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2011 Two Blue Cubes Ltd. All rights reserved.
+ *
+ *  Distributed under the Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#include "catch.hpp"
+
+#include <chrono>
+#include <thread>
+
+TEST_CASE( "sleep_for_100ms", "[.min_duration_test][approvals]" )
+{
+  std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+  CHECK( true );
+}
+
+TEST_CASE( "sleep_for_200ms", "[.min_duration_test][approvals]" )
+{
+  std::this_thread::sleep_for( std::chrono::milliseconds( 200 ) );
+  CHECK( true );
+}

--- a/projects/TestScripts/testTimeThreshold.py
+++ b/projects/TestScripts/testTimeThreshold.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+
+def run_tests_with_threshold(self_test_exe, threshold):
+    cmd = [self_test_exe, '--min-duration', str(threshold),
+            '[min_duration_test]']
+    process = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+    if stderr:
+        raise RuntimeError("Unexpected error output:\n" +
+                stderr.decode())
+    if process.returncode != 0:
+        raise RuntimeError("Unexpected failure to run tests\n")
+    result = stdout.split(b'\n')
+    report_lines = [s.split() for s in result if b' s: ' in s]
+    tests_reported = [l[2] for l in report_lines]
+    times_reported = [float(l[0]) for l in report_lines]
+    return tests_reported, times_reported
+
+def check_times_at_least(times_reported, minimum):
+    for time in times_reported:
+        assert time >= minimum, (
+                'Time {} was less that requested minimum {}' .format(
+                    time, minimum))
+
+def main():
+    self_test_exe, = sys.argv[1:]
+    tests, times = run_tests_with_threshold(self_test_exe, '0.15')
+    assert tests == [b'sleep_for_200ms'], (
+            "Unexpected tests reported %s" % tests)
+    check_times_at_least(times, 0.15)
+    tests,times = run_tests_with_threshold(self_test_exe, '0')
+    assert tests == [b'sleep_for_100ms', b'sleep_for_200ms'], (
+            "Unexpected tests reported %s" % tests)
+    check_times_at_least(times, 0)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/single_include/catch2/catch.hpp
+++ b/single_include/catch2/catch.hpp
@@ -4522,6 +4522,7 @@ namespace Catch {
         virtual int abortAfter() const = 0;
         virtual bool showInvisibles() const = 0;
         virtual ShowDurations::OrNot showDurations() const = 0;
+        virtual double minDuration() const = 0;
         virtual TestSpec const& testSpec() const = 0;
         virtual bool hasTestFilters() const = 0;
         virtual std::vector<std::string> const& getTestsOrTags() const = 0;


### PR DESCRIPTION
## Description
A test runner already has a --durations option to print durations.  However, this isn't entirely satisfactory.

When there are many tests, this produces output spam which makes it hard to find the test failure output.  Nevertheless, it is helpful to be informed of tests which are unusually slow.

Therefore, introduce a new option --min-duration that causes all durations above a certain threshold to be printed.  This allows slow tests to be visible without mentioning every test.

In our CI we're currently emulating this with [some ugly grep](https://github.com/CleverRaven/Cataclysm-DDA/blob/ef0197a5fb40f3937a0ad764ba097ff229cdbc4e/build-scripts/build.sh#L12) on the output, but this is a bit limited, and harder to use when running the tests outside of CI.

I've made a bunch of choices in this implementation that could have gone differently:
* `--min-duration` is independent of `--durations`.  Specifying either will cause things to be printed.  I could have rolled them into a single option that takes either a string or numeric argument, or made `--min-duration` do nothing if `--durations` was not also given.
* I made `IConfig::shouldShowDuration` a member function.  It could have been a free function, but I wouldn't know where to put it.
* `--min-duration` only affects the console and compact reporters, not e.g. the XML reporter, because I figured output spam is not an issue there.
* It's tricky to test this change, because every test in `SelfTest` is so fast that it is printed as `0.000 s`.  So for now the test just verifies that no durations are printed if a minimum of 1s is specified.  But it's written in such a way that it should do something more interesting if slower tests are ever added.