### PR TITLE
Split some configuration options out of catch_compiler_capabilities

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ set(INTERNAL_HEADERS
     ${SOURCES_DIR}/internal/catch_compiler_capabilities.hpp
     ${SOURCES_DIR}/catch_config.hpp
     ${SOURCES_DIR}/internal/catch_config_android_logwrite.hpp
+    ${SOURCES_DIR}/internal/catch_config_counter.hpp
     ${SOURCES_DIR}/internal/catch_config_uncaught_exceptions.hpp
     ${SOURCES_DIR}/internal/catch_config_wchar.hpp
     ${SOURCES_DIR}/internal/catch_console_colour.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ set(INTERNAL_HEADERS
     ${SOURCES_DIR}/catch_config.hpp
     ${SOURCES_DIR}/internal/catch_config_android_logwrite.hpp
     ${SOURCES_DIR}/internal/catch_config_uncaught_exceptions.hpp
+    ${SOURCES_DIR}/internal/catch_config_wchar.hpp
     ${SOURCES_DIR}/internal/catch_console_colour.hpp
     ${SOURCES_DIR}/internal/catch_context.hpp
     ${SOURCES_DIR}/internal/catch_debug_console.hpp

--- a/src/catch2/catch_all.hpp
+++ b/src/catch2/catch_all.hpp
@@ -51,6 +51,7 @@
 #include <catch2/internal/catch_commandline.hpp>
 #include <catch2/internal/catch_compiler_capabilities.hpp>
 #include <catch2/internal/catch_config_android_logwrite.hpp>
+#include <catch2/internal/catch_config_counter.hpp>
 #include <catch2/internal/catch_config_uncaught_exceptions.hpp>
 #include <catch2/internal/catch_config_wchar.hpp>
 #include <catch2/internal/catch_console_colour.hpp>

--- a/src/catch2/catch_all.hpp
+++ b/src/catch2/catch_all.hpp
@@ -52,6 +52,7 @@
 #include <catch2/internal/catch_compiler_capabilities.hpp>
 #include <catch2/internal/catch_config_android_logwrite.hpp>
 #include <catch2/internal/catch_config_uncaught_exceptions.hpp>
+#include <catch2/internal/catch_config_wchar.hpp>
 #include <catch2/internal/catch_console_colour.hpp>
 #include <catch2/internal/catch_console_width.hpp>
 #include <catch2/internal/catch_container_nonmembers.hpp>

--- a/src/catch2/catch_session.hpp
+++ b/src/catch2/catch_session.hpp
@@ -12,7 +12,7 @@
 #include <catch2/internal/catch_noncopyable.hpp>
 #include <catch2/catch_config.hpp>
 #include <catch2/internal/catch_unique_ptr.hpp>
-#include <catch2/internal/catch_compiler_capabilities.hpp>
+#include <catch2/internal/catch_config_wchar.hpp>
 
 namespace Catch {
 

--- a/src/catch2/catch_tag_alias_autoregistrar.hpp
+++ b/src/catch2/catch_tag_alias_autoregistrar.hpp
@@ -8,6 +8,7 @@
 #ifndef CATCH_TAG_ALIAS_AUTOREGISTRAR_HPP_INCLUDED
 #define CATCH_TAG_ALIAS_AUTOREGISTRAR_HPP_INCLUDED
 
+#include <catch2/internal/catch_compiler_capabilities.hpp>
 #include <catch2/internal/catch_source_line_info.hpp>
 
 namespace Catch {

--- a/src/catch2/catch_tostring.hpp
+++ b/src/catch2/catch_tostring.hpp
@@ -14,6 +14,7 @@
 #include <type_traits>
 #include <string>
 #include <catch2/internal/catch_compiler_capabilities.hpp>
+#include <catch2/internal/catch_config_wchar.hpp>
 #include <catch2/internal/catch_stream.hpp>
 #include <catch2/interfaces/catch_interfaces_enum_values_registry.hpp>
 
@@ -162,7 +163,7 @@ namespace Catch {
         static std::string convert(char * str);
     };
 
-#ifdef CATCH_CONFIG_WCHAR
+#if defined(CATCH_CONFIG_WCHAR)
     template<>
     struct StringMaker<std::wstring> {
         static std::string convert(const std::wstring& wstr);
@@ -183,7 +184,7 @@ namespace Catch {
     struct StringMaker<wchar_t *> {
         static std::string convert(wchar_t * str);
     };
-#endif
+#endif // CATCH_CONFIG_WCHAR
 
     // TBD: Should we use `strnlen` to ensure that we don't go out of the buffer,
     //      while keeping string semantics?

--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -186,11 +186,6 @@
 #  define CATCH_INTERNAL_CONFIG_EXCEPTIONS_ENABLED
 #endif
 
-////////////////////////////////////////////////////////////////////////////////
-// DJGPP
-#ifdef __DJGPP__
-#  define CATCH_INTERNAL_CONFIG_NO_WCHAR
-#endif // __DJGPP__
 
 ////////////////////////////////////////////////////////////////////////////////
 // Embarcadero C++Build
@@ -272,10 +267,6 @@
 // This is set by default, because we assume that unix compilers are posix-signal-compatible by default.
 #if defined(CATCH_INTERNAL_CONFIG_POSIX_SIGNALS) && !defined(CATCH_INTERNAL_CONFIG_NO_POSIX_SIGNALS) && !defined(CATCH_CONFIG_NO_POSIX_SIGNALS) && !defined(CATCH_CONFIG_POSIX_SIGNALS)
 #   define CATCH_CONFIG_POSIX_SIGNALS
-#endif
-// This is set by default, because we assume that compilers with no wchar_t support are just rare exceptions.
-#if !defined(CATCH_INTERNAL_CONFIG_NO_WCHAR) && !defined(CATCH_CONFIG_NO_WCHAR) && !defined(CATCH_CONFIG_WCHAR)
-#   define CATCH_CONFIG_WCHAR
 #endif
 
 #if !defined(CATCH_INTERNAL_CONFIG_NO_CPP11_TO_STRING) && !defined(CATCH_CONFIG_NO_CPP11_TO_STRING) && !defined(CATCH_CONFIG_CPP11_TO_STRING)

--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -11,7 +11,6 @@
 // Detect a number of compiler features - by compiler
 // The following features are defined:
 //
-// CATCH_CONFIG_COUNTER : is the __COUNTER__ macro supported?
 // CATCH_CONFIG_WINDOWS_SEH : is Windows SEH supported?
 // CATCH_CONFIG_POSIX_SIGNALS : are POSIX signals supported?
 // CATCH_CONFIG_DISABLE_EXCEPTIONS : Are exceptions enabled?
@@ -195,18 +194,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Use of __COUNTER__ is suppressed during code analysis in
-// CLion/AppCode 2017.2.x and former, because __COUNTER__ is not properly
-// handled by it.
-// Otherwise all supported compilers support COUNTER macro,
-// but user still might want to turn it off
-#if ( !defined(__JETBRAINS_IDE__) || __JETBRAINS_IDE__ >= 20170300L )
-    #define CATCH_INTERNAL_CONFIG_COUNTER
-#endif
-
-
-////////////////////////////////////////////////////////////////////////////////
-
 // RTX is a special version of Windows that is real time.
 // This means that it is detected as Windows, but does not provide
 // the same set of capabilities as real Windows does.
@@ -258,9 +245,6 @@
 #endif // defined(__has_include)
 
 
-#if defined(CATCH_INTERNAL_CONFIG_COUNTER) && !defined(CATCH_CONFIG_NO_COUNTER) && !defined(CATCH_CONFIG_COUNTER)
-#   define CATCH_CONFIG_COUNTER
-#endif
 #if defined(CATCH_INTERNAL_CONFIG_WINDOWS_SEH) && !defined(CATCH_CONFIG_NO_WINDOWS_SEH) && !defined(CATCH_CONFIG_WINDOWS_SEH) && !defined(CATCH_INTERNAL_CONFIG_NO_WINDOWS_SEH)
 #   define CATCH_CONFIG_WINDOWS_SEH
 #endif

--- a/src/catch2/internal/catch_config_counter.hpp
+++ b/src/catch2/internal/catch_config_counter.hpp
@@ -1,0 +1,32 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE_1_0.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+/** \file
+ * Wrapper for the CONFIG configuration option
+ *
+ * When generating internal unique names, there are two options. Either
+ * we mix in the current line number, or mix in an incrementing number.
+ * We prefer the latter, using `__COUNTER__`, but users might want to
+ * use the former.
+ */
+
+#ifndef CATCH_CONFIG_COUNTER_HPP_INCLUDED
+#define CATCH_CONFIG_COUNTER_HPP_INCLUDED
+
+#if ( !defined(__JETBRAINS_IDE__) || __JETBRAINS_IDE__ >= 20170300L )
+    #define CATCH_INTERNAL_CONFIG_COUNTER
+#endif
+
+#if defined( CATCH_INTERNAL_CONFIG_COUNTER ) && \
+    !defined( CATCH_CONFIG_NO_COUNTER ) && \
+    !defined( CATCH_CONFIG_COUNTER )
+#    define CATCH_CONFIG_COUNTER
+#endif
+
+
+#endif // CATCH_CONFIG_COUNTER_HPP_INCLUDED

--- a/src/catch2/internal/catch_config_wchar.hpp
+++ b/src/catch2/internal/catch_config_wchar.hpp
@@ -1,0 +1,33 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE_1_0.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+/** \file
+ * Wrapper for the WCHAR configuration option
+ *
+ * We want to support platforms that do not provide `wchar_t`, so we
+ * sometimes have to disable providing wchar_t overloads through Catch2,
+ * e.g. the StringMaker specialization for `std::wstring`.
+ */
+
+#ifndef CATCH_CONFIG_WCHAR_HPP_INCLUDED
+#define CATCH_CONFIG_WCHAR_HPP_INCLUDED
+
+// We assume that WCHAR should be enabled by default, and only disabled
+// for a shortlist (so far only DJGPP) of compilers.
+
+#if defined(__DJGPP__)
+#  define CATCH_INTERNAL_CONFIG_NO_WCHAR
+#endif // __DJGPP__
+
+#if !defined( CATCH_INTERNAL_CONFIG_NO_WCHAR ) && \
+    !defined( CATCH_CONFIG_NO_WCHAR ) && \
+    !defined( CATCH_CONFIG_WCHAR )
+#    define CATCH_CONFIG_WCHAR
+#endif
+
+#endif // CATCH_CONFIG_WCHAR_HPP_INCLUDED

--- a/src/catch2/internal/catch_main.cpp
+++ b/src/catch2/internal/catch_main.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: BSL-1.0
 #include <catch2/catch_session.hpp>
 #include <catch2/internal/catch_compiler_capabilities.hpp>
+#include <catch2/internal/catch_config_wchar.hpp>
 #include <catch2/internal/catch_leak_detector.hpp>
 #include <catch2/internal/catch_platform.hpp>
 

--- a/src/catch2/internal/catch_source_line_info.hpp
+++ b/src/catch2/internal/catch_source_line_info.hpp
@@ -8,7 +8,7 @@
 #ifndef CATCH_SOURCE_LINE_INFO_HPP_INCLUDED
 #define CATCH_SOURCE_LINE_INFO_HPP_INCLUDED
 
-#include <catch2/internal/catch_compiler_capabilities.hpp>
+#include <catch2/internal/catch_config_counter.hpp>
 
 #include <cstddef>
 #include <iosfwd>

--- a/src/catch2/internal/catch_test_case_tracker.hpp
+++ b/src/catch2/internal/catch_test_case_tracker.hpp
@@ -8,7 +8,6 @@
 #ifndef CATCH_TEST_CASE_TRACKER_HPP_INCLUDED
 #define CATCH_TEST_CASE_TRACKER_HPP_INCLUDED
 
-#include <catch2/internal/catch_compiler_capabilities.hpp>
 #include <catch2/internal/catch_source_line_info.hpp>
 #include <catch2/internal/catch_unique_ptr.hpp>
 

--- a/src/catch2/internal/catch_test_registry.hpp
+++ b/src/catch2/internal/catch_test_registry.hpp
@@ -11,7 +11,6 @@
 #include <catch2/internal/catch_source_line_info.hpp>
 #include <catch2/internal/catch_noncopyable.hpp>
 #include <catch2/interfaces/catch_interfaces_testcase.hpp>
-#include <catch2/internal/catch_compiler_capabilities.hpp>
 #include <catch2/internal/catch_stringref.hpp>
 #include <catch2/internal/catch_unique_ptr.hpp>
 

--- a/src/catch2/internal/catch_xmlwriter.hpp
+++ b/src/catch2/internal/catch_xmlwriter.hpp
@@ -9,7 +9,6 @@
 #define CATCH_XMLWRITER_HPP_INCLUDED
 
 #include <catch2/internal/catch_stream.hpp>
-#include <catch2/internal/catch_compiler_capabilities.hpp>
 
 // FixMe: Without this include (and something inside it), MSVC goes crazy
 //        and reports that calls to XmlEncode's op << are ambiguous between

--- a/src/catch2/reporters/catch_reporter_compact.cpp
+++ b/src/catch2/reporters/catch_reporter_compact.cpp
@@ -9,7 +9,7 @@
 
 #include <catch2/reporters/catch_reporter_helpers.hpp>
 #include <catch2/interfaces/catch_interfaces_config.hpp>
-#include <catch2/internal/catch_compiler_capabilities.hpp>
+#include <catch2/internal/catch_platform.hpp>
 #include <catch2/internal/catch_console_colour.hpp>
 #include <catch2/internal/catch_string_manip.hpp>
 #include <catch2/internal/catch_stringref.hpp>

--- a/tests/SelfTest/UsageTests/Misc.tests.cpp
+++ b/tests/SelfTest/UsageTests/Misc.tests.cpp
@@ -5,6 +5,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_template_test_macros.hpp>
+#include <catch2/internal/catch_config_wchar.hpp>
 
 #ifdef __clang__
 #   pragma clang diagnostic ignored "-Wc++98-compat"
@@ -423,7 +424,7 @@ TEST_CASE( "Tabs and newlines show in output", "[.][whitespace][failing]" ) {
 }
 
 
-#ifdef CATCH_CONFIG_WCHAR
+#if defined(CATCH_CONFIG_WCHAR)
 TEST_CASE( "toString on const wchar_t const pointer returns the string contents", "[toString]" ) {
         const wchar_t * const s = L"wide load";
         std::string result = ::Catch::Detail::stringify( s );
@@ -447,7 +448,7 @@ TEST_CASE( "toString on wchar_t returns the string contents", "[toString]" ) {
         std::string result = ::Catch::Detail::stringify( s );
         CHECK( result == "\"wide load\"" );
 }
-#endif
+#endif // CATCH_CONFIG_WCHAR
 
 TEST_CASE( "long long" ) {
     long long l = std::numeric_limits<long long>::max();


### PR DESCRIPTION
## Description
Small part of the `catch_compiler_capabilities.hpp` refactoring required in #2041

## GitHub Issues

#2041 
