### PR TITLE
Add the HIP CPU Runtime as a Catch2 user

### DIFF
--- a/docs/opensource-users.md
+++ b/docs/opensource-users.md
@@ -53,6 +53,9 @@ Template Library of Tree Data Structures.
 ### [Fuxedo](https://github.com/fuxedo/fuxedo)
 Open source Oracle Tuxedo-like XATMI middleware for C and C++.
 
+### [HIP CPU Runtime](https://github.com/ROCm-Developer-Tools/HIP-CPU)
+A header-only library that allows CPUs to execute unmodified HIP code. It is generic and does not assume a particular CPU vendor or architecture.
+
 ### [Inja](https://github.com/pantor/inja)
 A header-only template engine for modern C++.
 


### PR DESCRIPTION
## Description

The HIP CPU Runtime uses Catch2 for its unit tests and micro-benchmarks, and it only feels proper to admit to it. Thank you for an excellent tool gents.