### PR TITLE
Issue 1992: Better c++17 std::byte detection

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -240,7 +240,10 @@
 
   // Check if byte is available and usable
   #  if __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
-  #    define CATCH_INTERNAL_CONFIG_CPP17_BYTE
+  #    include <cstddef>
+  #    if __cpp_lib_byte > 0
+  #      define CATCH_INTERNAL_CONFIG_CPP17_BYTE
+  #    endif
   #  endif // __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
 
   // Check if variant is available and usable


### PR DESCRIPTION
This fixed buld errors for ubuntu-16 + clang and similar situations
where C++17 is supported in the compiler but not the default
C++ standard library.

## Description
Clang packages on ubuntu-16 use the clang compiler which supports C++17, but use the system-default C++ library which does not fully support C++17.  This results in compile errors where Catch2 mis-identifies support for std::bytes.

## GitHub Issues
Closes #1992