### PR TITLE
Create a BUILD file for compatibility with bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Build
 cmake-build-*
 benchmark-dir
 .conan/test_package/build
+bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,10 @@
+# Load the cc_library rule.
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# Header-only rule to export catch2/catch.hpp.
+cc_library(
+  name = "catch2",
+  hdrs = ["single_include/catch2/catch.hpp"],
+  visibility = ["//visibility:public"],
+  includes = ["single_include/"],
+)


### PR DESCRIPTION
With this change, it's much easier for bazel projects to depend on
Catch. They just need to add:
  - In the workspace:
  ```
http_archive(
    name = "com_github_catchorg_catch2",
    urls = ["https://github.com/catchorg/Catch2/archive/v2.12.1.tar.gz"],
    strip_prefix = "Catch2-2.12.1",
    sha256 = "e5635c082282ea518a8dd7ee89796c8026af8ea9068cd7402fb1615deacd91c3",
)
  ```
  Or the appropriate version/sha256.
  - For the tests, assuming that `test_main.cc` contains the
  `CATCH_CONFIG_MAIN`:
  ```
cc_library(
    name = "test_main",
    srcs = ["test_main.cc"],
    deps = ["@com_github_catchorg_catch2//:catch2"],
)
```