### PR TITLE
Fix for macOS on ARM

### DIFF
--- a/include/internal/catch_debugger.h
+++ b/include/internal/catch_debugger.h
@@ -17,7 +17,11 @@ namespace Catch {
 
 #ifdef CATCH_PLATFORM_MAC
 
-    #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+    #if defined(__i386__) || defined(__x86_64__)
+        #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+    #elif defined(__aarch64__)
+        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+    #endif
 
 #elif defined(CATCH_PLATFORM_IPHONE)
 


### PR DESCRIPTION
These changes resolve compilation issues for the Catch headers when compiling with macOS on ARM, which is not x86/x86_64 based. The changes are similar to the "elif defined(CATCH_PLATFORM_IPHONE)" logic later in these files.  ARM based macOS machines were already announced at Apple's WWDC.

The error being resolved looks like the following:
```
catch.hpp:8237:13: error: invalid token in expression
            CATCH_BREAK_INTO_DEBUGGER();
            ^
catch.hpp:7948:83: note: expanded from macro 'CATCH_BREAK_INTO_DEBUGGER'
        #define CATCH_BREAK_INTO_DEBUGGER() []{ if( Catch::isDebuggerActive() ) { CATCH_TRAP(); } }()
                                                                                  ^
catch.hpp:7913:34: note: expanded from macro 'CATCH_TRAP'
    #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
                                 ^
<inline asm>:1:6: note: instantiated into assembly here
        int $3
            ^
```