### PR TITLE
Making target detection on Mac more robust

### DIFF
--- a/src/catch2/internal/catch_platform.hpp
+++ b/src/catch2/internal/catch_platform.hpp
@@ -8,22 +8,16 @@
 #ifndef CATCH_PLATFORM_HPP_INCLUDED
 #define CATCH_PLATFORM_HPP_INCLUDED
 
+// See e.g.:
+// https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/TargetConditionals.h.auto.html
 #ifdef __APPLE__
-# include <TargetConditionals.h>
-# ifdef TARGET_OS_OSX
-#  if TARGET_OS_OSX == 1
-#   define CATCH_PLATFORM_MAC
+#  include <TargetConditionals.h>
+#  if (defined(TARGET_OS_OSX) && TARGET_OS_OSX == 1) || \
+      (defined(TARGET_OS_MAC) && TARGET_OS_MAC == 1)
+#    define CATCH_PLATFORM_MAC
+#  elif (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
+#    define CATCH_PLATFORM_IPHONE
 #  endif
-# else
-#  if TARGET_OS_MAC == 1
-#   define CATCH_PLATFORM_MAC
-#  endif
-# endif
-# ifndef CATCH_PLATFORM_MAC
-#  if TARGET_OS_IPHONE == 1
-#   define CATCH_PLATFORM_IPHONE
-#  endif
-# endif
 
 #elif defined(linux) || defined(__linux) || defined(__linux__)
 #  define CATCH_PLATFORM_LINUX

--- a/src/catch2/internal/catch_platform.hpp
+++ b/src/catch2/internal/catch_platform.hpp
@@ -24,7 +24,6 @@
 #   define CATCH_PLATFORM_IPHONE
 #  endif
 # endif
-#endif
 
 #elif defined(linux) || defined(__linux) || defined(__linux__)
 #  define CATCH_PLATFORM_LINUX

--- a/src/catch2/internal/catch_platform.hpp
+++ b/src/catch2/internal/catch_platform.hpp
@@ -10,11 +10,21 @@
 
 #ifdef __APPLE__
 # include <TargetConditionals.h>
-# if TARGET_OS_OSX == 1
-#  define CATCH_PLATFORM_MAC
-# elif TARGET_OS_IPHONE == 1
-#  define CATCH_PLATFORM_IPHONE
+# ifdef TARGET_OS_OSX
+#  if TARGET_OS_OSX == 1
+#   define CATCH_PLATFORM_MAC
+#  endif
+# else
+#  if TARGET_OS_MAC == 1
+#   define CATCH_PLATFORM_MAC
+#  endif
 # endif
+# ifndef CATCH_PLATFORM_MAC
+#  if TARGET_OS_IPHONE == 1
+#   define CATCH_PLATFORM_IPHONE
+#  endif
+# endif
+#endif
 
 #elif defined(linux) || defined(__linux) || defined(__linux__)
 #  define CATCH_PLATFORM_LINUX


### PR DESCRIPTION
## Description
Upon encountering https://github.com/conda-forge/catch2-feedstock/pull/37 if found that [`TargetConditionals.h`](https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-8A428/TargetConditionals.h.auto.html) may not define the used `TARGET_OS_OSX`, but `TARGET_OS_MAC` is. Since it was changed the other way before it could be safest to test for both. Not an expert here, so it would be good if an expert could comment.

> I have no idea by conda-forge's CI *is* failing but the CI here *wasn't*. 

I just realised that I could check if it fixes https://github.com/conda-forge/catch2-feedstock/pull/37 , see https://github.com/conda-forge/catch2-feedstock/pull/38 , if only I would understand how to get the right patch ;) I think that I failed because the release is not made on the main branch. 

## GitHub Issues
Fixes https://github.com/catchorg/Catch2/issues/2139