### PR TITLE
Inject conan_basic_setup to properly set MD/MT flags

### DIFF
--- a/.conan/test_package/CMakeLists.txt
+++ b/.conan/test_package/CMakeLists.txt
@@ -1,19 +1,12 @@
 cmake_minimum_required(VERSION 3.2.0)
 project(test_package CXX)
 
-# We set it only for the convenience of calling the executable
-# in the package test function
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup()
 
 find_package(Catch2 REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-# Note: Conan 1.21 doesn't support granular target generation yet.
-# The Main library would be included into the unified target.
-# It's controlled by the `with_main` option in the recipe.
-target_link_libraries(${PROJECT_NAME} Catch2::Catch2)
+
+target_link_libraries(${PROJECT_NAME} Catch2::Catch2WithMain)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 14)

--- a/.conan/test_package/conanfile.py
+++ b/.conan/test_package/conanfile.py
@@ -6,7 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake_find_package_multi"
+    generators = "cmake_find_package_multi", "cmake"
 
     def build(self):
         cmake = CMake(self)
@@ -14,6 +14,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        assert os.path.isfile(os.path.join(self.deps_cpp_info["catch2"].rootpath, "licenses", "LICENSE.txt"))
+        assert os.path.isfile(os.path.join(
+            self.deps_cpp_info["catch2"].rootpath, "licenses", "LICENSE.txt"))
         bin_path = os.path.join("bin", "test_package")
         self.run("%s -s" % bin_path, run_environment=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,11 +29,13 @@ class CatchConan(ConanFile):
         return cmake
 
     def build(self):
+        # We need this workaround until the toolchains feature
+        # to inject stuff like MD/MT
         line_to_replace = 'list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")'
         tools.replace_in_file("CMakeLists.txt", line_to_replace,
                               '''{}
-include({}/conanbuildinfo.cmake)
-conan_basic_setup()'''.format(line_to_replace, self.install_folder))
+include("{}/conanbuildinfo.cmake")
+conan_basic_setup()'''.format(line_to_replace, self.install_folder.replace("\\", "/")))
 
         cmake = self._configure_cmake()
         cmake.build()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 
 
 class CatchConan(ConanFile):
@@ -18,6 +18,8 @@ class CatchConan(ConanFile):
     options = {"with_main": [True, False]}
     default_options = {"with_main": True}
 
+    generators = "cmake"
+
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["BUILD_TESTING"] = "OFF"
@@ -27,6 +29,12 @@ class CatchConan(ConanFile):
         return cmake
 
     def build(self):
+        line_to_replace = 'list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")'
+        tools.replace_in_file("CMakeLists.txt", line_to_replace,
+                              '''{}
+include({}/conanbuildinfo.cmake)
+conan_basic_setup()'''.format(line_to_replace, self.install_folder))
+
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from conans import ConanFile, CMake, tools
 
-
 class CatchConan(ConanFile):
     name = "catch2"
     description = "A modern, C++-native, framework for unit-tests, TDD and BDD"
@@ -14,9 +13,6 @@ class CatchConan(ConanFile):
     exports_sources = ("src/*", "CMakeLists.txt", "CMake/*", "extras/*")
 
     settings = "os", "compiler", "build_type", "arch"
-
-    options = {"with_main": [True, False]}
-    default_options = {"with_main": True}
 
     generators = "cmake"
 
@@ -45,11 +41,17 @@ conan_basic_setup()'''.format(line_to_replace, self.install_folder.replace("\\",
         cmake = self._configure_cmake()
         cmake.install()
 
-    def package_id(self):
-        del self.info.options.with_main
-
     def package_info(self):
-        self.cpp_info.libs = [
-            'Catch2Main', 'Catch2'] if self.options.with_main else ['Catch2']
         self.cpp_info.names["cmake_find_package"] = "Catch2"
         self.cpp_info.names["cmake_find_package_multi"] = "Catch2"
+        # Catch2
+        self.cpp_info.components["catch2base"].names["cmake_find_package"] = "Catch2"
+        self.cpp_info.components["catch2base"].names["cmake_find_package_multi"] = "Catch2"
+        self.cpp_info.components["catch2base"].names["pkg_config"] = "Catch2"
+        self.cpp_info.components["catch2base"].libs = ["Catch2"]
+        # Catch2WithMain
+        self.cpp_info.components["catch2main"].names["cmake_find_package"] = "Catch2WithMain"
+        self.cpp_info.components["catch2main"].names["cmake_find_package_multi"] = "Catch2WithMain"
+        self.cpp_info.components["catch2main"].names["pkg_config"] = "Catch2WithMain"
+        self.cpp_info.components["catch2main"].libs = ["Catch2Main"]
+        self.cpp_info.components["catch2main"].requires = ["catch2base"]


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description

Fixes the injecting of build flags from Conan with `conan_basic_setup`.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
TODO
