### PR TITLE
Fix ULP matcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 option(CATCH_INSTALL_DOCS "Install documentation alongside library" ON)
 option(CATCH_INSTALL_EXTRAS "Install extras alongside library" ON)
 option(CATCH_DEVELOPMENT_BUILD "Build tests, enable warnings, enable Werror, etc" OFF)
+option(CATCH_FORCE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)" OFF)
 
 include(CMakeDependentOption)
 cmake_dependent_option(CATCH_BUILD_TESTING "Build the SelfTest project" ON "CATCH_DEVELOPMENT_BUILD" OFF)
@@ -32,6 +33,14 @@ endif()
 
 
 project(Catch2 LANGUAGES CXX VERSION 3.0.0)
+
+if (${CATCH_FORCE_COLORED_OUTPUT})
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+       add_compile_options (-fdiagnostics-color=always)
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+       add_compile_options (-fcolor-diagnostics)
+    endif ()
+endif()
 
 # Provide path for scripts
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")
@@ -158,7 +167,7 @@ if (NOT_SUBPROJECT)
           DESTINATION
             ${CATCH_CMAKE_CONFIG_DESTINATION}
         )
-    
+
         # Install debugger helpers
         install(
           FILES

--- a/src/catch2/matchers/catch_matchers_floating_point.cpp
+++ b/src/catch2/matchers/catch_matchers_floating_point.cpp
@@ -167,7 +167,7 @@ namespace Detail {
     WithinUlpsMatcher::WithinUlpsMatcher(double target, uint64_t ulps, Detail::FloatingPointKind baseType)
         :m_target{ target }, m_ulps{ ulps }, m_type{ baseType } {
         CATCH_ENFORCE(m_type == Detail::FloatingPointKind::Double
-                   || m_ulps < (std::numeric_limits<uint32_t>::max)(),
+                   || m_ulps <= (std::numeric_limits<uint32_t>::max)(),
             "Provided ULP is impossibly large for a float comparison.");
     }
 

--- a/src/catch2/matchers/catch_matchers_floating_point.cpp
+++ b/src/catch2/matchers/catch_matchers_floating_point.cpp
@@ -66,7 +66,7 @@ namespace {
           return INFINITE_DISTANCE;
         if(a > b) // Ensure a < b
             return -ulpDistance(b, a);
-        if(a == b) // This also ensure ulpDistance(-0f, +0f) == 0
+        if(a == b) // This also ensures ulpDistance(-0f, +0f) == 0
             return 0;
         if(a == 0) // Ensure a != 0
             return 1 + std::abs(ulpDistance((b < 0) ? -EPSILON_0 : EPSILON_0, b));

--- a/tests/SelfTest/UsageTests/Matchers.tests.cpp
+++ b/tests/SelfTest/UsageTests/Matchers.tests.cpp
@@ -16,6 +16,8 @@
 #include <list>
 #include <sstream>
 
+#include <iostream>
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wweak-vtables"
@@ -447,15 +449,45 @@ namespace { namespace MatchersTests {
                 REQUIRE_THAT(-10.f, WithinAbs(-9.6f, 0.5f));
             }
             SECTION("ULPs") {
-                REQUIRE_THAT(1.f, WithinULP(1.f, 0));
+                const float ONE_EPSILON_0 = nextafter(0.f, 1.f);
+                const float TWO_EPSILON_0 = nextafter(ONE_EPSILON_0, 1.f);
+                const float NEG_ONE_EPSILON_1 = nextafter(1.f, 0.f);
+                const float POS_ONE_EPSILON_1 = nextafter(1.f, 2.f);
+                const uint32_t ULP_DISTANCE_0_1 = 1065353216;
 
-                REQUIRE_THAT(nextafter(1.f, 2.f), WithinULP(1.f, 1));
-                REQUIRE_THAT(0.f, WithinULP(nextafter(0.f, 1.f), 1));
-                REQUIRE_THAT(1.f, WithinULP(nextafter(1.f, 0.f), 1));
-                REQUIRE_THAT(1.f, !WithinULP(nextafter(1.f, 2.f), 0));
-
                 REQUIRE_THAT(1.f, WithinULP(1.f, 0));
+                REQUIRE_THAT(-1.f, WithinULP(-1.f, 0));
+                REQUIRE_THAT(-1.f, !WithinULP(1.f, 0));
+                REQUIRE_THAT(1.f, !WithinULP(-1.f, 0));
                 REQUIRE_THAT(-0.f, WithinULP(0.f, 0));
+                REQUIRE_THAT(0.f, WithinULP(-0.f, 0));
+                REQUIRE_THAT(999e10f, WithinULP(999e10f, 0));
+                REQUIRE_THAT(-999e10f, WithinULP(-999e10f, 0));
+                REQUIRE_THAT(999e10f, !WithinULP(-999e10f, 0));
+                REQUIRE_THAT(-999e10f, !WithinULP(999e10f, 0));
+                REQUIRE_THAT(0.f, !WithinULP(1.f, 1));
+                REQUIRE_THAT(1.f, !WithinULP(0.f, 1));
+
+                REQUIRE_THAT(0.f, WithinULP(ONE_EPSILON_0, 1));
+                REQUIRE_THAT(-ONE_EPSILON_0, WithinULP(ONE_EPSILON_0, 2));
+                REQUIRE_THAT(0.f, WithinULP(1.f, ULP_DISTANCE_0_1));
+                REQUIRE_THAT(0.f, WithinULP(-1.f, ULP_DISTANCE_0_1));
+                REQUIRE_THAT(1.f, WithinULP(0.f, ULP_DISTANCE_0_1));
+                REQUIRE_THAT(-1.f, WithinULP(0.f, ULP_DISTANCE_0_1));
+                REQUIRE_THAT(-1.f, WithinULP(1.f, 2*ULP_DISTANCE_0_1));
+                REQUIRE_THAT(1.f, WithinULP(-1.f, 2*ULP_DISTANCE_0_1));
+
+                REQUIRE_THAT(0.f, WithinULP(ONE_EPSILON_0, 1));
+                REQUIRE_THAT(0.f, WithinULP(TWO_EPSILON_0, 2));
+                REQUIRE_THAT(1.f, WithinULP(NEG_ONE_EPSILON_1, 1));
+                REQUIRE_THAT(1.f, WithinULP(POS_ONE_EPSILON_1, 1));
+                REQUIRE_THAT(POS_ONE_EPSILON_1, WithinULP(1.f, 1));
+                REQUIRE_THAT(1.f, !WithinULP(NEG_ONE_EPSILON_1, 0));
+                REQUIRE_THAT(1.f, !WithinULP(POS_ONE_EPSILON_1, 0));
+
+                REQUIRE_THAT(0.f, WithinULP(TWO_EPSILON_0, 2));
+                REQUIRE_THAT(ONE_EPSILON_0, WithinULP(TWO_EPSILON_0, 1));
+                REQUIRE_THAT(POS_ONE_EPSILON_1, WithinULP(NEG_ONE_EPSILON_1, 2));
             }
             SECTION("Composed") {
                 REQUIRE_THAT(1.f, WithinAbs(1.f, 0.5) || WithinULP(1.f, 1));
@@ -503,15 +535,45 @@ namespace { namespace MatchersTests {
                 REQUIRE_THAT(-10., WithinAbs(-9.6, 0.5));
             }
             SECTION("ULPs") {
-                REQUIRE_THAT(1., WithinULP(1., 0));
+                const double ONE_EPSILON_0 = nextafter(0., 1.);
+                const double TWO_EPSILON_0 = nextafter(ONE_EPSILON_0, 1.);
+                const double NEG_ONE_EPSILON_1 = nextafter(1., 0.);
+                const double POS_ONE_EPSILON_1 = nextafter(1., 2.);
+                const uint64_t ULP_DISTANCE_0_1 = 4607182418800017408;
 
-                REQUIRE_THAT(nextafter(1., 2.), WithinULP(1., 1));
-                REQUIRE_THAT(0.,  WithinULP(nextafter(0., 1.), 1));
-                REQUIRE_THAT(1.,  WithinULP(nextafter(1., 0.), 1));
-                REQUIRE_THAT(1., !WithinULP(nextafter(1., 2.), 0));
-
                 REQUIRE_THAT(1., WithinULP(1., 0));
+                REQUIRE_THAT(-1., WithinULP(-1., 0));
+                REQUIRE_THAT(-1., !WithinULP(1., 0));
+                REQUIRE_THAT(1., !WithinULP(-1., 0));
                 REQUIRE_THAT(-0., WithinULP(0., 0));
+                REQUIRE_THAT(0., WithinULP(-0., 0));
+                REQUIRE_THAT(999e10, WithinULP(999e10, 0));
+                REQUIRE_THAT(-999e10, WithinULP(-999e10, 0));
+                REQUIRE_THAT(999e10, !WithinULP(-999e10, 0));
+                REQUIRE_THAT(-999e10, !WithinULP(999e10, 0));
+                REQUIRE_THAT(0., !WithinULP(1., 1));
+                REQUIRE_THAT(1., !WithinULP(0., 1));
+
+                REQUIRE_THAT(0., WithinULP(ONE_EPSILON_0, 1));
+                REQUIRE_THAT(-ONE_EPSILON_0, WithinULP(ONE_EPSILON_0, 2));
+                REQUIRE_THAT(0., WithinULP(1., ULP_DISTANCE_0_1));
+                REQUIRE_THAT(0., WithinULP(-1., ULP_DISTANCE_0_1));
+                REQUIRE_THAT(1., WithinULP(0., ULP_DISTANCE_0_1));
+                REQUIRE_THAT(-1., WithinULP(0., ULP_DISTANCE_0_1));
+                REQUIRE_THAT(-1., WithinULP(1., 2*ULP_DISTANCE_0_1));
+                REQUIRE_THAT(1., WithinULP(-1., 2*ULP_DISTANCE_0_1));
+
+                REQUIRE_THAT(0., WithinULP(ONE_EPSILON_0, 1));
+                REQUIRE_THAT(0., WithinULP(TWO_EPSILON_0, 2));
+                REQUIRE_THAT(1., WithinULP(NEG_ONE_EPSILON_1, 1));
+                REQUIRE_THAT(1., WithinULP(POS_ONE_EPSILON_1, 1));
+                REQUIRE_THAT(POS_ONE_EPSILON_1, WithinULP(1., 1));
+                REQUIRE_THAT(1., !WithinULP(NEG_ONE_EPSILON_1, 0));
+                REQUIRE_THAT(1., !WithinULP(POS_ONE_EPSILON_1, 0));
+
+                REQUIRE_THAT(0., WithinULP(TWO_EPSILON_0, 2));
+                REQUIRE_THAT(ONE_EPSILON_0, WithinULP(TWO_EPSILON_0, 1));
+                REQUIRE_THAT(POS_ONE_EPSILON_1, WithinULP(NEG_ONE_EPSILON_1, 2));
             }
             SECTION("Composed") {
                 REQUIRE_THAT(1., WithinAbs(1., 0.5) || WithinULP(2., 1));

--- a/tests/SelfTest/UsageTests/Matchers.tests.cpp
+++ b/tests/SelfTest/UsageTests/Matchers.tests.cpp
@@ -603,6 +603,14 @@ namespace { namespace MatchersTests {
             REQUIRE_THAT(NAN, !WithinRel(NAN));
             REQUIRE_THAT(1., !WithinRel(NAN));
             REQUIRE_THAT(NAN, !WithinRel(1.));
+            REQUIRE_THAT(INFINITY, WithinULP(INFINITY, 0));
+            REQUIRE_THAT(-INFINITY, WithinULP(-INFINITY, 0));
+            REQUIRE_THAT(INFINITY, !WithinULP(-INFINITY, 0));
+            REQUIRE_THAT(-INFINITY, !WithinULP(INFINITY, 0));
+            REQUIRE_THAT(-INFINITY, !WithinULP(static_cast<float>(INFINITY), std::numeric_limits<uint32_t>::max()));
+            REQUIRE_THAT(INFINITY, !WithinULP(static_cast<float>(-INFINITY), std::numeric_limits<uint32_t>::max()));
+            REQUIRE_THAT(1., !WithinULP(INFINITY, std::numeric_limits<uint32_t>::max()));
+            REQUIRE_THAT(1., !WithinULP(-INFINITY, std::numeric_limits<uint32_t>::max()));
         }
 
         TEST_CASE("Arbitrary predicate matcher", "[matchers][generic]") {

--- a/tests/SelfTest/UsageTests/Matchers.tests.cpp
+++ b/tests/SelfTest/UsageTests/Matchers.tests.cpp
@@ -16,8 +16,6 @@
 #include <list>
 #include <sstream>
 
-#include <iostream>
-
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wweak-vtables"


### PR DESCRIPTION
In [the ULP matcher implemented](https://github.com/catchorg/Catch2/blob/a091853f4ae62b428983c63224fec9f1af377295/src/catch2/matchers/catch_matchers_floating_point.cpp#L52-L55), there is a check `(lc < 0) != (rc < 0)` seemingly there to allow `+0` and `-0` to compare equal even if `maxUlpDiff` is zero. However, this check passes for _any_ two numbers that do not have the same sign. This is incorrect, for example `almostEqualUlps(-EPSILON, EPSILON, INT64_MAX)` returns false, even though it is obviously true (`2` ULPS < `INT_MAX` ULPS). I've reimplemented the matcher, using `boost::math` as a reference.