### PR TITLE
Silence -Wuseless-cast warning with GCC10

### DIFF
--- a/src/catch2/internal/catch_test_macro_impl.hpp
+++ b/src/catch2/internal/catch_test_macro_impl.hpp
@@ -56,7 +56,7 @@
             CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
         } INTERNAL_CATCH_CATCH( catchAssertionHandler ) \
         INTERNAL_CATCH_REACT( catchAssertionHandler ) \
-    } while( (void)0, (false) && static_cast<bool>( !!(__VA_ARGS__) ) )
+    } while( (void)0, (false) && static_cast<const bool&>( !!(__VA_ARGS__) ) )
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_IF( macroName, resultDisposition, ... ) \


### PR DESCRIPTION
I open this pull request as a way to open the discussion with a very simple fix. I couldn't find any issue to link it to.

## Description

With GCC 10, the `static_cast<bool>` triggers the -Wuseless-cast warning. This commit changes the cast into `static_cast<const bool&>`: it achieves the same thing but doesn't trigger the warning thanks to the "gratuitous" type conversion to `const bool&`. As per references rules, `const bool&` should bind to anything, be it `const` or not, an rvalue or an lvalue, so I doubt that this change is breaking anything.