### PR TITLE
Silence a -Wsign-conversio warning in Clara under GCC

### DIFF
--- a/src/catch2/internal/catch_clara.hpp
+++ b/src/catch2/internal/catch_clara.hpp
@@ -25,10 +25,19 @@
   #pragma clang diagnostic ignored "-Wdeprecated"
 #endif
 
+#if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+
 #include <catch2/internal/catch_clara_upstream.hpp>
 
 #if defined(__clang__)
   #pragma clang diagnostic pop
+#endif
+
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
 #endif
 
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

I upgraded to catch 3, including `<catch2/catch_session.hpp>` caused a warning under GCC 8 in clara,
this silences that warning

```
 catch_clara_upstream.hpp:495:77: error: conversion to 'long unsigned int' from '__gnu_cxx::__normal_iterator<const std::__cxx11::basic_string<char>*, std::vector<std::__cxx11::basic_string<char> > >::difference_type' {aka 'long int'} may change the sign of the result [-Werror=sign-conversion]
         auto count() const -> size_t { return m_tokenBuffer.size() + (itEnd - it); }
                                                                      ~~~~~~~^~~~~
```