### PR TITLE
Add infrastructure for embedding code samples in docs, and fix documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ benchmark-dir
 .conan/test_package/build
 bazel-*
 build-fuzzers
+debug-build

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ By default a console width of 80 is assumed but this can be controlled by defini
     CATCH_CONFIG_NOSTDOUT
 
 To support platforms that do not provide `std::cout`, `std::cerr` and
-`std::clog`, Catch does not usem the directly, but rather calls
+`std::clog`, Catch does not use them directly, but rather calls
 `Catch::cout`, `Catch::cerr` and `Catch::clog`. You can replace their
 implementation by defining `CATCH_CONFIG_NOSTDOUT` and implementing
 them yourself, their signatures are:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -85,7 +85,7 @@ and run all tests in the `Debug` compilation.
 ./tools/scripts/generateAmalgamatedFiles.py
 
 # 2. Configure the full test build
-cmake -Bdebug-build -H. -DCMAKE_BUILD_TYPE=Debug -DCATCH_BUILD_EXAMPLES=ON -DCATCH_BUILD_EXTRA_TESTS=ON
+cmake -Bdebug-build -H. -DCMAKE_BUILD_TYPE=Debug -DCATCH_BUILD_EXAMPLES=ON -DCATCH_BUILD_EXTRA_TESTS=ON -DCATCH_DEVELOPMENT_BUILD=ON
 
 # 3. Run the actual build
 cmake --build debug-build

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -78,23 +78,30 @@ the invocation of CMake configuration step.
 Bringing this all together, the steps below should configure, build,
 and run all tests in the `Debug` compilation.
 
-1. Regenerate the amalgamated distribution
+<!-- snippet: catch2-build-and-test -->
+<a id='snippet-catch2-build-and-test'></a>
+```sh
+# 1. Regenerate the amalgamated distribution
+./tools/scripts/generateAmalgamatedFiles.py
+
+# 2. Configure the full test build
+cmake -Bdebug-build -H. -DCMAKE_BUILD_TYPE=Debug -DCATCH_BUILD_EXAMPLES=ON -DCATCH_BUILD_EXTRA_TESTS=ON
+
+# 3. Run the actual build
+cmake --build debug-build
+
+# 4. Run the tests using CTest
+cd debug-build
+ctest -j 4 --output-on-failure -C Debug
 ```
-$ cd Catch2
-$ ./tools/scripts/generateAmalgamatedFiles.py
-```
-2. Configure the full test build
-```
-$ cmake -Bdebug-build -H. -DCMAKE_BUILD_TYPE=Debug -DCATCH_BUILD_EXAMPLES=ON -DCATCH_BUILD_EXTRA_TESTS=ON
-```
-3. Run the actual build
-```
-$ cmake --build debug-build
-```
-4. Run the tests using CTest
-```
-$ cd debug-build
-$ ctest -j 4 --output-on-failure -C Debug
+<sup><a href='/tools/scripts/buildAndTest.sh#L6-L19' title='File snippet `catch2-build-and-test` was extracted from'>snippet source</a> | <a href='#snippet-catch2-build-and-test' title='Navigate to start of snippet `catch2-build-and-test`'>anchor</a></sup>
+<!-- endSnippet -->
+
+For convenience, the above commands are in the script `tools/scripts/buildAndTest.sh`, and can be run like this:
+
+```bash
+cd Catch2
+./tools/scripts/buildAndTest.sh
 ```
 
 If you added new tests, you will likely see `ApprovalTests` failure.

--- a/mdsnippets.json
+++ b/mdsnippets.json
@@ -1,0 +1,9 @@
+{
+  "ReadOnly": false,
+  "TocLevel": 5,
+  "Exclude": [
+    "cmake-build"
+  ],
+  "WriteHeader": false,
+  "Convention": "InPlaceOverwrite"
+}

--- a/tools/scripts/buildAndTest.sh
+++ b/tools/scripts/buildAndTest.sh
@@ -8,7 +8,7 @@
 ./tools/scripts/generateAmalgamatedFiles.py
 
 # 2. Configure the full test build
-cmake -Bdebug-build -H. -DCMAKE_BUILD_TYPE=Debug -DCATCH_BUILD_EXAMPLES=ON -DCATCH_BUILD_EXTRA_TESTS=ON
+cmake -Bdebug-build -H. -DCMAKE_BUILD_TYPE=Debug -DCATCH_BUILD_EXAMPLES=ON -DCATCH_BUILD_EXTRA_TESTS=ON -DCATCH_DEVELOPMENT_BUILD=ON
 
 # 3. Run the actual build
 cmake --build debug-build

--- a/tools/scripts/buildAndTest.sh
+++ b/tools/scripts/buildAndTest.sh
@@ -3,6 +3,7 @@
 # Start at the root of the Catch project directory, for example:
 # cd Catch2
 
+# begin-snippet: catch2-build-and-test
 # 1. Regenerate the amalgamated distribution
 ./tools/scripts/generateAmalgamatedFiles.py
 
@@ -15,3 +16,4 @@ cmake --build debug-build
 # 4. Run the tests using CTest
 cd debug-build
 ctest -j 4 --output-on-failure -C Debug
+# end-snippet

--- a/tools/scripts/buildAndTest.sh
+++ b/tools/scripts/buildAndTest.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+# Start at the root of the Catch project directory, for example:
+# cd Catch2
+
+# 1. Regenerate the amalgamated distribution
+./tools/scripts/generateAmalgamatedFiles.py
+
+# 2. Configure the full test build
+cmake -Bdebug-build -H. -DCMAKE_BUILD_TYPE=Debug -DCATCH_BUILD_EXAMPLES=ON -DCATCH_BUILD_EXTRA_TESTS=ON
+
+# 3. Run the actual build
+cmake --build debug-build
+
+# 4. Run the tests using CTest
+cd debug-build
+ctest -j 4 --output-on-failure -C Debug

--- a/tools/scripts/updateDocumentSnippets.py
+++ b/tools/scripts/updateDocumentSnippets.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+from scriptCommon import catchPath
+import os
+import subprocess
+
+# ---------------------------------------------------
+# Update code examples
+# ---------------------------------------------------
+# For info on mdsnippets, see https://github.com/SimonCropp/MarkdownSnippets
+
+# install dotnet SDK from http://go.microsoft.com/fwlink/?LinkID=798306&clcid=0x409
+# Then install MarkdownSnippets.Tool with
+#   dotnet tool install -g MarkdownSnippets.Tool
+# To update:
+#   dotnet tool update  -g MarkdownSnippets.Tool
+# To uninstall (e.g. to downgrade to a lower version)
+# dotnet tool uninstall -g MarkdownSnippets.Tool
+
+os.chdir(catchPath)
+
+subprocess.run('dotnet tool update  -g MarkdownSnippets.Tool --version 21.2.0', shell=True, check=True)
+subprocess.run('mdsnippets', shell=True, check=True)


### PR DESCRIPTION
## Description

This adds the scripts to use mdsnippets to embed code samples in the docs.

* tools/scripts/updateDocumentSnippets.py regenerates docs. See the comments for how to install the tool
* tools/scripts/buildAndTest.sh does a developer build and runs the tests. Much of its contents is now included in docs/contributing.md, which also lets users know about the script, so they don't need to run all the commands by hand.

Having created the above, I also fixed the build script to add the missing CMake option that is now needed.

If the PR is accepted, I'm happy to write a description in the contributing docs on how to set up mdsnippets.