### PR TITLE
Fix unintended colouring of user's stderr on POSIX

### DIFF
--- a/src/catch2/internal/catch_console_colour.cpp
+++ b/src/catch2/internal/catch_console_colour.cpp
@@ -157,8 +157,10 @@ namespace {
 
     private:
         void setColour( const char* _escapeCode ) {
+            // The escape sequence must be flushed to console, otherwise if
+            // stdin and stderr are intermixed, we'd get accidentally coloured output.
             getCurrentContext().getConfig()->stream()
-                << '\033' << _escapeCode;
+                << '\033' << _escapeCode << std::flush;
         }
     };
 


### PR DESCRIPTION
## Description
At some places, the colour reset code is printed after a newline. Since the default output buffering to console is line-based, the reset code is not actually written out. If messages from user code are printed to stderr (different stream, same console), they are printed before the colour reset code, and thus they are coloured.

Explicitly flushing the stream after writing the colour escape code solves this.
