### PR TITLE
Add WORKING_DIRECTORY to CatchAddTests.cmake commands

### DIFF
--- a/contrib/CatchAddTests.cmake
+++ b/contrib/CatchAddTests.cmake
@@ -36,6 +36,7 @@ execute_process(
   COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-test-names-only
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
+  WORKING_DIRECTORY "${TEST_WORKING_DIR}"
 )
 # Catch --list-test-names-only reports the number of tests, so 0 is... surprising
 if(${result} EQUAL 0)
@@ -57,6 +58,7 @@ execute_process(
   COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-reporters
   OUTPUT_VARIABLE reporters_output
   RESULT_VARIABLE reporters_result
+  WORKING_DIRECTORY "${TEST_WORKING_DIR}"
 )
 if(${reporters_result} EQUAL 0)
   message(WARNING


### PR DESCRIPTION
## Description
In a CMake project, when using `catch_discover_tests(WORKING_DIRECTORY [...])` it usually means that the test binary needs resources that are relative to said working directory. This could lead to UB or a crash when running `--list-test-names-only` or `--list-reporters` on the produced test binary i.e when a .dll is not lazy loaded and not available in the current PATH.
This commit simply forwards the `WORKING_DIRECTORY` argument to the `execute_process()` calls.

This also remove the need of using CMake's own magic with `CMAKE_MSVCIDE_RUN_PATH` and the like...

