### PR TITLE
Better support for stringifying pointer types

### DIFF
--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -279,7 +279,26 @@ namespace Catch {
     template <typename T>
     struct StringMaker<T*> {
         template <typename U>
-        static std::string convert(U* p) {
+        static typename std::enable_if<
+            ::Catch::Detail::IsStreamInsertable<U>::value,
+            std::string>::type
+        convert(U* p) {
+            if (p) {
+                ReusableStringStream rss;
+                // NB: call using the function-like syntax to avoid ambiguity with
+                // user-defined templated operator<< under clang.
+                rss.operator<<(*p);
+                return rss.str();
+            } else {
+                return "nullptr";
+            }
+        }
+
+        template <typename U>
+        static typename std::enable_if<
+            !::Catch::Detail::IsStreamInsertable<U>::value,
+            std::string>::type
+        convert(U* p) {
             if (p) {
                 return ::Catch::Detail::rawMemoryToString(p);
             } else {

--- a/projects/SelfTest/UsageTests/ToStringWhich.tests.cpp
+++ b/projects/SelfTest/UsageTests/ToStringWhich.tests.cpp
@@ -71,6 +71,12 @@ TEST_CASE( "stringify( has_operator )", "[toString]" ) {
     REQUIRE( ::Catch::Detail::stringify( item ) == "operator<<( has_operator )" );
 }
 
+// Uses the operator also for pointer types
+TEST_CASE( "stringify( &has_operator )", "[toString]" ) {
+    has_operator item;
+    REQUIRE( ::Catch::Detail::stringify( &item ) == "operator<<( has_operator )" );
+}
+
 // Call the stringmaker
 TEST_CASE( "stringify( has_maker )", "[toString]" ) {
     has_maker item;


### PR DESCRIPTION
When stringifying a pointer to a type, and there's an ostream operator<< for
that type, use it instead of printing a hex address.