### PR TITLE
Make experimental capture work on Windows with read-write temp file b…

### DIFF
--- a/include/internal/catch_output_redirect.cpp
+++ b/include/internal/catch_output_redirect.cpp
@@ -66,7 +66,7 @@ namespace Catch {
         if (tmpnam_s(m_buffer)) {
             CATCH_RUNTIME_ERROR("Could not get a temp filename");
         }
-        if (fopen_s(&m_file, m_buffer, "w")) {
+        if (fopen_s(&m_file, m_buffer, "w+")) {
             char buffer[100];
             if (strerror_s(buffer, errno)) {
                 CATCH_RUNTIME_ERROR("Could not translate errno to a string");


### PR DESCRIPTION
## Description
The `OutputRedirect` class guarded under the `CATCH_CONFIG_EXPERIMENTAL_REDIRECT` compiler flag allows test reporters to capture `fprintf()` output to `stdout` and `stderr` rather than just the higher-level `std::cout`, `std::cerr`, and `std::clog` streams.

It doesn't work on Windows.

The easiest way to see this in action is to run a very primitive test case like the following:

```cpp
TEST_CASE("output capture works")
{
    printf("Hello world\n");
    fprintf(stderr, "So many errors\n");
    std::cout << "At least this should work, right?" << std::endl;
}
```

When using a reporter that should be capturing output (compiling with the flag set), it's empty--not even `cout` works as expected:

```
C:\Users\travisw\source\repos\CatchReporterTest\x64\Debug>CatchReporterTest.exe -r junit
```
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="CatchReporterTest.exe" errors="0" failures="0" tests="0" hostname="tbd" time="0.018109" timestamp="2020-09-01T00:29:24Z">
    <system-out/>
    <system-err/>
  </testsuite>
</testsuites>
```

Investigating this, the temporary files created for Windows are opened with write-only access. We successfully write all the data to the temp files that we should, but when we attempt to read it back, we get nothing. This is because `"w"` is provided as the access modifier instead of the more appropriate `"w+"` modifier that allows read.

Making this simple change, test cases produce the expected output:
```
C:\Users\travisw\source\repos\CatchReporterTest\x64\Debug>CatchReporterTest.exe -r junit
```
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="CatchReporterTest.exe" errors="0" failures="0" tests="0" hostname="tbd" time="0.007952" timestamp="2020-09-01T00:31:23Z">
    <testcase classname="CatchReporterTest.exe.global" name="output capture works" time="0.006514" status="run">
      <system-out>
Hello world
At least this should work, right?
      </system-out>
      <system-err>
So many errors
      </system-err>
    </testcase>
    <system-out>
Hello world
At least this should work, right?
    </system-out>
    <system-err>
So many errors
    </system-err>
  </testsuite>
</testsuites>
```

## GitHub Issues
