### PR TITLE
Do not match exact amount of spaces for errno macro expansion in approvalTests.py

### DIFF
--- a/tools/scripts/approvalTests.py
+++ b/tools/scripts/approvalTests.py
@@ -44,7 +44,7 @@ specialCaseParser = re.compile(r'file\((\d+)\)')
 
 # errno macro expands into various names depending on platform, so we need to fix them up as well
 errnoParser = re.compile(r'''
-    \(\*__errno_location\ \(\)\)
+    \(\*__errno_location\s*\(\)\)
     |
     \(\*__error\(\)\)
     |


### PR DESCRIPTION
## Description
The amount of spaces between the function name and the () is irrelevant, and breaks test on musl libc,
since it expands to `__errno_location()` without the space in between.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
