### PR TITLE
Use snprintf instead of sprintf

### DIFF
--- a/extras/catch_amalgamated.cpp
+++ b/extras/catch_amalgamated.cpp
@@ -6974,7 +6974,7 @@ namespace Catch {
 #ifdef _MSC_VER
         sprintf_s( buffer, "%.3f", duration );
 #else
-        std::snprintf( buffer, maxDoubleSize, "%.3f", duration );
+        std::sprintf( buffer, "%.3f", duration );
 #endif
         return std::string( buffer );
     }

--- a/extras/catch_amalgamated.cpp
+++ b/extras/catch_amalgamated.cpp
@@ -6974,7 +6974,7 @@ namespace Catch {
 #ifdef _MSC_VER
         sprintf_s( buffer, "%.3f", duration );
 #else
-        std::sprintf( buffer, "%.3f", duration );
+        std::snprintf( buffer, maxDoubleSize, "%.3f", duration );
 #endif
         return std::string( buffer );
     }

--- a/src/catch2/reporters/catch_reporter_combined_tu.cpp
+++ b/src/catch2/reporters/catch_reporter_combined_tu.cpp
@@ -44,7 +44,7 @@ namespace Catch {
 #ifdef _MSC_VER
         sprintf_s( buffer, "%.3f", duration );
 #else
-        std::sprintf( buffer, "%.3f", duration );
+        std::snprintf( buffer, maxDoubleSize, "%.3f", duration );
 #endif
         return std::string( buffer );
     }


### PR DESCRIPTION
## Description
Trivial change to propose to use a safer string formatter.