### PR TITLE
Fix build with CATCH_CONFIG_DISABLE_EXCEPTIONS enabled

### DIFF
--- a/include/internal/catch_assertionhandler.cpp
+++ b/include/internal/catch_assertionhandler.cpp
@@ -15,6 +15,7 @@
 #include "catch_interfaces_registry_hub.h"
 #include "catch_capture_matchers.h"
 #include "catch_run_context.h"
+#include "catch_enforce.h"
 
 namespace Catch {
 

--- a/include/internal/catch_interfaces_exception.h
+++ b/include/internal/catch_interfaces_exception.h
@@ -46,6 +46,9 @@ namespace Catch {
             {}
 
             std::string translate( ExceptionTranslators::const_iterator it, ExceptionTranslators::const_iterator itEnd ) const override {
+#if defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
+                return "";
+#else
                 try {
                     if( it == itEnd )
                         std::rethrow_exception(std::current_exception());
@@ -55,6 +58,7 @@ namespace Catch {
                 catch( T& ex ) {
                     return m_translateFunction( ex );
                 }
+#endif
             }
 
         protected:


### PR DESCRIPTION
Tested by building our program that consumes Catch2 with `-fno-exceptions`.

The #include change is a little abstract, so to be clear, this is the line that was failing to build (with `CATCH_ERROR not found`) https://github.com/catchorg/Catch2/blob/37cbf4a4fe7a2963f8ae6d6fe998f8ac9360cbc0/include/internal/catch_assertionhandler.cpp#L88