### PR TITLE
Fix indentation in ParseAndAddCatchTests

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -197,10 +197,10 @@ function(ParseAndAddCatchTests_ParseFile SourceFile TestTarget)
                 set(CTestName "\"${CTestName}\"")
             endif()
 
-	    # Handle template test cases
-	    if("${TestTypeAndFixture}" MATCHES ".*TEMPLATE_.*")
-	      set(Name "${Name} - *")
-	    endif()
+            # Handle template test cases
+            if("${TestTypeAndFixture}" MATCHES ".*TEMPLATE_.*")
+              set(Name "${Name} - *")
+            endif()
 
             # Add the test and set its properties
             add_test(NAME "${CTestName}" COMMAND ${OptionalCatchTestLauncher} $<TARGET_FILE:${TestTarget}> ${Name} ${AdditionalCatchParameters})


### PR DESCRIPTION
## Description
Consistently use 4 spaces instead of tabs

## GitHub Issues
none
