### PR TITLE
Wrap all std::min and std::max calls in parentheses

### DIFF
--- a/include/internal/benchmark/detail/catch_estimate_clock.hpp
+++ b/include/internal/benchmark/detail/catch_estimate_clock.hpp
@@ -68,7 +68,9 @@ namespace Catch {
             }
             template <typename Clock>
             EnvironmentEstimate<FloatDuration<Clock>> estimate_clock_cost(FloatDuration<Clock> resolution) {
-                auto time_limit = std::min(resolution * clock_cost_estimation_tick_limit, FloatDuration<Clock>(clock_cost_estimation_time_limit));
+                auto time_limit = (std::min)(
+                    resolution * clock_cost_estimation_tick_limit,
+                    FloatDuration<Clock>(clock_cost_estimation_time_limit));
                 auto time_clock = [](int k) {
                     return Detail::measure<Clock>([k] {
                         for (int i = 0; i < k; ++i) {

--- a/include/internal/benchmark/detail/catch_stats.cpp
+++ b/include/internal/benchmark/detail/catch_stats.cpp
@@ -152,7 +152,7 @@ namespace Catch {
                 double sb = stddev.point;
                 double mn = mean.point / n;
                 double mg_min = mn / 2.;
-                double sg = std::min(mg_min / 4., sb / std::sqrt(n));
+                double sg = (std::min)(mg_min / 4., sb / std::sqrt(n));
                 double sg2 = sg * sg;
                 double sb2 = sb * sb;
 
@@ -171,7 +171,7 @@ namespace Catch {
                     return (nc / n) * (sb2 - nc * sg2);
                 };
 
-                return std::min(var_out(1), var_out(std::min(c_max(0.), c_max(mg_min)))) / sb2;
+                return (std::min)(var_out(1), var_out((std::min)(c_max(0.), c_max(mg_min)))) / sb2;
             }
 
 

--- a/include/internal/benchmark/detail/catch_stats.hpp
+++ b/include/internal/benchmark/detail/catch_stats.hpp
@@ -138,8 +138,8 @@ namespace Catch {
                 double b2 = bias - z1;
                 double a1 = a(b1);
                 double a2 = a(b2);
-                auto lo = std::max(cumn(a1), 0);
-                auto hi = std::min(cumn(a2), n - 1);
+                auto lo = (std::max)(cumn(a1), 0);
+                auto hi = (std::min)(cumn(a2), n - 1);
 
                 return { point, resample[lo], resample[hi], confidence_level };
             }


### PR DESCRIPTION
Fixes x86 MSVC v19.28 compiler error C2589 on Windows.

Many of the std::min and std::max calls were already wrapped in parentheses.

Some of the errors were for benchmark builds only.