### PR TITLE
Escaping "*" ("times") to fix Markdown presentation

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -24,9 +24,9 @@ TEST_CASE("Generators") {
 }
 ```
 
-The `SECTION` "one" will be run 4 (2*2) times, because the outer
+The `SECTION` "one" will be run 4 (2\*2) times, because the outer
 generator has 2 elements in it, and the inner generator also has 2
-elements in it. The `SECTION` "two" will be run 6 (2*3) times. The
+elements in it. The `SECTION` "two" will be run 6 (2\*3) times. The
 sections will be run in order "one", "one", "two", "two", "two", "one",
 ...
 
@@ -34,7 +34,7 @@ It is also possible to have multiple generators at the same level of
 nesting. The result is the same as when generators are inside nested
 sections, that is, the result will be a cartesian product of all
 elements. This means that in the snippet below, the test case will be
-run 6 (2*3) times.
+run 6 (2\*3) times.
 
 ```cpp
 TEST_CASE("Generators") {


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description

If you want to write "2\*2" you need to escape the asterisk, or else it becomes formatting in Markdown.

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues

None that I know of.

<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
