### PR TITLE
Add deprecation warning in ParseAndCatchTests

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -241,6 +241,7 @@ endfunction()
 
 # entry point
 function(ParseAndAddCatchTests TestTarget)
+    message(DEPRECATION "ParseAndAddCatchTest: function deprecated because of possibility of missed test cases. Consider using 'catch_discover_tests' from 'Catch.cmake'")
     ParseAndAddCatchTests_PrintDebugMessage("Started parsing ${TestTarget}")
     get_target_property(SourceFiles ${TestTarget} SOURCES)
     ParseAndAddCatchTests_PrintDebugMessage("Found the following sources: ${SourceFiles}")

--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -57,7 +57,7 @@ with automatically registering their `TEST_CASE`s with CTest. They
 can be found in the `contrib` folder, and are
 
 1) `Catch.cmake` (and its dependency `CatchAddTests.cmake`)
-2) `ParseAndAddCatchTests.cmake`
+2) `ParseAndAddCatchTests.cmake` (deprecated)
 
 If Catch2 has been installed in system, both of these can be used after
 doing `find_package(Catch2 REQUIRED)`. Otherwise you need to add them
@@ -176,10 +176,17 @@ the output file name e.g. ".xml".
 
 ### `ParseAndAddCatchTests.cmake`
 
+⚠ This script is [deprecated](https://github.com/catchorg/Catch2/pull/2120)
+in Catch X.Y.Z and superseded by the above approach using `catch_discover_tests`.
+See [#2092](https://github.com/catchorg/Catch2/issues/2092) for details.
+
 `ParseAndAddCatchTests` works by parsing all implementation files
 associated with the provided target, and registering them via CTest's
 `add_test`. This approach has some limitations, such as the fact that
-commented-out tests will be registered anyway.
+commented-out tests will be registered anyway. More serious, only a
+subset of the assertion macros currently available in Catch can be
+detected by this script and tests with any macros that cannot be
+parsed are *silently ignored*.
 
 
 #### Usage

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -72,6 +72,13 @@ Instead you will have to write this:
             REQUIRE_THAT(foo(), m1 || m2 || m3);
 ```
 
+### `ParseAndAddCatchTests.cmake`
+
+The CMake/CTest integration using `ParseAndAddCatchTests.cmake` is deprecated,
+as it can be replaced by `Catch.cmake` that provides the function
+`catch_discover_tests` to get tests directly from a CMake target via the
+command line interface instead of parsing C++ code with regular expressions.
+
 
 ## Planned changes
 


### PR DESCRIPTION
Parsing C++ with regex in CMake is error prone and regularly leads to silently
dropped (not run) test cases.

Going forward the function `catch_discover_tests` from `contrib/CMake.cmake`
should be used.

For more information see https://github.com/catchorg/Catch2/issues/2092#issuecomment-747342765