### PR TITLE
Added ElementsAre and UnorderedElementsAre

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ set(INTERNAL_HEADERS
     ${SOURCES_DIR}/matchers/catch_matchers.hpp
     ${SOURCES_DIR}/matchers/catch_matchers_container_properties.hpp
     ${SOURCES_DIR}/matchers/catch_matchers_contains.hpp
+    ${SOURCES_DIR}/matchers/catch_matchers_elements_are.hpp
     ${SOURCES_DIR}/matchers/catch_matchers_exception.hpp
     ${SOURCES_DIR}/matchers/catch_matchers_floating_point.hpp
     ${SOURCES_DIR}/matchers/catch_matchers_predicate.hpp

--- a/src/catch2/matchers/catch_matchers_all.hpp
+++ b/src/catch2/matchers/catch_matchers_all.hpp
@@ -23,6 +23,7 @@
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_container_properties.hpp>
 #include <catch2/matchers/catch_matchers_contains.hpp>
+#include <catch2/matchers/catch_matchers_elements_are.hpp>
 #include <catch2/matchers/catch_matchers_exception.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_predicate.hpp>

--- a/src/catch2/matchers/catch_matchers_elements_are.hpp
+++ b/src/catch2/matchers/catch_matchers_elements_are.hpp
@@ -1,3 +1,4 @@
+
 //              Copyright Catch2 Authors
 // Distributed under the Boost Software License, Version 1.0.
 //   (See accompanying file LICENSE_1_0.txt or copy at

--- a/src/catch2/matchers/catch_matchers_elements_are.hpp
+++ b/src/catch2/matchers/catch_matchers_elements_are.hpp
@@ -1,0 +1,67 @@
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE_1_0.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+#ifndef CATCH_MATCHERS_ELEMENTS_ARE_HPP_INCLUDED
+#define CATCH_MATCHERS_ELEMENTS_ARE_HPP_INCLUDED
+
+#include <catch2/matchers/catch_matchers_templated.hpp>
+
+#include <algorithm>
+#include <utility>
+
+namespace Catch {
+namespace Matchers {
+
+    template<typename RangeLike>
+    class ElementsAreElementsMatcher final : public MatcherGenericBase {
+        RangeLike m_range;
+	public:
+		ElementsAreElementsMatcher(RangeLike range):
+		    m_range(std::move(range))
+		{}
+
+		bool match(RangeLike rng) const {
+		    return std::equal(m_range.begin(), m_range.end(), rng.begin());
+		}
+
+		std::string describe() const override {
+		    return "elements are " + Catch::Detail::stringify(m_range);
+		}
+    };
+
+    template<typename RangeLike>
+    class UnorderedElementsAreElementsMatcher final : public MatcherGenericBase {
+        RangeLike m_range;
+	public:
+		UnorderedElementsAreElementsMatcher(RangeLike range):
+		    m_range(std::move(range))
+		{}
+
+		bool match(RangeLike rng) const {
+		    return std::is_permutation(m_range.begin(), m_range.end(), rng.begin());
+		}
+
+		std::string describe() const override {
+		    return "unordered elements are " + ::Catch::Detail::stringify( m_range );
+		}
+    };
+
+    //! Creates a matcher that checks if all elements in a range are equal to all elements in another range
+    template<typename RangeLike>
+    ElementsAreElementsMatcher<RangeLike> ElementsAre(RangeLike rng) {
+        return { std::forward<RangeLike>(rng) };
+    }
+
+    //! Creates a matcher that checks if all elements in a range are equal to all elements in another range in some permutation
+    template<typename RangeLike>
+    UnorderedElementsAreElementsMatcher<RangeLike> UnorderedElementsAre(RangeLike rng) {
+        return { std::forward<RangeLike>(rng) };
+    }
+
+} // namespace Matchers
+} // namespace Catch
+
+#endif // CATCH_MATCHERS_ELEMENTS_ARE_HPP_INCLUDED


### PR DESCRIPTION
## Description
Added `ElementsAre` and `UnorderedElementsAre` generic range matchers which take a range during construction and their `match` method take a range as well.

## GitHub Issues
Addressing issue #2087 .

## Notes
I did not include support to providing a `matcher` as construction argument due to `ElementsAre` would be exactly the same as `AllMatch`.