### PR TITLE
Add the static library Catch2::Main for CMake and bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,8 +3,15 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 # Header-only rule to export catch2/catch.hpp.
 cc_library(
-  name = "catch2",
-  hdrs = ["single_include/catch2/catch.hpp"],
-  visibility = ["//visibility:public"],
-  includes = ["single_include/"],
+    name = "catch2",
+    hdrs = ["single_include/catch2/catch.hpp"],
+    includes = ["single_include/"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "catch2_main",
+    srcs = ["src/catch_with_main.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:catch2"],
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,14 @@ endif()
 # provide a namespaced alias for clients to 'link' against if catch is included as a sub-project
 add_library(Catch2::Catch2 ALIAS Catch2)
 
+if (NOT NOT_SUBPROJECT)
+    add_library(Catch2Main src/catch_with_main.cpp)
+
+    target_link_libraries(Catch2Main Catch2)
+
+    add_library(Catch2::Main ALIAS Catch2Main)
+endif ()
+
 # Only perform the installation steps when Catch is not being used as
 # a subproject via `add_subdirectory`, or the destinations will break,
 # see https://github.com/catchorg/Catch2/issues/1373

--- a/docs/slow-compiles.md
+++ b/docs/slow-compiles.md
@@ -64,6 +64,18 @@ tests-factorial.cpp:11: failed: Factorial(0) == 1 for: 0 == 1
 Failed 1 test case, failed 1 assertion.
 ```
 
+## Using the static library Catch2Main
+
+Catch also provides a static library that implements the runner. When
+Catch2 is included with `add_subdirectory` using CMake, it is possible to simply
+link against this library which also provides the include path for the header.
+
+```cmake
+add_executable(tests-factorial tests-factorial.cpp)
+
+target_link_libraries(tests-factorial Catch2::Main)
+```
+
 ## Other possible solutions
 You can also opt to sacrifice some features in order to speed-up Catch's compilation times. For details see the [documentation on Catch's compile-time configuration](configuration.md#other-toggles).
 

--- a/docs/slow-compiles.md
+++ b/docs/slow-compiles.md
@@ -65,15 +65,25 @@ Failed 1 test case, failed 1 assertion.
 ```
 
 ## Using the static library Catch2Main
-
-Catch also provides a static library that implements the runner. When
-Catch2 is included with `add_subdirectory` using CMake, it is possible to simply
-link against this library which also provides the include path for the header.
-
+Catch also provides a static library that implements the runner.
+### CMake
 ```cmake
 add_executable(tests-factorial tests-factorial.cpp)
 
 target_link_libraries(tests-factorial Catch2::Main)
+```
+### bazel
+```python
+cc_test(
+    name = "hello_world_test",
+    srcs = [
+        "test/hello_world_test.cpp",
+    ],
+    deps = [
+        "lib_hello_world",
+        "@catch2//:catch2_main",
+    ],
+)
 ```
 
 ## Other possible solutions

--- a/src/catch_with_main.cpp
+++ b/src/catch_with_main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>


### PR DESCRIPTION
## Description

Starting of from (the somehow inactive PR) https://github.com/catchorg/Catch2/pull/1423:
1. add a new bazel target `catch2_main`
2. add documentation how to use bazel target
3. update to current master

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
