### PR TITLE
Update ParseAndAddCatchTests.cmake for cmake 3.18.1

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -190,8 +190,8 @@ function(ParseAndAddCatchTests_ParseFile SourceFile TestTarget)
             string(REPLACE "," "\\," Name ${Name})
 
             # Work around CMake 3.18.0 change in `add_test()`, before the escaped quotes were neccessary,
-            # beginning with CMake 3.18.0 the escaped double quotes confuse the call
-            if(${CMAKE_VERSION} VERSION_LESS "3.18")
+            # only with CMake 3.18.0 the escaped double quotes confuse the call. This change is reverted in 3.18.1
+            if(NOT ${CMAKE_VERSION} VERSION_EQUAL "3.18")
                 set(CTestName "\"${CTestName}\"")
             endif()
             # Add the test and set its properties


### PR DESCRIPTION
## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

https://cmake.org/cmake/help/v3.18/release/3.18.html#id1

In CMake 3.18.0 the add_test() command learned to support special characters in test names. This was accidentally left out of its release notes. Unfortunately the fix breaks existing projects that were using manual quoting or escaping to work around the prior limitation. This fix has been reverted in 3.18.1, but may be re-introduced in future versions of CMake with a policy for compatibility.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
