### PR TITLE
Clang-format configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+---
+AccessModifierOffset: '-4'
+AlignEscapedNewlines: Left
+AllowAllConstructorInitializersOnNextLine: 'true'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakConstructorInitializers: AfterColon
+ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
+DerivePointerAlignment: 'false'
+FixNamespaceComments: 'true'
+IncludeBlocks: Regroup
+IndentCaseLabels: 'false'
+IndentPPDirectives: AfterHash
+IndentWidth: '4'
+Language: Cpp
+NamespaceIndentation: All
+PointerAlignment: Left
+SpaceBeforeCtorInitializerColon: 'false'
+SpaceInEmptyParentheses: 'false'
+SpacesInParentheses: 'true'
+Standard: Cpp11
+TabWidth: '4'
+UseTab: Never
+
+...


### PR DESCRIPTION
##  Description

Initial `.clang-format` file, open for discussion. The config doesn't contain much as the defaults fit most cases already. Documentation of all options is available [here](https://clang.llvm.org/docs/ClangFormatStyleOptions.html).

## Settings to discuss / change

- [x] :question:  `NamespaceIndentation`: Indention of namespaces – `All`, `Inner` or `None`?
- [x] :question: `IndentPPDirectives`: Indention of proprocessor directives

## GitHub Issues

#1182 