### PR TITLE
Fix compilation failure when using libstdc++10

### DIFF
--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -469,20 +469,27 @@ namespace Catch {
 #endif // CATCH_CONFIG_ENABLE_VARIANT_STRINGMAKER
 
 namespace Catch {
-    struct not_this_one {}; // Tag type for detecting which begin/ end are being selected
+    namespace detail {
+        // Import begin/ end from std here
+        using std::begin;
+        using std::end;
 
-    // Import begin/ end from std here so they are considered alongside the fallback (...) overloads in this namespace
-    using std::begin;
-    using std::end;
+        template <typename...>
+        struct void_type {
+            using type = void;
+        };
 
-    not_this_one begin( ... );
-    not_this_one end( ... );
+        template <typename T, typename = void>
+        struct is_range_impl : std::false_type {
+        };
+
+        template <typename T>
+        struct is_range_impl<T, typename void_type<decltype(begin(std::declval<T>()))>::type> : std::true_type {
+        };
+    } // namespace detail
 
     template <typename T>
-    struct is_range {
-        static const bool value =
-            !std::is_same<decltype(begin(std::declval<T>())), not_this_one>::value &&
-            !std::is_same<decltype(end(std::declval<T>())), not_this_one>::value;
+    struct is_range : detail::is_range_impl<T> {
     };
 
 #if defined(_MANAGED) // Managed types are never ranges

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -469,11 +469,11 @@ namespace Catch {
 #endif // CATCH_CONFIG_ENABLE_VARIANT_STRINGMAKER
 
 namespace Catch {
-    namespace detail {
-        // Import begin/ end from std here
-        using std::begin;
-        using std::end;
+    // Import begin/ end from std here
+    using std::begin;
+    using std::end;
 
+    namespace detail {
         template <typename...>
         struct void_type {
             using type = void;


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
Sorry for my poor English, I'm not a native speaker.
The failure case is published on https://wandbox.org/permlink/E3IuG3dbqTTDAwxv
Which can be fixed by this patch as https://wandbox.org/permlink/jDqVGe2TlJ8F3Q9r
This bug is caused by std::__detail::begin declared by bits/iterator_concepts.h, the function may be lookup by adl, like the case above, so here will be a matched but deleted begin, not the begin returning not_this_one
This patch fixed the bug by detecting whether expression begin(std::declval<T>()) is well-formed directly
The void_type is introduced because of issue mentioned [here](https://en.cppreference.com/w/cpp/types/void_t#Notes)

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
