### PR TITLE
Use gmtime_r instead of gmtime when compiling for posixy platforms

### DIFF
--- a/src/catch2/reporters/catch_reporter_junit.cpp
+++ b/src/catch2/reporters/catch_reporter_junit.cpp
@@ -22,28 +22,22 @@ namespace Catch {
 
     namespace {
         std::string getCurrentTimestamp() {
-            // Beware, this is not reentrant because of backward compatibility issues
-            // Also, UTC only, again because of backward compatibility (%z is C++11)
             time_t rawtime;
             std::time(&rawtime);
-            auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
 
-#ifdef _MSC_VER
             std::tm timeInfo = {};
+#ifdef _MSC_VER
             gmtime_s(&timeInfo, &rawtime);
 #else
-            std::tm* timeInfo;
-            timeInfo = std::gmtime(&rawtime);
+            gmtime_r(&rawtime, &timeInfo);
 #endif
 
+            auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
             char timeStamp[timeStampSize];
             const char * const fmt = "%Y-%m-%dT%H:%M:%SZ";
 
-#ifdef _MSC_VER
             std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
-#else
-            std::strftime(timeStamp, timeStampSize, fmt, timeInfo);
-#endif
+
             return std::string(timeStamp);
         }
 


### PR DESCRIPTION
## Description
`gmtime` has the rather obvious problem of not being reentrant, and thus being rather unsafe to use. Catch2 does not support threads in its internals, but this is not enough to avoid the danger: if user uses `gmtime` inside the tested function, then our use of `gmtime` in the JUnit reporter will corrupt their state.

However, it took until `C11` to get a standard alternative, which is `gmtime_s`, and which is only available under specific conditions (`__STDC_WANT_LIB_EXT1__` has to be defined before the first inclusion of `time.h`). Instead we use `gmtime_r`, which while standardized only by `C23`, has been part of POSIX for ages.

While there are no nice compatibility guarantees for using `gmtime_r`, it should likely be compatible with all major supported non-Windows platforms.


## GitHub Issues
Closes #2008