### PR TITLE
Consider CMP0110 add_test() policy

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -119,6 +119,14 @@ function(ParseAndAddCatchTests_ParseFile SourceFile TestTarget)
       )
     endif()
 
+    # check CMP0110 policy for new add_test() behavior
+    if(POLICY CMP0110)
+        cmake_policy(GET CMP0110 _cmp0110_value) # new add_test() behavior
+    else()
+        # just to be thorough explicitly set the variable
+        set(_cmp0110_value)
+    endif()
+
     foreach(TestName ${Tests})
         # Strip newlines
         string(REGEX REPLACE "\\\\\n|\n" "" TestName "${TestName}")
@@ -193,7 +201,11 @@ function(ParseAndAddCatchTests_ParseFile SourceFile TestTarget)
 
             # Work around CMake 3.18.0 change in `add_test()`, before the escaped quotes were neccessary,
             # only with CMake 3.18.0 the escaped double quotes confuse the call. This change is reverted in 3.18.1
-            if(NOT ${CMAKE_VERSION} VERSION_EQUAL "3.18")
+            # And properly introduced in 3.19 with the CMP0110 policy
+            if(_cmp0110_value STREQUAL "NEW" OR ${CMAKE_VERSION} VERSION_EQUAL "3.18")
+                ParseAndAddCatchTests_PrintDebugMessage("CMP0110 set to NEW, no need for add_test(\"\") workaround")
+            else()
+                ParseAndAddCatchTests_PrintDebugMessage("CMP0110 set to OLD adding \"\" for add_test() workaround")
                 set(CTestName "\"${CTestName}\"")
             endif()
 


### PR DESCRIPTION
## Description
CMake 3.19 introduces new add_test() behavior guarded with the policy
CMP0110.

See: https://cmake.org/cmake/help/latest/policy/CMP0110.html

Update the helper script ParseAndAddCatchTests to consider the policy and
handle the test case name accordingly.

## GitHub Issues
Related issue (CMake 3.18.0): https://github.com/catchorg/Catch2/issues/1984
