### PR TITLE
Add OverallResultsCases element to XML reporter

### DIFF
--- a/include/reporters/catch_reporter_xml.cpp
+++ b/include/reporters/catch_reporter_xml.cpp
@@ -207,6 +207,10 @@ namespace Catch {
             .writeAttribute( "successes", testGroupStats.totals.assertions.passed )
             .writeAttribute( "failures", testGroupStats.totals.assertions.failed )
             .writeAttribute( "expectedFailures", testGroupStats.totals.assertions.failedButOk );
+        m_xml.scopedElement( "OverallResultsCases")
+            .writeAttribute( "successes", testGroupStats.totals.testCases.passed )
+            .writeAttribute( "failures", testGroupStats.totals.testCases.failed )
+            .writeAttribute( "expectedFailures", testGroupStats.totals.testCases.failedButOk );
         m_xml.endElement();
     }
 
@@ -216,6 +220,10 @@ namespace Catch {
             .writeAttribute( "successes", testRunStats.totals.assertions.passed )
             .writeAttribute( "failures", testRunStats.totals.assertions.failed )
             .writeAttribute( "expectedFailures", testRunStats.totals.assertions.failedButOk );
+        m_xml.scopedElement( "OverallResultsCases")
+            .writeAttribute( "successes", testRunStats.totals.testCases.passed )
+            .writeAttribute( "failures", testRunStats.totals.testCases.failed )
+            .writeAttribute( "expectedFailures", testRunStats.totals.testCases.failedButOk );
         m_xml.endElement();
     }
 

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -16376,6 +16376,8 @@ loose text artifact
       <OverallResult success="true"/>
     </TestCase>
     <OverallResults successes="1564" failures="149" expectedFailures="21"/>
+    <OverallResultsCases successes="226" failures="86" expectedFailures="4"/>
   </Group>
   <OverallResults successes="1564" failures="148" expectedFailures="21"/>
+  <OverallResultsCases successes="226" failures="86" expectedFailures="4"/>
 </Catch>


### PR DESCRIPTION
## Description

This adds a small additional output to the XML reporter: the number of passed/failed/expected-failed test *cases* and not just assertions. I am working with a team that is building somewhat of a system test, rather than unit test, with Catch2, and some assertions are called in a loop making the total assertion count not as helpful as the total test case count.

The approval tests appear to fail but for apparently unrelated reasons?