### PR TITLE
Update catch_debugger.h for Apple Silicon

### DIFF
--- a/include/internal/catch_debugger.h
+++ b/include/internal/catch_debugger.h
@@ -27,6 +27,9 @@ namespace Catch{
         #define CATCH_TRAP() \
                 __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
                 : : : "memory","r0","r3","r4" ) /* NOLINT */
+    #elif defined(__aarch64__)
+        // Backport of https://github.com/catchorg/Catch2/commit/a25c1a24af8bffd35727a888a307ff0280cf9387
+        #define CATCH_TRAP() __asm__(".inst 0xd4200000")
     #else
         #define CATCH_TRAP() __asm__("int $3\n" : : /* NOLINT */ )
     #endif


### PR DESCRIPTION
## Description

`CATCH_TRAP` is not well-defined on Apple Silicon, as there is no codepath for `__aarch64__`.
This is a backport of the Catch2 commit at https://github.com/catchorg/Catch2/commit/a25c1a24af8bffd35727a888a307ff0280cf9387

## GitHub Issues

https://github.com/osmcode/libosmium/issues/320
