### PR TITLE
fix warning in extras/CatchAddTests.cmake

### DIFF
--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -55,11 +55,7 @@ execute_process(
   RESULT_VARIABLE reporters_result
   WORKING_DIRECTORY "${TEST_WORKING_DIR}"
 )
-if(${reporters_result} EQUAL 0)
-  message(WARNING
-    "Test executable '${TEST_EXECUTABLE}' contains no reporters!\n"
-  )
-elseif(${reporters_result} LESS 0)
+if(NOT ${reporters_result} EQUAL 0)
   message(FATAL_ERROR
     "Error running test executable '${TEST_EXECUTABLE}':\n"
     "  Result: ${reporters_result}\n"


### PR DESCRIPTION


<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
  - don't warn on zero return code of `--list-reporters`
  - previously return code was the number of reporters (#1410, #1146)
  - as of 2c06ee9 return code is zero on success

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
