### PR TITLE
Fix CMake add test helper for CMake 3.18.0

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -189,24 +189,29 @@ function(ParseAndAddCatchTests_ParseFile SourceFile TestTarget)
             # Escape commas in the test spec
             string(REPLACE "," "\\," Name ${Name})
 
+            # Work around CMake 3.18.0 change in `add_test()`, before the escaped quotes were neccessary,
+            # beginning with CMake 3.18.0 the escaped double quotes confuse the call
+            if(${CMAKE_VERSION} VERSION_LESS "3.18")
+                set(CTestName "\"${CTestName}\"")
+            endif()
             # Add the test and set its properties
-            add_test(NAME "\"${CTestName}\"" COMMAND ${OptionalCatchTestLauncher} $<TARGET_FILE:${TestTarget}> ${Name} ${AdditionalCatchParameters})
+            add_test(NAME "${CTestName}" COMMAND ${OptionalCatchTestLauncher} $<TARGET_FILE:${TestTarget}> ${Name} ${AdditionalCatchParameters})
             # Old CMake versions do not document VERSION_GREATER_EQUAL, so we use VERSION_GREATER with 3.8 instead
             if(PARSE_CATCH_TESTS_NO_HIDDEN_TESTS AND ${HiddenTagFound} AND ${CMAKE_VERSION} VERSION_GREATER "3.8")
                 ParseAndAddCatchTests_PrintDebugMessage("Setting DISABLED test property")
-                set_tests_properties("\"${CTestName}\"" PROPERTIES DISABLED ON)
+                set_tests_properties("${CTestName}" PROPERTIES DISABLED ON)
             else()
-                set_tests_properties("\"${CTestName}\"" PROPERTIES FAIL_REGULAR_EXPRESSION "No tests ran"
+                set_tests_properties("${CTestName}" PROPERTIES FAIL_REGULAR_EXPRESSION "No tests ran"
                                                         LABELS "${Labels}")
             endif()
             set_property(
               TARGET ${TestTarget}
               APPEND
-              PROPERTY ParseAndAddCatchTests_TESTS "\"${CTestName}\"")
+              PROPERTY ParseAndAddCatchTests_TESTS "${CTestName}")
             set_property(
               SOURCE ${SourceFile}
               APPEND
-              PROPERTY ParseAndAddCatchTests_TESTS "\"${CTestName}\"")
+              PROPERTY ParseAndAddCatchTests_TESTS "${CTestName}")
         endif()
 
 


### PR DESCRIPTION


## Description
With CMake 3.18.0 the `add_test(NAME)` handling changed. The escaped
double quotes confuse the new call. Work around this upstream change.

## GitHub Issues
Closes: https://github.com/catchorg/Catch2/issues/1984
