### PR TITLE
add fuzzer for TestSpecParser and XmlWriter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ cmake-build-*
 benchmark-dir
 .conan/test_package/build
 bazel-*
+build-fuzzers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include(CMakeDependentOption)
 cmake_dependent_option(CATCH_BUILD_TESTING "Build the SelfTest project" ON "CATCH_DEVELOPMENT_BUILD" OFF)
 cmake_dependent_option(CATCH_BUILD_EXAMPLES "Build code examples" OFF "CATCH_DEVELOPMENT_BUILD" OFF)
 cmake_dependent_option(CATCH_BUILD_EXTRA_TESTS "Build extra tests" OFF "CATCH_DEVELOPMENT_BUILD" OFF)
+cmake_dependent_option(CATCH_BUILD_FUZZERS "Build fuzzers" OFF "CATCH_DEVELOPMENT_BUILD" OFF)
 cmake_dependent_option(CATCH_ENABLE_COVERAGE "Generate coverage for codecov.io" OFF "CATCH_DEVELOPMENT_BUILD" OFF)
 cmake_dependent_option(CATCH_ENABLE_WERROR "Enables Werror during build" ON "CATCH_DEVELOPMENT_BUILD" OFF)
 
@@ -73,6 +74,9 @@ if(CATCH_BUILD_EXTRA_TESTS)
     add_subdirectory(tests/ExtraTests)
 endif()
 
+if(CATCH_BUILD_FUZZERS)
+    add_subdirectory(fuzzing)
+endif()
 
 if (CATCH_DEVELOPMENT_BUILD)
     add_warnings_to_targets("${CATCH_WARNING_TARGETS}")

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -7,11 +7,14 @@
 add_library(fuzzhelper NullOStream.h NullOStream.cpp)
 target_link_libraries(fuzzhelper PUBLIC Catch2::Catch2)
 
+# use C++17 so we can get string_view
+target_compile_features(fuzzhelper PUBLIC cxx_std_17)
+
 # This should be possible to set from the outside to be oss-fuzz compatible,
 # fix later. For now, target libFuzzer only.
 target_link_options(fuzzhelper PUBLIC "-fsanitize=fuzzer")
 
-foreach(fuzzer TestSpecParser XmlWriter)
+foreach(fuzzer TestSpecParser XmlWriter textflow)
 add_executable(fuzz_${fuzzer} fuzz_${fuzzer}.cpp)
 target_link_libraries(fuzz_${fuzzer} PRIVATE fuzzhelper)
 endforeach()

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -1,0 +1,17 @@
+# License: Boost 1.0
+# By Paul Dreik 2020
+
+# add a library that brings in the main() function from libfuzzer
+# and has all the dependencies, so the individual fuzzers can be
+# added one line each.
+add_library(fuzzhelper NullOStream.h NullOStream.cpp)
+target_link_libraries(fuzzhelper PUBLIC Catch2::Catch2)
+
+# This should be possible to set from the outside to be oss-fuzz compatible,
+# fix later. For now, target libFuzzer only.
+target_link_options(fuzzhelper PUBLIC "-fsanitize=fuzzer")
+
+foreach(fuzzer TestSpecParser XmlWriter)
+add_executable(fuzz_${fuzzer} fuzz_${fuzzer}.cpp)
+target_link_libraries(fuzz_${fuzzer} PRIVATE fuzzhelper)
+endforeach()

--- a/fuzzing/NullOStream.cpp
+++ b/fuzzing/NullOStream.cpp
@@ -1,0 +1,10 @@
+#include "NullOStream.h"
+
+void NullOStream::avoidOutOfLineVirtualCompilerWarning()
+{
+}
+
+int NullStreambuf::overflow(int c){
+    setp(dummyBuffer, dummyBuffer + sizeof(dummyBuffer));
+    return (c == traits_type::eof()) ? '\0' : c;
+}

--- a/fuzzing/NullOStream.h
+++ b/fuzzing/NullOStream.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <iostream>
+
+// from https://stackoverflow.com/a/8244052
+class NullStreambuf : public std::streambuf {
+  char dummyBuffer[64];
+
+protected:
+  virtual int overflow(int c) override final;
+};
+
+class NullOStream final : private NullStreambuf, public std::ostream {
+public:
+  NullOStream() : std::ostream(this) {}
+  NullStreambuf *rdbuf() { return this; }
+  virtual void avoidOutOfLineVirtualCompilerWarning();
+};
+
+

--- a/fuzzing/NullOStream.h
+++ b/fuzzing/NullOStream.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <iostream>
+#include <ostream>
+#include <streambuf>
 
 // from https://stackoverflow.com/a/8244052
 class NullStreambuf : public std::streambuf {
@@ -16,5 +17,4 @@ public:
   NullStreambuf *rdbuf() { return this; }
   virtual void avoidOutOfLineVirtualCompilerWarning();
 };
-
 

--- a/fuzzing/build_fuzzers.sh
+++ b/fuzzing/build_fuzzers.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Builds the fuzzers
+#
+# By Paul Dreik 20200923
+set -exu
+
+CATCHROOT=$(readlink -f $(dirname $0)/..)
+
+
+BUILDDIR=$CATCHROOT/build-fuzzers
+mkdir -p $BUILDDIR
+cd $BUILDDIR
+
+if which /usr/lib/ccache/clang++ >/dev/null 2>&1 ; then
+ CXX=/usr/lib/ccache/clang++
+else
+ CXX=clang++
+fi
+
+cmake $CATCHROOT \
+  -DCMAKE_CXX_COMPILER=$CXX \
+  -DCMAKE_CXX_FLAGS="-fsanitize=fuzzer-no-link,address,undefined -O3 -g" \
+  -DCATCH_DEVELOPMENT_BUILD=On \
+  -DCATCH_BUILD_EXAMPLES=Off \
+  -DCATCH_BUILD_EXTRA_TESTS=Off \
+  -DCATCH_BUILD_TESTING=Off \
+  -DBUILD_TESTING=Off \
+  -DCATCH_ENABLE_WERROR=Off \
+  -DCATCH_BUILD_FUZZERS=On
+
+cmake --build . -j $(nproc)
+

--- a/fuzzing/fuzz_TestSpecParser.cpp
+++ b/fuzzing/fuzz_TestSpecParser.cpp
@@ -1,0 +1,16 @@
+//License: Boost 1.0
+//By Paul Dreik 2020
+
+#include <catch2/internal/catch_test_spec_parser.hpp>
+#include <catch2/internal/catch_tag_alias_registry.hpp>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+
+    Catch::TagAliasRegistry tar;
+    Catch::TestSpecParser tsp(tar);
+
+    std::string buf(Data,Data+Size);
+    tsp.parse(buf);
+
+    return 0;
+}

--- a/fuzzing/fuzz_XmlWriter.cpp
+++ b/fuzzing/fuzz_XmlWriter.cpp
@@ -1,0 +1,16 @@
+//License: Boost 1.0
+//By Paul Dreik 2020
+
+#include <catch2/internal/catch_xmlwriter.hpp>
+
+#include "NullOStream.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+
+    std::string buf(Data,Data+Size);
+    NullOStream nul;
+    Catch::XmlEncode encode(buf);
+    encode.encodeTo(nul);
+    return 0;
+}
+

--- a/fuzzing/fuzz_textflow.cpp
+++ b/fuzzing/fuzz_textflow.cpp
@@ -1,0 +1,47 @@
+//License: Boost 1.0
+//By Paul Dreik 2020
+
+#include <catch2/internal/catch_textflow.hpp>
+
+#include "NullOStream.h"
+
+#include <string>
+#include <string_view>
+
+
+template<class Callback>
+void split(const char *Data, size_t Size, Callback callback) {
+
+    using namespace std::literals;
+    constexpr auto sep="\n~~~\n"sv;
+
+    std::string_view remainder(Data,Size);
+    for (;;) {
+        auto pos=remainder.find(sep);
+        if(pos==std::string_view::npos) {
+            //not found. use the remainder and exit
+            callback(remainder);
+            return;
+        } else {
+            //found. invoke callback on the first part, then proceed with the rest.
+            callback(remainder.substr(0,pos));
+            remainder=remainder.substr(pos+sep.size());
+        }
+    }
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+
+    Catch::TextFlow::Columns columns;
+
+    // break the input on separator
+    split((const char*)Data,Size,[&](std::string_view word) {
+        columns+=Catch::TextFlow::Column(std::string(word));
+    });
+
+    NullOStream nul;
+    nul << columns;
+
+    return 0;
+}
+


### PR DESCRIPTION
This adds a fuzzer for the TestSpecParser and XmlWriter. I ran them for a few minutes, and it found nothing (unusual!).

This addition should not affect anyone, fuzzing is disabled by default.

I do not want to add more fuzzers, scripts, documentation etc at this point because I want to have early feedback. For instance, the cmake I wrote is probably horrible and there is some better way to do it.

Also, it is libFuzzer only. Making it oss-fuzz compatible can easily be done later (I have done that with simdjson and fmt).