### PR TITLE
Fixed wrong script path

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -81,7 +81,7 @@ and run all tests in the `Debug` compilation.
 1. Regenerate the amalgamated distribution
 ```
 $ cd Catch2
-$ ./tools/scripts/generateAmalgamatedFiles.py
+$ ./scripts/generateAmalgamatedFiles.py
 ```
 2. Configure the full test build
 ```


### PR DESCRIPTION
The path to the `generateAmalgamatedFiles.py` script is wrong on the documentation. There is no "tools" directory.