### PR TITLE
CMake integration - note about CMAKE_MODULE_PATH

### DIFF
--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -85,6 +85,7 @@ include(Catch)
 catch_discover_tests(foo)
 ```
 
+Note, in case of using `FetchContent`, `find_package(Catch2 REQUIRED)` should be substituted with `list(APPEND CMAKE_MODULE_PATH "${Catch2_SOURCE_DIR}/contrib")`.
 
 #### Customization
 `catch_discover_tests` can be given several extra argumets:


### PR DESCRIPTION
## Description
Solving a problem of missing `Catch` CMake include in case of using `FetchContent` by documenting
the way to add the proper note in the documentation.

## GitHub Issues

Closes https://github.com/catchorg/Catch2/issues/1805

See also https://github.com/catchorg/Catch2/issues/2026
