### PR TITLE
Add Bazel support for the v3 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Build
 cmake-build-*
 benchmark-dir
 .conan/test_package/build
+bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,25 @@
+# Load the cc_library rule.
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# Static library, without main.
+cc_library(
+    name = "catch2",
+    hdrs = glob(["src/catch2/**/*.hpp"]),
+    srcs = glob(["src/catch2/**/*.cpp"],
+                exclude=[ "src/catch2/internal/catch_main.cpp"]),
+    visibility = ["//visibility:public"],
+    copts = ["-std=c++14"],
+    linkstatic = True,
+    includes = ["src/"],
+)
+
+# Static library, with main.
+cc_library(
+    name = "catch2_main",
+    srcs = ["src/catch2/internal/catch_main.cpp"],
+    deps = [":catch2"],
+    visibility = ["//visibility:public"],
+    linkstatic = True,
+    copts = ["-std=c++14"],
+    includes = ["src/"],
+)


### PR DESCRIPTION
This PR adds support for easily depending on catch2 v3 as a Bazel dependency.

It adds 2 targets: `catch2` and `catch2_main`, with the `_main` version depending on the `catch2` library.

I didn't try to hide the `internal` headers (well, actually I tried and failed), but I guess that's the same as CMake (they're available by default).

To create a unit test, you just have to write a `BUILD` file like:

```bazel
cc_test(
    name = "test",
    srcs = ["test.cc"],
    deps = ["@catch2//:catch2_main"],
    copts = ["-std=c++14"],
)
```