### PR TITLE
Enable IPO for CMake versions that support it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ if (CMAKE_BINARY_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     message(FATAL_ERROR "Building in-source is not supported! Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
 endif()
 
+if(CMAKE_VERSION VERSION_GREATER 3.8)
+  # Enable IPO for CMake versions that support it
+  cmake_policy(SET CMP0069 NEW)
+endif()
+
 
 project(Catch2 LANGUAGES CXX VERSION 3.0.0)
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
I've began porting a project of mine to Catch3 where I have IPO/LTO enabled and since Catch is now build as a static library I've noticed the following warning coming up:
```
CMake Warning (dev) at external/Catch2/src/CMakeLists.txt:230 (add_library):
Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
cmake_policy command to set the policy and suppress this warning.

INTERPROCEDURAL_OPTIMIZATION property will be ignored for target 'Catch2'.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
This patch should fix that warning and allow Catch to be build with link time optimizations with non Intel compilers like Clang or GCC, when enabled.
Note that this patch does not enable link time optimizations or directly modifies compile/link flags in any way. I've you want to build with these flags you still need to set 'CMAKE_INTERPROCEDURAL_OPTIMIZATION' for example or enable them per target.

[CMP0069 Refernce](https://cmake.org/cmake/help/git-stage/policy/CMP0069.html)
## GitHub Issues
<!--
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
N/A