### PR TITLE
Support sentinel-based ranges in default stringify

### DIFF
--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -309,8 +309,8 @@ namespace Catch {
 #endif
 
     namespace Detail {
-        template<typename InputIterator>
-        std::string rangeToString(InputIterator first, InputIterator last) {
+        template<typename InputIterator, typename Sentinel = InputIterator>
+        std::string rangeToString(InputIterator first, Sentinel last) {
             ReusableStringStream rss;
             rss << "{ ";
             if (first != last) {

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -1203,6 +1203,7 @@ CmdLine.tests.cpp:<line number>: passed: config.benchmarkWarmupTime == 10 for: 1
 Misc.tests.cpp:<line number>: passed: std::tuple_size<TestType>::value >= 1 for: 3 >= 1
 Misc.tests.cpp:<line number>: passed: std::tuple_size<TestType>::value >= 1 for: 2 >= 1
 Misc.tests.cpp:<line number>: passed: std::tuple_size<TestType>::value >= 1 for: 1 >= 1
+ToString.tests.cpp:<line number>: passed: Catch::Detail::stringify(UsesSentinel{}) == "{  }" for: "{  }" == "{  }"
 Decomposition.tests.cpp:<line number>: failed: truthy(false) for: Hey, its truthy!
 Matchers.tests.cpp:<line number>: failed: testStringForMatching(), Matches("this STRING contains 'abc' as a substring") for: "this string contains 'abc' as a substring" matches "this STRING contains 'abc' as a substring" case sensitively
 Matchers.tests.cpp:<line number>: failed: testStringForMatching(), Matches("contains 'abc' as a substring") for: "this string contains 'abc' as a substring" matches "contains 'abc' as a substring" case sensitively

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -1380,6 +1380,6 @@ due to unexpected exception with message:
   Why would you throw a std::string?
 
 ===============================================================================
-test cases:  321 |  247 passed |  70 failed |  4 failed as expected
-assertions: 1758 | 1606 passed | 131 failed | 21 failed as expected
+test cases:  322 |  248 passed |  70 failed |  4 failed as expected
+assertions: 1759 | 1607 passed | 131 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -8896,6 +8896,17 @@ with expansion:
   1 >= 1
 
 -------------------------------------------------------------------------------
+Range type with sentinel
+-------------------------------------------------------------------------------
+ToString.tests.cpp:<line number>
+...............................................................................
+
+ToString.tests.cpp:<line number>: PASSED:
+  CHECK( Catch::Detail::stringify(UsesSentinel{}) == "{  }" )
+with expansion:
+  "{  }" == "{  }"
+
+-------------------------------------------------------------------------------
 Reconstruction should be based on stringification: #914
 -------------------------------------------------------------------------------
 Decomposition.tests.cpp:<line number>
@@ -14127,6 +14138,6 @@ Misc.tests.cpp:<line number>
 Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
-test cases:  321 |  231 passed |  86 failed |  4 failed as expected
-assertions: 1775 | 1606 passed | 148 failed | 21 failed as expected
+test cases:  322 |  232 passed |  86 failed |  4 failed as expected
+assertions: 1776 | 1607 passed | 148 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="132" tests="1776" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="132" tests="1777" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="filters" value="~[!nonportable]~[!benchmark]~[approvals]"/>
       <property name="random-seed" value="1"/>
@@ -1045,6 +1045,7 @@ Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Product with differing arities - std::tuple&lt;int, double, float>" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Product with differing arities - std::tuple&lt;int, double>" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Product with differing arities - std::tuple&lt;int>" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="Range type with sentinel" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Reconstruction should be based on stringification: #914" time="{duration}" status="run">
       <failure message="truthy(false)" type="CHECK">
 FAILED:

--- a/projects/SelfTest/Baselines/sonarqube.sw.approved.txt
+++ b/projects/SelfTest/Baselines/sonarqube.sw.approved.txt
@@ -162,6 +162,7 @@
   </file>
   <file path="projects/<exe-name>/IntrospectiveTests/ToString.tests.cpp">
     <testCase name="Directly creating an EnumInfo" duration="{duration}"/>
+    <testCase name="Range type with sentinel" duration="{duration}"/>
     <testCase name="parseEnums/No enums" duration="{duration}"/>
     <testCase name="parseEnums/One enum value" duration="{duration}"/>
     <testCase name="parseEnums/Multiple enum values" duration="{duration}"/>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -10962,6 +10962,17 @@ Nor would this
       </Expression>
       <OverallResult success="true"/>
     </TestCase>
+    <TestCase name="Range type with sentinel" filename="projects/<exe-name>/IntrospectiveTests/ToString.tests.cpp" >
+      <Expression success="true" type="CHECK" filename="projects/<exe-name>/IntrospectiveTests/ToString.tests.cpp" >
+        <Original>
+          Catch::Detail::stringify(UsesSentinel{}) == "{  }"
+        </Original>
+        <Expanded>
+          "{  }" == "{  }"
+        </Expanded>
+      </Expression>
+      <OverallResult success="true"/>
+    </TestCase>
     <TestCase name="Reconstruction should be based on stringification: #914" tags="[!hide][.][Decomposition][failing]" filename="projects/<exe-name>/UsageTests/Decomposition.tests.cpp" >
       <Expression success="false" type="CHECK" filename="projects/<exe-name>/UsageTests/Decomposition.tests.cpp" >
         <Original>
@@ -16711,9 +16722,9 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="1606" failures="149" expectedFailures="21"/>
-    <OverallResultsCases successes="231" failures="86" expectedFailures="4"/>
+    <OverallResults successes="1607" failures="149" expectedFailures="21"/>
+    <OverallResultsCases successes="232" failures="86" expectedFailures="4"/>
   </Group>
-  <OverallResults successes="1606" failures="148" expectedFailures="21"/>
-  <OverallResultsCases successes="231" failures="86" expectedFailures="4"/>
+  <OverallResults successes="1607" failures="148" expectedFailures="21"/>
+  <OverallResultsCases successes="232" failures="86" expectedFailures="4"/>
 </Catch>

--- a/projects/SelfTest/IntrospectiveTests/ToString.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/ToString.tests.cpp
@@ -8,7 +8,6 @@ struct UsesSentinel {
     using const_iterator = int const*;
     using const_sentinel = std::nullptr_t;
 
-    bool operator==(int) const { return false; }
     const_iterator begin() const { return nullptr; }
     const_iterator end() const { return nullptr; }
 };
@@ -50,5 +49,5 @@ TEST_CASE( "Directly creating an EnumInfo" ) {
 }
 
 TEST_CASE("Range type with sentinel") {
-    CHECK( UsesSentinel{} == 0 );
+    CHECK( Catch::Detail::stringify(UsesSentinel{}) == "{  }" );
 }

--- a/projects/SelfTest/IntrospectiveTests/ToString.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/ToString.tests.cpp
@@ -4,6 +4,14 @@
 
 enum class EnumClass3 { Value1, Value2, Value3, Value4 };
 
+struct UsesSentinel {
+    using const_iterator = int const*;
+    using const_sentinel = std::nullptr_t;
+
+    bool operator==(int) const { return false; }
+    const_iterator begin() const { return nullptr; }
+    const_iterator end() const { return nullptr; }
+};
 
 TEST_CASE( "parseEnums", "[Strings][enums]" ) {
     using namespace Catch::Matchers;
@@ -39,4 +47,8 @@ TEST_CASE( "Directly creating an EnumInfo" ) {
     CHECK( enumInfo->lookup(0) == "Value1" );
     CHECK( enumInfo->lookup(1) == "Value2" );
     CHECK( enumInfo->lookup(3) == "{** unexpected enum value **}" );
+}
+
+TEST_CASE("Range type with sentinel") {
+    CHECK( UsesSentinel{} == 0 );
 }


### PR DESCRIPTION
Fix for issue #2003 

- Enhances `rangeToString` to work with a separate iterator and sentinel type
- Adds a test to ensure this compiles