### PR TITLE
[Issue 2154] Correct error when building with IBM's latest XLC

### DIFF
--- a/include/internal/catch_matchers_floating.cpp
+++ b/include/internal/catch_matchers_floating.cpp
@@ -55,6 +55,7 @@ namespace {
             return lhs == rhs;
         }
 
+        // static cast as a workaround for IBM XLC
         auto ulpDiff = std::abs(static_cast<FP>(lc - rc));
         return static_cast<uint64_t>(ulpDiff) <= maxUlpDiff;
     }
@@ -234,4 +235,3 @@ Floating::WithinRelMatcher WithinRel(float target) {
 
 } // namespace Matchers
 } // namespace Catch
-

--- a/include/internal/catch_matchers_floating.cpp
+++ b/include/internal/catch_matchers_floating.cpp
@@ -55,7 +55,7 @@ namespace {
             return lhs == rhs;
         }
 
-        auto ulpDiff = std::abs(lc - rc);
+        auto ulpDiff = std::abs(static_cast<FP>(lc - rc));
         return static_cast<uint64_t>(ulpDiff) <= maxUlpDiff;
     }
 


### PR DESCRIPTION
Correct error when building with IBM's latest XLC compiler with xlclang++ front-end.

On AIX, the XLC 16.1.0.1 compiler considers the call to `std::abs` ambiguous, so it needs help with a static_cast to the type of the template argument.


## Description

Add a statc_cast to make IBM's xlclang++ happy.

## GitHub Issues
#2154 


With this change (and a freshly generated catch.hpp) the test suite fails 3 tests.
Without this change, a compiler error is thrown from Cmake.

```
(python-env-aix7-dev) robb@aix7-dev:/raid/proj/procyon/checkouts-procyon/robb/dle-sandbox/Catch2/debug-build (xlclang-fix)$ ctest -j 4 --output-on-failure -C Debug
Test project /raid/proj/procyon/checkouts-procyon/robb/dle-sandbox/Catch2/debug-build
      Start  1: RunTests
      Start  2: ListTests
      Start  3: ListTags
      Start  4: ListReporters
 1/38 Test  #3: ListTags .............................................   Passed    0.05 sec
      Start  5: ListTestNamesOnly
 2/38 Test  #2: ListTests ............................................   Passed    0.12 sec
      Start  6: NoAssertions
 3/38 Test  #4: ListReporters ........................................   Passed    0.11 sec
      Start  7: NoTest
 4/38 Test  #1: RunTests .............................................   Passed    0.40 sec
      Start  8: WarnAboutNoTests
 5/38 Test  #5: ListTestNamesOnly ....................................   Passed    0.21 sec
      Start  9: UnmatchedOutputFilter
 6/38 Test  #6: NoAssertions .........................................   Passed    0.21 sec
      Start 10: FilteredSection-1
 7/38 Test  #7: NoTest ...............................................   Passed    0.12 sec
      Start 11: FilteredSection-2
 8/38 Test  #8: WarnAboutNoTests .....................................   Passed    0.09 sec
      Start 12: FilteredSection::GeneratorsDontCauseInfiniteLoop-1
 9/38 Test  #9: UnmatchedOutputFilter ................................   Passed    0.08 sec
      Start 13: FilteredSection::GeneratorsDontCauseInfiniteLoop-2
10/38 Test #10: FilteredSection-1 ....................................   Passed    0.08 sec
      Start 14: ApprovalTests
11/38 Test #11: FilteredSection-2 ....................................   Passed    0.08 sec
      Start 15: RegressionCheck-1670
12/38 Test #12: FilteredSection::GeneratorsDontCauseInfiniteLoop-1 ...   Passed    0.08 sec
      Start 16: VersionCheck
13/38 Test #13: FilteredSection::GeneratorsDontCauseInfiniteLoop-2 ...   Passed    0.20 sec
      Start 17: LibIdentityTest
14/38 Test #15: RegressionCheck-1670 .................................   Passed    0.20 sec
      Start 18: FilenameAsTagsTest
15/38 Test #16: VersionCheck .........................................   Passed    0.15 sec
      Start 19: EscapeSpecialCharactersInTestNames
16/38 Test #17: LibIdentityTest ......................................   Passed    0.06 sec
      Start 20: TestsInFile::SimpleSpecs
17/38 Test #18: FilenameAsTagsTest ...................................   Passed    0.06 sec
      Start 21: TestsInFile::EscapeSpecialCharacters
18/38 Test #19: EscapeSpecialCharactersInTestNames ...................   Passed    0.09 sec
      Start 22: TestsInFile::InvalidTestNames-1
19/38 Test #20: TestsInFile::SimpleSpecs .............................   Passed    0.09 sec
      Start 23: TestsInFile::InvalidTestNames-2
20/38 Test #21: TestsInFile::EscapeSpecialCharacters .................   Passed    0.16 sec
      Start 24: RandomTestOrdering
21/38 Test #22: TestsInFile::InvalidTestNames-1 ......................   Passed    0.19 sec
      Start 26: MinDuration::DurationOverrideYes
22/38 Test #23: TestsInFile::InvalidTestNames-2 ......................   Passed    0.20 sec
      Start 27: MinDuration::DurationOverrideNo
23/38 Test #24: RandomTestOrdering ...................................   Passed    0.21 sec
      Start 28: CATCH_CONFIG_PREFIX_ALL
24/38 Test #28: CATCH_CONFIG_PREFIX_ALL ..............................   Passed    0.01 sec
      Start 29: CATCH_CONFIG_DISABLE-1
25/38 Test #29: CATCH_CONFIG_DISABLE-1 ...............................   Passed    0.01 sec
      Start 30: CATCH_CONFIG_DISABLE-2
26/38 Test #30: CATCH_CONFIG_DISABLE-2 ...............................   Passed    0.01 sec
      Start 31: CATCH_CONFIG_DISABLE_EXCEPTIONS-1
27/38 Test #31: CATCH_CONFIG_DISABLE_EXCEPTIONS-1 ....................   Passed    0.01 sec
      Start 32: CATCH_CONFIG_DISABLE_EXCEPTIONS-2
28/38 Test #32: CATCH_CONFIG_DISABLE_EXCEPTIONS-2 ....................***Failed  Required regular expression not found. Regex=[Catch will terminate
]  0.01 sec
Filters: Tests that abort

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DisabledExceptions-DefaultHandler is a Catch v2.13.4 host application.
Run with -? for options

-------------------------------------------------------------------------------
Tests that abort
-------------------------------------------------------------------------------
/raid/proj/procyon/checkouts-procyon/robb/dle-sandbox/Catch2/projects/ExtraTests/X03-DisabledExceptions-DefaultHandler.cpp:14
...............................................................................

/raid/proj/procyon/checkouts-procyon/robb/dle-sandbox/Catch2/projects/ExtraTests/X03-DisabledExceptions-DefaultHandler.cpp:20: FAILED:
  REQUIRE( 1 == 3 )

===============================================================================
test cases: 1 | 1 failed
assertions: 3 | 2 passed | 1 failed


      Start 33: CATCH_CONFIG_DISABLE_EXCEPTIONS-3
29/38 Test #33: CATCH_CONFIG_DISABLE_EXCEPTIONS-3 ....................   Passed    0.01 sec
      Start 34: CATCH_CONFIG_DISABLE_EXCEPTIONS-4
30/38 Test #34: CATCH_CONFIG_DISABLE_EXCEPTIONS-4 ....................***Failed  Required regular expression not found. Regex=[====== CUSTOM HANDLER ======
]  0.01 sec
Filters: Tests that abort

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DisabledExceptions-CustomHandler is a Catch v2.13.4 host application.
Run with -? for options

-------------------------------------------------------------------------------
Tests that abort
-------------------------------------------------------------------------------
/raid/proj/procyon/checkouts-procyon/robb/dle-sandbox/Catch2/projects/ExtraTests/X04-DisabledExceptions-CustomHandler.cpp:27
...............................................................................

/raid/proj/procyon/checkouts-procyon/robb/dle-sandbox/Catch2/projects/ExtraTests/X04-DisabledExceptions-CustomHandler.cpp:30: FAILED:
  REQUIRE( 1 == 3 )

===============================================================================
test cases: 1 | 1 failed
assertions: 3 | 2 passed | 1 failed


      Start 35: FallbackStringifier
31/38 Test #35: FallbackStringifier ..................................   Passed    0.01 sec
      Start 36: CATCH_CONFIG_DISABLE_STRINGIFICATION
32/38 Test #36: CATCH_CONFIG_DISABLE_STRINGIFICATION .................   Passed    0.01 sec
      Start 37: BenchmarkingMacros
33/38 Test #26: MinDuration::DurationOverrideYes .....................   Passed    0.40 sec
      Start 38: DebugBreakMacros
34/38 Test #38: DebugBreakMacros .....................................   Passed    0.01 sec
35/38 Test #27: MinDuration::DurationOverrideNo ......................   Passed    0.37 sec
36/38 Test #14: ApprovalTests ........................................***Failed  Error regular expression found in output. Regex=[Results differed]  3.32 sec
Running approvals against executable:
  /raid/proj/procyon/checkouts-procyon/robb/dle-sandbox/Catch2/debug-build/projects/SelfTest

console.std:
  Results matched


console.sw:
--- console.sw.approved.txt

+++ console.sw.unapproved.txt

-  REQUIRE( errno == 1 )
+  REQUIRE( (*_Errno()) == 1 )
  
****************************
  Results differed


console.swa4:
--- console.swa4.approved.txt

+++ console.swa4.unapproved.txt

-  REQUIRE( errno == 1 )
+  REQUIRE( (*_Errno()) == 1 )
  
****************************
  Results differed


junit.sw:
  Results matched


xml.sw:
--- xml.sw.approved.txt

+++ xml.sw.unapproved.txt

-          errno == 1
+          (*_Errno()) == 1
  
****************************
  Results differed


compact.sw:
--- compact.sw.approved.txt

+++ compact.sw.unapproved.txt

-Misc.tests.cpp:<line number>: passed: errno == 1 for: 1 == 1
+Misc.tests.cpp:<line number>: passed: (*_Errno()) == 1 for: 1 == 1
  
****************************
  Results differed


sonarqube.sw:
  Results matched

If these differences are expected, run approve.py to approve new baselines.

37/38 Test #37: BenchmarkingMacros ...................................   Passed   18.97 sec
      Start 25: MinDuration::SimpleThreshold
38/38 Test #25: MinDuration::SimpleThreshold .........................   Passed    0.37 sec

92% tests passed, 3 tests failed out of 38

Total Test time (real) =  21.25 sec

The following tests FAILED:
	 14 - ApprovalTests (Failed)
	 32 - CATCH_CONFIG_DISABLE_EXCEPTIONS-2 (Failed)
	 34 - CATCH_CONFIG_DISABLE_EXCEPTIONS-4 (Failed)
Errors while running CTest
(python-env-aix7-dev) robb@aix7-dev:/raid/proj/procyon/checkouts-procyon/robb/dle-sandbox/Catch2/debug-build (xlclang-fix)$ 
```