### PR TITLE
Silence a warning in clara under clang

### DIFF
--- a/src/catch2/internal/catch_clara.hpp
+++ b/src/catch2/internal/catch_clara.hpp
@@ -23,6 +23,7 @@
   #pragma clang diagnostic ignored "-Wexit-time-destructors"
   #pragma clang diagnostic ignored "-Wshadow"
   #pragma clang diagnostic ignored "-Wdeprecated"
+  #pragma clang diagnostic ignored "-Wextra-semi"
 #endif
 
 #if defined(__GNUC__)


### PR DESCRIPTION
## Description

internal/catch_clara_upstream.hpp:863:10: error: extra ';' after member function definition [-Werror,-Wextra-semi]

