### PR TITLE
Update catch_reporter_tap.hpp

### DIFF
--- a/include/reporters/catch_reporter_tap.hpp
+++ b/include/reporters/catch_reporter_tap.hpp
@@ -23,14 +23,15 @@ namespace Catch {
 
         using StreamingReporterBase::StreamingReporterBase;
 
+        TAPReporter( ReporterConfig const& config )
+        	: StreamingReporterBase( config ) {
+            m_reporterPrefs.shouldReportAllAssertions = true;
+        }
+
         ~TAPReporter() override;
 
         static std::string getDescription() {
             return "Reports test results in TAP format, suitable for test harnesses";
-        }
-
-        ReporterPreferences getPreferences() const override {
-            return m_reporterPrefs;
         }
 
         void noMatchingTestCases( std::string const& spec ) override {
@@ -203,16 +204,15 @@ namespace Catch {
                     return;
                 }
 
-                // using messages.end() directly (or auto) yields compilation error:
-                std::vector<MessageInfo>::const_iterator itEnd = messages.end();
-                const std::size_t N = static_cast<std::size_t>( std::distance( itMessage, itEnd ) );
+                const auto itEnd = messages.cend();
+                const auto N = static_cast<std::size_t>( std::distance( itMessage, itEnd ) );
 
                 {
                     Colour colourGuard( colour );
                     stream << " with " << pluralise( N, "message" ) << ":";
                 }
 
-                for(; itMessage != itEnd; ) {
+                while( itMessage != itEnd ) {
                     // If this assertion is a warning ignore any INFO messages
                     if( printInfoMessages || itMessage->type != ResultWas::Info ) {
                         stream << " '" << itMessage->message << "'";
@@ -220,7 +220,9 @@ namespace Catch {
                             Colour colourGuard( dimColour() );
                             stream << " and";
                         }
+                        continue;
                     }
+                    ++itMessage;
                 }
             }
 
@@ -234,10 +236,9 @@ namespace Catch {
         };
 
         void printTotals( const Totals& totals ) const {
+            stream << "1.." << totals.assertions.total();
             if( totals.testCases.total() == 0 ) {
-                stream << "1..0 # Skipped: No tests ran.";
-            } else {
-                stream << "1.." << counter;
+                stream << " # Skipped: No tests ran.";
             }
         }
     };


### PR DESCRIPTION


<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
Modified the reporter to collect all tests run, not just failures. Needed to meet the TAP spec.
Discovered issue when I was getting weird results from [sublime-test-runner](https://github.com/accerqueira/sublime-test-runner) this fixes it. Fix was mentioned in #1264 .

Also made the following changes:
Removed extraneous preferences function (handled by parent)
Incorporated fix from 3d9e7db2e0fff8fc2edcf59d24351f3937e3ac62
Simplified total printing
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
