### PR TITLE
Prevent macro redefinition when using Clang with MSVC on Windows #2047

### DIFF
--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -57,7 +57,7 @@
 
 #endif
 
-#if defined(__clang__)
+#if defined(__clang__) && !defined(_MSC_VER)
 
 #    define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION _Pragma( "clang diagnostic push" )
 #    define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  _Pragma( "clang diagnostic pop" )


### PR DESCRIPTION
## Description

When using Clang on Windows the macro `CATCH_INTERNAL_START_WARNINGS_SUPPRESSION` gets redefined because both `__clang__` and `_MSC_VER` are set and both lead to a definition of this macro. This change is supposed to allow using Clang on Windows without such issue by adding additional condition to the clang's variant to prevent it taking effect when used with MSVC headers (clang-cl).

## GitHub Issues

Resolves #2047 