### PR TITLE
Add surrogate TUs for header files

### DIFF
--- a/.github/workflows/check-surrogates.yml
+++ b/.github/workflows/check-surrogates.yml
@@ -1,0 +1,20 @@
+name: Check surrogate files
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    # Set the type of machine to run on
+    runs-on: ubuntu-20.04
+    steps:
+
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Setup Dependencies
+        uses: actions/setup-python@v2
+        with:
+            python-version: '3.7'
+      - name: Check each header for its respective surrogate
+        run: |
+          ./tools/scripts/checkSurrogateExists.py

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -263,4 +263,6 @@ endif()
 list(APPEND CATCH_WARNING_TARGETS SelfTest)
 set(CATCH_WARNING_TARGETS ${CATCH_WARNING_TARGETS} PARENT_SCOPE)
 
-add_subdirectory(SurrogateCpps)
+if(CATCH_BUILD_SURROGATES)
+    add_subdirectory(SurrogateCpps)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -262,3 +262,5 @@ endif()
 
 list(APPEND CATCH_WARNING_TARGETS SelfTest)
 set(CATCH_WARNING_TARGETS ${CATCH_WARNING_TARGETS} PARENT_SCOPE)
+
+add_subdirectory(SurrogateCpps)

--- a/tests/ExtraTests/CMakeLists.txt
+++ b/tests/ExtraTests/CMakeLists.txt
@@ -224,3 +224,14 @@ set_tests_properties(
   PROPERTIES
     PASS_REGULAR_EXPRESSION "All tests passed \\(14 assertions in 3 test cases\\)"
 )
+
+add_executable(SurrogateCatchBenchmark
+  ${TESTS_DIR}/surr_catch_benchmark.cpp
+)
+
+target_include_directories(SurrogateCatchBenchmark PUBLIC ${CATCH_DIR}/src/)
+set_property( TARGET SurrogateCatchBenchmark PROPERTY CXX_STANDARD 14 )
+set_property( TARGET SurrogateCatchBenchmark PROPERTY CXX_STANDARD_REQUIRED ON )
+set_property( TARGET SurrogateCatchBenchmark PROPERTY CXX_EXTENSIONS OFF )
+
+add_test(NAME SurrogateCatchBenchmarkTest COMMAND SurrogateCatchBenchmark)

--- a/tests/ExtraTests/surr_catch_benchmark.cpp
+++ b/tests/ExtraTests/surr_catch_benchmark.cpp
@@ -1,0 +1,6 @@
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+
+int main(void) {
+  return 0;
+}

--- a/tests/SurrogateCpps/CMakeLists.txt
+++ b/tests/SurrogateCpps/CMakeLists.txt
@@ -42,6 +42,12 @@ set(SURROGATE_TEST_SOURCES
   surr_catch_translate_exception.cpp
   surr_catch_version.cpp
   surr_catch_version_macros.cpp
+  surr_catch_generator_exception.cpp
+  surr_catch_generators.cpp
+  surr_catch_generators_adapters.cpp
+  surr_catch_generators_all.cpp
+  surr_catch_generators_random.cpp
+  surr_catch_generators_range.cpp
   )
 
 add_executable(SurrogateTUsTest ${SURROGATE_TEST_SOURCES})

--- a/tests/SurrogateCpps/CMakeLists.txt
+++ b/tests/SurrogateCpps/CMakeLists.txt
@@ -2,6 +2,25 @@ include(CTest)
 
 set(SURROGATE_TEST_SOURCES
   surr_catch_benchmark.cpp
+  surr_catch_benchmark_all.cpp
+  surr_catch_chronometer.cpp
+  surr_catch_clock.cpp
+  #surr_catch_constructor.cpp #This does not build
+  surr_catch_environment.cpp
+  surr_catch_estimate.cpp
+  surr_catch_execution_plan.cpp
+  surr_catch_optimizer.cpp
+  surr_catch_outlier_classification.cpp
+  surr_catch_sample_analysis.cpp
+  #surr_catch_analyse.cpp #This does not build
+  surr_catch_benchmark_function.cpp
+  surr_catch_complete_invoke.cpp
+  surr_catch_estimate_clock.cpp
+  surr_catch_measure.cpp
+  surr_catch_repeat.cpp
+  surr_catch_run_for_at_least.cpp
+  surr_catch_stats.cpp
+  surr_catch_timing.cpp
   )
 
 add_executable(SurrogateTUsTest ${SURROGATE_TEST_SOURCES})

--- a/tests/SurrogateCpps/CMakeLists.txt
+++ b/tests/SurrogateCpps/CMakeLists.txt
@@ -48,6 +48,19 @@ set(SURROGATE_TEST_SOURCES
   surr_catch_generators_all.cpp
   surr_catch_generators_random.cpp
   surr_catch_generators_range.cpp
+  surr_catch_interfaces_all.cpp
+  surr_catch_interfaces_capture.cpp
+  surr_catch_interfaces_config.cpp
+  surr_catch_interfaces_enum_values_registry.cpp
+  surr_catch_interfaces_exception.cpp
+  surr_catch_interfaces_generatortracker.cpp
+  surr_catch_interfaces_registry_hub.cpp
+  surr_catch_interfaces_reporter.cpp
+  #surr_catch_interfaces_reporter_factory.cpp # This does not build
+  surr_catch_interfaces_reporter_registry.cpp
+  surr_catch_interfaces_runner.cpp
+  surr_catch_interfaces_tag_alias_registry.cpp
+  surr_catch_interfaces_testcase.cpp
   )
 
 add_executable(SurrogateTUsTest ${SURROGATE_TEST_SOURCES})

--- a/tests/SurrogateCpps/CMakeLists.txt
+++ b/tests/SurrogateCpps/CMakeLists.txt
@@ -75,6 +75,18 @@ set(SURROGATE_TEST_SOURCES
   surr_catch_reporter_teamcity.cpp
   surr_catch_reporter_xml.cpp
   surr_catch_reporters_all.cpp
+  surr_catch_matchers.cpp
+  surr_catch_matchers_all.cpp
+  surr_catch_matchers_container_properties.cpp
+  surr_catch_matchers_contains.cpp
+  surr_catch_matchers_exception.cpp
+  surr_catch_matchers_floating_point.cpp
+  surr_catch_matchers_predicate.cpp
+  surr_catch_matchers_quantifiers.cpp
+  surr_catch_matchers_string.cpp
+  surr_catch_matchers_templated.cpp
+  surr_catch_matchers_vector.cpp
+  surr_catch_matchers_impl.cpp
   )
 add_executable(SurrogateTUsTest ${SURROGATE_TEST_SOURCES})
 target_link_libraries(SurrogateTUsTest PRIVATE Catch2WithMain)

--- a/tests/SurrogateCpps/CMakeLists.txt
+++ b/tests/SurrogateCpps/CMakeLists.txt
@@ -87,7 +87,67 @@ set(SURROGATE_TEST_SOURCES
   surr_catch_matchers_templated.cpp
   surr_catch_matchers_vector.cpp
   surr_catch_matchers_impl.cpp
+  surr_catch_assertion_handler.cpp
+  surr_catch_case_sensitive.cpp
+  surr_catch_clara.cpp
+  surr_catch_commandline.cpp
+  surr_catch_compiler_capabilities.cpp
+  surr_catch_config_android_logwrite.cpp
+  surr_catch_config_counter.cpp
+  surr_catch_config_uncaught_exceptions.cpp
+  surr_catch_config_wchar.cpp
+  surr_catch_console_colour.cpp
+  surr_catch_console_width.cpp
+  #surr_catch_container_nonmembers.cpp
+  surr_catch_context.cpp
+  surr_catch_debug_console.cpp
+  surr_catch_debugger.cpp
+  surr_catch_decomposer.cpp
+  surr_catch_enforce.cpp
+  surr_catch_enum_values_registry.cpp
+  surr_catch_errno_guard.cpp
+  surr_catch_exception_translator_registry.cpp
+  surr_catch_fatal_condition_handler.cpp
+  surr_catch_lazy_expr.cpp
+  surr_catch_leak_detector.cpp
+  surr_catch_list.cpp
+  surr_catch_message_info.cpp
+  surr_catch_meta.cpp
+  surr_catch_noncopyable.cpp
+  surr_catch_option.cpp
+  surr_catch_output_redirect.cpp
+  surr_catch_platform.cpp
+  surr_catch_polyfills.cpp
+  surr_catch_preprocessor.cpp
+  surr_catch_random_number_generator.cpp
+  surr_catch_reporter_registry.cpp
+  surr_catch_result_type.cpp
+  surr_catch_run_context.cpp
+  surr_catch_section.cpp
+  surr_catch_singletons.cpp
+  surr_catch_source_line_info.cpp
+  surr_catch_startup_exception_registry.cpp
+  surr_catch_stream.cpp
+  surr_catch_stream_end_stop.cpp
+  surr_catch_string_manip.cpp
+  surr_catch_stringref.cpp
+  surr_catch_tag_alias_registry.cpp
+  surr_catch_template_test_registry.cpp
+  surr_catch_test_case_registry_impl.cpp
+  surr_catch_test_case_tracker.cpp
+  surr_catch_test_failure_exception.cpp
+  surr_catch_test_macro_impl.cpp
+  surr_catch_test_registry.cpp
+  surr_catch_test_spec_parser.cpp
+  surr_catch_textflow.cpp
+  surr_catch_to_string.cpp
+  surr_catch_uncaught_exceptions.cpp
+  surr_catch_unique_ptr.cpp
+  surr_catch_wildcard_pattern.cpp
+  surr_catch_windows_h_proxy.cpp
+  surr_catch_xmlwriter.cpp
   )
+
 add_executable(SurrogateTUsTest ${SURROGATE_TEST_SOURCES})
 target_link_libraries(SurrogateTUsTest PRIVATE Catch2WithMain)
 

--- a/tests/SurrogateCpps/CMakeLists.txt
+++ b/tests/SurrogateCpps/CMakeLists.txt
@@ -1,0 +1,10 @@
+include(CTest)
+
+set(SURROGATE_TEST_SOURCES
+  surr_catch_benchmark.cpp
+  )
+
+add_executable(SurrogateTUsTest ${SURROGATE_TEST_SOURCES})
+target_link_libraries(SurrogateTUsTest PRIVATE Catch2WithMain)
+
+add_test(NAME SurrogateTUsTest COMMAND $<TARGET_FILE:SurrogateTUsTest>)

--- a/tests/SurrogateCpps/CMakeLists.txt
+++ b/tests/SurrogateCpps/CMakeLists.txt
@@ -21,6 +21,27 @@ set(SURROGATE_TEST_SOURCES
   surr_catch_run_for_at_least.cpp
   surr_catch_stats.cpp
   surr_catch_timing.cpp
+  surr_catch_all.cpp
+  surr_catch_approx.cpp
+  surr_catch_assertion_info.cpp
+  surr_catch_assertion_result.cpp
+  surr_catch_config.cpp
+  surr_catch_message.cpp
+  #surr_catch_reporter_registrars.cpp #This does not build
+  surr_catch_section_info.cpp
+  surr_catch_session.cpp
+  surr_catch_tag_alias.cpp
+  surr_catch_tag_alias_autoregistrar.cpp
+  surr_catch_template_test_macros.cpp
+  surr_catch_test_case_info.cpp
+  surr_catch_test_macros.cpp
+  surr_catch_test_spec.cpp
+  surr_catch_timer.cpp
+  surr_catch_tostring.cpp
+  surr_catch_totals.cpp
+  surr_catch_translate_exception.cpp
+  surr_catch_version.cpp
+  surr_catch_version_macros.cpp
   )
 
 add_executable(SurrogateTUsTest ${SURROGATE_TEST_SOURCES})

--- a/tests/SurrogateCpps/CMakeLists.txt
+++ b/tests/SurrogateCpps/CMakeLists.txt
@@ -61,8 +61,21 @@ set(SURROGATE_TEST_SOURCES
   surr_catch_interfaces_runner.cpp
   surr_catch_interfaces_tag_alias_registry.cpp
   surr_catch_interfaces_testcase.cpp
+  surr_catch_reporter_automake.cpp
+  surr_catch_reporter_compact.cpp
+  surr_catch_reporter_console.cpp
+  surr_catch_reporter_cumulative_base.cpp
+  surr_catch_reporter_event_listener.cpp
+  surr_catch_reporter_helpers.cpp
+  surr_catch_reporter_junit.cpp
+  surr_catch_reporter_listening.cpp
+  surr_catch_reporter_sonarqube.cpp
+  surr_catch_reporter_streaming_base.cpp
+  surr_catch_reporter_tap.cpp
+  surr_catch_reporter_teamcity.cpp
+  surr_catch_reporter_xml.cpp
+  surr_catch_reporters_all.cpp
   )
-
 add_executable(SurrogateTUsTest ${SURROGATE_TEST_SOURCES})
 target_link_libraries(SurrogateTUsTest PRIVATE Catch2WithMain)
 

--- a/tests/SurrogateCpps/surr_catch_all.cpp
+++ b/tests/SurrogateCpps/surr_catch_all.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_all.hpp>

--- a/tests/SurrogateCpps/surr_catch_analyse.cpp
+++ b/tests/SurrogateCpps/surr_catch_analyse.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/detail/catch_analyse.hpp>

--- a/tests/SurrogateCpps/surr_catch_approx.cpp
+++ b/tests/SurrogateCpps/surr_catch_approx.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_approx.hpp>

--- a/tests/SurrogateCpps/surr_catch_assertion_handler.cpp
+++ b/tests/SurrogateCpps/surr_catch_assertion_handler.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_assertion_handler.hpp>

--- a/tests/SurrogateCpps/surr_catch_assertion_info.cpp
+++ b/tests/SurrogateCpps/surr_catch_assertion_info.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_assertion_info.hpp>

--- a/tests/SurrogateCpps/surr_catch_assertion_result.cpp
+++ b/tests/SurrogateCpps/surr_catch_assertion_result.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_assertion_result.hpp>

--- a/tests/SurrogateCpps/surr_catch_benchmark.cpp
+++ b/tests/SurrogateCpps/surr_catch_benchmark.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/catch_benchmark.hpp>

--- a/tests/SurrogateCpps/surr_catch_benchmark_all.cpp
+++ b/tests/SurrogateCpps/surr_catch_benchmark_all.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/catch_benchmark_all.hpp>

--- a/tests/SurrogateCpps/surr_catch_benchmark_function.cpp
+++ b/tests/SurrogateCpps/surr_catch_benchmark_function.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/detail/catch_benchmark_function.hpp>

--- a/tests/SurrogateCpps/surr_catch_case_sensitive.cpp
+++ b/tests/SurrogateCpps/surr_catch_case_sensitive.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_case_sensitive.hpp>

--- a/tests/SurrogateCpps/surr_catch_chronometer.cpp
+++ b/tests/SurrogateCpps/surr_catch_chronometer.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/catch_chronometer.hpp>

--- a/tests/SurrogateCpps/surr_catch_clara.cpp
+++ b/tests/SurrogateCpps/surr_catch_clara.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_clara.hpp>

--- a/tests/SurrogateCpps/surr_catch_clock.cpp
+++ b/tests/SurrogateCpps/surr_catch_clock.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/catch_clock.hpp>

--- a/tests/SurrogateCpps/surr_catch_commandline.cpp
+++ b/tests/SurrogateCpps/surr_catch_commandline.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_commandline.hpp>

--- a/tests/SurrogateCpps/surr_catch_compiler_capabilities.cpp
+++ b/tests/SurrogateCpps/surr_catch_compiler_capabilities.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_compiler_capabilities.hpp>

--- a/tests/SurrogateCpps/surr_catch_complete_invoke.cpp
+++ b/tests/SurrogateCpps/surr_catch_complete_invoke.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/detail/catch_complete_invoke.hpp>

--- a/tests/SurrogateCpps/surr_catch_config.cpp
+++ b/tests/SurrogateCpps/surr_catch_config.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_config.hpp>

--- a/tests/SurrogateCpps/surr_catch_config_android_logwrite.cpp
+++ b/tests/SurrogateCpps/surr_catch_config_android_logwrite.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_config_android_logwrite.hpp>

--- a/tests/SurrogateCpps/surr_catch_config_counter.cpp
+++ b/tests/SurrogateCpps/surr_catch_config_counter.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_config_counter.hpp>

--- a/tests/SurrogateCpps/surr_catch_config_uncaught_exceptions.cpp
+++ b/tests/SurrogateCpps/surr_catch_config_uncaught_exceptions.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_config_uncaught_exceptions.hpp>

--- a/tests/SurrogateCpps/surr_catch_config_wchar.cpp
+++ b/tests/SurrogateCpps/surr_catch_config_wchar.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_config_wchar.hpp>

--- a/tests/SurrogateCpps/surr_catch_console_colour.cpp
+++ b/tests/SurrogateCpps/surr_catch_console_colour.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_console_colour.hpp>

--- a/tests/SurrogateCpps/surr_catch_console_width.cpp
+++ b/tests/SurrogateCpps/surr_catch_console_width.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_console_width.hpp>

--- a/tests/SurrogateCpps/surr_catch_constructor.cpp
+++ b/tests/SurrogateCpps/surr_catch_constructor.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/catch_constructor.hpp>

--- a/tests/SurrogateCpps/surr_catch_container_nonmembers.cpp
+++ b/tests/SurrogateCpps/surr_catch_container_nonmembers.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_container_nonmembers.hpp>

--- a/tests/SurrogateCpps/surr_catch_context.cpp
+++ b/tests/SurrogateCpps/surr_catch_context.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_context.hpp>

--- a/tests/SurrogateCpps/surr_catch_debug_console.cpp
+++ b/tests/SurrogateCpps/surr_catch_debug_console.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_debug_console.hpp>

--- a/tests/SurrogateCpps/surr_catch_debugger.cpp
+++ b/tests/SurrogateCpps/surr_catch_debugger.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_debugger.hpp>

--- a/tests/SurrogateCpps/surr_catch_decomposer.cpp
+++ b/tests/SurrogateCpps/surr_catch_decomposer.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_decomposer.hpp>

--- a/tests/SurrogateCpps/surr_catch_enforce.cpp
+++ b/tests/SurrogateCpps/surr_catch_enforce.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_enforce.hpp>

--- a/tests/SurrogateCpps/surr_catch_enum_values_registry.cpp
+++ b/tests/SurrogateCpps/surr_catch_enum_values_registry.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_enum_values_registry.hpp>

--- a/tests/SurrogateCpps/surr_catch_environment.cpp
+++ b/tests/SurrogateCpps/surr_catch_environment.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/catch_environment.hpp>

--- a/tests/SurrogateCpps/surr_catch_errno_guard.cpp
+++ b/tests/SurrogateCpps/surr_catch_errno_guard.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_errno_guard.hpp>

--- a/tests/SurrogateCpps/surr_catch_estimate.cpp
+++ b/tests/SurrogateCpps/surr_catch_estimate.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/catch_estimate.hpp>

--- a/tests/SurrogateCpps/surr_catch_estimate_clock.cpp
+++ b/tests/SurrogateCpps/surr_catch_estimate_clock.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/detail/catch_estimate_clock.hpp>

--- a/tests/SurrogateCpps/surr_catch_exception_translator_registry.cpp
+++ b/tests/SurrogateCpps/surr_catch_exception_translator_registry.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_exception_translator_registry.hpp>

--- a/tests/SurrogateCpps/surr_catch_execution_plan.cpp
+++ b/tests/SurrogateCpps/surr_catch_execution_plan.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/catch_execution_plan.hpp>

--- a/tests/SurrogateCpps/surr_catch_fatal_condition_handler.cpp
+++ b/tests/SurrogateCpps/surr_catch_fatal_condition_handler.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_fatal_condition_handler.hpp>

--- a/tests/SurrogateCpps/surr_catch_generator_exception.cpp
+++ b/tests/SurrogateCpps/surr_catch_generator_exception.cpp
@@ -1,0 +1,1 @@
+#include <catch2/generators/catch_generator_exception.hpp>

--- a/tests/SurrogateCpps/surr_catch_generators.cpp
+++ b/tests/SurrogateCpps/surr_catch_generators.cpp
@@ -1,0 +1,1 @@
+#include <catch2/generators/catch_generators.hpp>

--- a/tests/SurrogateCpps/surr_catch_generators_adapters.cpp
+++ b/tests/SurrogateCpps/surr_catch_generators_adapters.cpp
@@ -1,0 +1,1 @@
+#include <catch2/generators/catch_generators_adapters.hpp>

--- a/tests/SurrogateCpps/surr_catch_generators_all.cpp
+++ b/tests/SurrogateCpps/surr_catch_generators_all.cpp
@@ -1,0 +1,1 @@
+#include <catch2/generators/catch_generators_all.hpp>

--- a/tests/SurrogateCpps/surr_catch_generators_random.cpp
+++ b/tests/SurrogateCpps/surr_catch_generators_random.cpp
@@ -1,0 +1,1 @@
+#include <catch2/generators/catch_generators_random.hpp>

--- a/tests/SurrogateCpps/surr_catch_generators_range.cpp
+++ b/tests/SurrogateCpps/surr_catch_generators_range.cpp
@@ -1,0 +1,1 @@
+#include <catch2/generators/catch_generators_range.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_all.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_all.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_all.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_capture.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_capture.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_capture.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_config.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_config.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_config.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_enum_values_registry.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_enum_values_registry.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_enum_values_registry.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_exception.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_exception.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_exception.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_generatortracker.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_generatortracker.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_generatortracker.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_registry_hub.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_registry_hub.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_registry_hub.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_reporter.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_reporter.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_reporter.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_reporter_factory.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_reporter_factory.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_reporter_factory.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_reporter_registry.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_reporter_registry.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_reporter_registry.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_runner.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_runner.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_runner.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_tag_alias_registry.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_tag_alias_registry.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_tag_alias_registry.hpp>

--- a/tests/SurrogateCpps/surr_catch_interfaces_testcase.cpp
+++ b/tests/SurrogateCpps/surr_catch_interfaces_testcase.cpp
@@ -1,0 +1,1 @@
+#include <catch2/interfaces/catch_interfaces_testcase.hpp>

--- a/tests/SurrogateCpps/surr_catch_lazy_expr.cpp
+++ b/tests/SurrogateCpps/surr_catch_lazy_expr.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_lazy_expr.hpp>

--- a/tests/SurrogateCpps/surr_catch_leak_detector.cpp
+++ b/tests/SurrogateCpps/surr_catch_leak_detector.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_leak_detector.hpp>

--- a/tests/SurrogateCpps/surr_catch_list.cpp
+++ b/tests/SurrogateCpps/surr_catch_list.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_list.hpp>

--- a/tests/SurrogateCpps/surr_catch_matchers.cpp
+++ b/tests/SurrogateCpps/surr_catch_matchers.cpp
@@ -1,0 +1,1 @@
+#include <catch2/matchers/catch_matchers.hpp>

--- a/tests/SurrogateCpps/surr_catch_matchers_all.cpp
+++ b/tests/SurrogateCpps/surr_catch_matchers_all.cpp
@@ -1,0 +1,1 @@
+#include <catch2/matchers/catch_matchers_all.hpp>

--- a/tests/SurrogateCpps/surr_catch_matchers_container_properties.cpp
+++ b/tests/SurrogateCpps/surr_catch_matchers_container_properties.cpp
@@ -1,0 +1,1 @@
+#include <catch2/matchers/catch_matchers_container_properties.hpp>

--- a/tests/SurrogateCpps/surr_catch_matchers_contains.cpp
+++ b/tests/SurrogateCpps/surr_catch_matchers_contains.cpp
@@ -1,0 +1,1 @@
+#include <catch2/matchers/catch_matchers_contains.hpp>

--- a/tests/SurrogateCpps/surr_catch_matchers_exception.cpp
+++ b/tests/SurrogateCpps/surr_catch_matchers_exception.cpp
@@ -1,0 +1,1 @@
+#include <catch2/matchers/catch_matchers_exception.hpp>

--- a/tests/SurrogateCpps/surr_catch_matchers_floating_point.cpp
+++ b/tests/SurrogateCpps/surr_catch_matchers_floating_point.cpp
@@ -1,0 +1,1 @@
+#include <catch2/matchers/catch_matchers_floating_point.hpp>

--- a/tests/SurrogateCpps/surr_catch_matchers_impl.cpp
+++ b/tests/SurrogateCpps/surr_catch_matchers_impl.cpp
@@ -1,0 +1,1 @@
+#include <catch2/matchers/internal/catch_matchers_impl.hpp>

--- a/tests/SurrogateCpps/surr_catch_matchers_predicate.cpp
+++ b/tests/SurrogateCpps/surr_catch_matchers_predicate.cpp
@@ -1,0 +1,1 @@
+#include <catch2/matchers/catch_matchers_predicate.hpp>

--- a/tests/SurrogateCpps/surr_catch_matchers_quantifiers.cpp
+++ b/tests/SurrogateCpps/surr_catch_matchers_quantifiers.cpp
@@ -1,0 +1,1 @@
+#include <catch2/matchers/catch_matchers_quantifiers.hpp>

--- a/tests/SurrogateCpps/surr_catch_matchers_string.cpp
+++ b/tests/SurrogateCpps/surr_catch_matchers_string.cpp
@@ -1,0 +1,1 @@
+#include <catch2/matchers/catch_matchers_string.hpp>

--- a/tests/SurrogateCpps/surr_catch_matchers_templated.cpp
+++ b/tests/SurrogateCpps/surr_catch_matchers_templated.cpp
@@ -1,0 +1,1 @@
+#include <catch2/matchers/catch_matchers_templated.hpp>

--- a/tests/SurrogateCpps/surr_catch_matchers_vector.cpp
+++ b/tests/SurrogateCpps/surr_catch_matchers_vector.cpp
@@ -1,0 +1,1 @@
+#include <catch2/matchers/catch_matchers_vector.hpp>

--- a/tests/SurrogateCpps/surr_catch_measure.cpp
+++ b/tests/SurrogateCpps/surr_catch_measure.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/detail/catch_measure.hpp>

--- a/tests/SurrogateCpps/surr_catch_message.cpp
+++ b/tests/SurrogateCpps/surr_catch_message.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_message.hpp>

--- a/tests/SurrogateCpps/surr_catch_message_info.cpp
+++ b/tests/SurrogateCpps/surr_catch_message_info.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_message_info.hpp>

--- a/tests/SurrogateCpps/surr_catch_meta.cpp
+++ b/tests/SurrogateCpps/surr_catch_meta.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_meta.hpp>

--- a/tests/SurrogateCpps/surr_catch_noncopyable.cpp
+++ b/tests/SurrogateCpps/surr_catch_noncopyable.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_noncopyable.hpp>

--- a/tests/SurrogateCpps/surr_catch_optimizer.cpp
+++ b/tests/SurrogateCpps/surr_catch_optimizer.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/catch_optimizer.hpp>

--- a/tests/SurrogateCpps/surr_catch_option.cpp
+++ b/tests/SurrogateCpps/surr_catch_option.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_option.hpp>

--- a/tests/SurrogateCpps/surr_catch_outlier_classification.cpp
+++ b/tests/SurrogateCpps/surr_catch_outlier_classification.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/catch_outlier_classification.hpp>

--- a/tests/SurrogateCpps/surr_catch_output_redirect.cpp
+++ b/tests/SurrogateCpps/surr_catch_output_redirect.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_output_redirect.hpp>

--- a/tests/SurrogateCpps/surr_catch_platform.cpp
+++ b/tests/SurrogateCpps/surr_catch_platform.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_platform.hpp>

--- a/tests/SurrogateCpps/surr_catch_polyfills.cpp
+++ b/tests/SurrogateCpps/surr_catch_polyfills.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_polyfills.hpp>

--- a/tests/SurrogateCpps/surr_catch_preprocessor.cpp
+++ b/tests/SurrogateCpps/surr_catch_preprocessor.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_preprocessor.hpp>

--- a/tests/SurrogateCpps/surr_catch_random_number_generator.cpp
+++ b/tests/SurrogateCpps/surr_catch_random_number_generator.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_random_number_generator.hpp>

--- a/tests/SurrogateCpps/surr_catch_repeat.cpp
+++ b/tests/SurrogateCpps/surr_catch_repeat.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/detail/catch_repeat.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_automake.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_automake.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_automake.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_compact.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_compact.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_compact.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_console.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_console.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_console.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_cumulative_base.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_cumulative_base.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_cumulative_base.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_event_listener.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_event_listener.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_event_listener.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_helpers.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_helpers.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_helpers.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_junit.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_junit.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_junit.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_listening.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_listening.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_listening.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_registrars.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_registrars.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_reporter_registrars.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_registry.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_registry.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_reporter_registry.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_sonarqube.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_sonarqube.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_sonarqube.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_streaming_base.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_streaming_base.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_streaming_base.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_tap.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_tap.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_tap.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_teamcity.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_teamcity.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_teamcity.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporter_xml.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporter_xml.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporter_xml.hpp>

--- a/tests/SurrogateCpps/surr_catch_reporters_all.cpp
+++ b/tests/SurrogateCpps/surr_catch_reporters_all.cpp
@@ -1,0 +1,1 @@
+#include <catch2/reporters/catch_reporters_all.hpp>

--- a/tests/SurrogateCpps/surr_catch_result_type.cpp
+++ b/tests/SurrogateCpps/surr_catch_result_type.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_result_type.hpp>

--- a/tests/SurrogateCpps/surr_catch_run_context.cpp
+++ b/tests/SurrogateCpps/surr_catch_run_context.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_run_context.hpp>

--- a/tests/SurrogateCpps/surr_catch_run_for_at_least.cpp
+++ b/tests/SurrogateCpps/surr_catch_run_for_at_least.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/detail/catch_run_for_at_least.hpp>

--- a/tests/SurrogateCpps/surr_catch_sample_analysis.cpp
+++ b/tests/SurrogateCpps/surr_catch_sample_analysis.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/catch_sample_analysis.hpp>

--- a/tests/SurrogateCpps/surr_catch_section.cpp
+++ b/tests/SurrogateCpps/surr_catch_section.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_section.hpp>

--- a/tests/SurrogateCpps/surr_catch_section_info.cpp
+++ b/tests/SurrogateCpps/surr_catch_section_info.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_section_info.hpp>

--- a/tests/SurrogateCpps/surr_catch_session.cpp
+++ b/tests/SurrogateCpps/surr_catch_session.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_session.hpp>

--- a/tests/SurrogateCpps/surr_catch_singletons.cpp
+++ b/tests/SurrogateCpps/surr_catch_singletons.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_singletons.hpp>

--- a/tests/SurrogateCpps/surr_catch_source_line_info.cpp
+++ b/tests/SurrogateCpps/surr_catch_source_line_info.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_source_line_info.hpp>

--- a/tests/SurrogateCpps/surr_catch_startup_exception_registry.cpp
+++ b/tests/SurrogateCpps/surr_catch_startup_exception_registry.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_startup_exception_registry.hpp>

--- a/tests/SurrogateCpps/surr_catch_stats.cpp
+++ b/tests/SurrogateCpps/surr_catch_stats.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/detail/catch_stats.hpp>

--- a/tests/SurrogateCpps/surr_catch_stream.cpp
+++ b/tests/SurrogateCpps/surr_catch_stream.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_stream.hpp>

--- a/tests/SurrogateCpps/surr_catch_stream_end_stop.cpp
+++ b/tests/SurrogateCpps/surr_catch_stream_end_stop.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_stream_end_stop.hpp>

--- a/tests/SurrogateCpps/surr_catch_string_manip.cpp
+++ b/tests/SurrogateCpps/surr_catch_string_manip.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_string_manip.hpp>

--- a/tests/SurrogateCpps/surr_catch_stringref.cpp
+++ b/tests/SurrogateCpps/surr_catch_stringref.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_stringref.hpp>

--- a/tests/SurrogateCpps/surr_catch_tag_alias.cpp
+++ b/tests/SurrogateCpps/surr_catch_tag_alias.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_tag_alias.hpp>

--- a/tests/SurrogateCpps/surr_catch_tag_alias_autoregistrar.cpp
+++ b/tests/SurrogateCpps/surr_catch_tag_alias_autoregistrar.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_tag_alias_autoregistrar.hpp>

--- a/tests/SurrogateCpps/surr_catch_tag_alias_registry.cpp
+++ b/tests/SurrogateCpps/surr_catch_tag_alias_registry.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_tag_alias_registry.hpp>

--- a/tests/SurrogateCpps/surr_catch_template_test_macros.cpp
+++ b/tests/SurrogateCpps/surr_catch_template_test_macros.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_template_test_macros.hpp>

--- a/tests/SurrogateCpps/surr_catch_template_test_registry.cpp
+++ b/tests/SurrogateCpps/surr_catch_template_test_registry.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_template_test_registry.hpp>

--- a/tests/SurrogateCpps/surr_catch_test_case_info.cpp
+++ b/tests/SurrogateCpps/surr_catch_test_case_info.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_test_case_info.hpp>

--- a/tests/SurrogateCpps/surr_catch_test_case_registry_impl.cpp
+++ b/tests/SurrogateCpps/surr_catch_test_case_registry_impl.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_test_case_registry_impl.hpp>

--- a/tests/SurrogateCpps/surr_catch_test_case_tracker.cpp
+++ b/tests/SurrogateCpps/surr_catch_test_case_tracker.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_test_case_tracker.hpp>

--- a/tests/SurrogateCpps/surr_catch_test_failure_exception.cpp
+++ b/tests/SurrogateCpps/surr_catch_test_failure_exception.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_test_failure_exception.hpp>

--- a/tests/SurrogateCpps/surr_catch_test_macro_impl.cpp
+++ b/tests/SurrogateCpps/surr_catch_test_macro_impl.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_test_macro_impl.hpp>

--- a/tests/SurrogateCpps/surr_catch_test_macros.cpp
+++ b/tests/SurrogateCpps/surr_catch_test_macros.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_test_macros.hpp>

--- a/tests/SurrogateCpps/surr_catch_test_registry.cpp
+++ b/tests/SurrogateCpps/surr_catch_test_registry.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_test_registry.hpp>

--- a/tests/SurrogateCpps/surr_catch_test_spec.cpp
+++ b/tests/SurrogateCpps/surr_catch_test_spec.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_test_spec.hpp>

--- a/tests/SurrogateCpps/surr_catch_test_spec_parser.cpp
+++ b/tests/SurrogateCpps/surr_catch_test_spec_parser.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_test_spec_parser.hpp>

--- a/tests/SurrogateCpps/surr_catch_textflow.cpp
+++ b/tests/SurrogateCpps/surr_catch_textflow.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_textflow.hpp>

--- a/tests/SurrogateCpps/surr_catch_timer.cpp
+++ b/tests/SurrogateCpps/surr_catch_timer.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_timer.hpp>

--- a/tests/SurrogateCpps/surr_catch_timing.cpp
+++ b/tests/SurrogateCpps/surr_catch_timing.cpp
@@ -1,0 +1,1 @@
+#include <catch2/benchmark/detail/catch_timing.hpp>

--- a/tests/SurrogateCpps/surr_catch_to_string.cpp
+++ b/tests/SurrogateCpps/surr_catch_to_string.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_to_string.hpp>

--- a/tests/SurrogateCpps/surr_catch_tostring.cpp
+++ b/tests/SurrogateCpps/surr_catch_tostring.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_tostring.hpp>

--- a/tests/SurrogateCpps/surr_catch_totals.cpp
+++ b/tests/SurrogateCpps/surr_catch_totals.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_totals.hpp>

--- a/tests/SurrogateCpps/surr_catch_translate_exception.cpp
+++ b/tests/SurrogateCpps/surr_catch_translate_exception.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_translate_exception.hpp>

--- a/tests/SurrogateCpps/surr_catch_uncaught_exceptions.cpp
+++ b/tests/SurrogateCpps/surr_catch_uncaught_exceptions.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_uncaught_exceptions.hpp>

--- a/tests/SurrogateCpps/surr_catch_unique_ptr.cpp
+++ b/tests/SurrogateCpps/surr_catch_unique_ptr.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_unique_ptr.hpp>

--- a/tests/SurrogateCpps/surr_catch_version.cpp
+++ b/tests/SurrogateCpps/surr_catch_version.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_version.hpp>

--- a/tests/SurrogateCpps/surr_catch_version_macros.cpp
+++ b/tests/SurrogateCpps/surr_catch_version_macros.cpp
@@ -1,0 +1,1 @@
+#include <catch2/catch_version_macros.hpp>

--- a/tests/SurrogateCpps/surr_catch_wildcard_pattern.cpp
+++ b/tests/SurrogateCpps/surr_catch_wildcard_pattern.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_wildcard_pattern.hpp>

--- a/tests/SurrogateCpps/surr_catch_windows_h_proxy.cpp
+++ b/tests/SurrogateCpps/surr_catch_windows_h_proxy.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_windows_h_proxy.hpp>

--- a/tests/SurrogateCpps/surr_catch_xmlwriter.cpp
+++ b/tests/SurrogateCpps/surr_catch_xmlwriter.cpp
@@ -1,0 +1,1 @@
+#include <catch2/internal/catch_xmlwriter.hpp>

--- a/tools/scripts/checkSurrogateExists.py
+++ b/tools/scripts/checkSurrogateExists.py
@@ -1,0 +1,36 @@
+#!/bin/python3
+import os
+import sys
+
+srcdir = "../../src/catch2"
+surrogates_folder = "../../tests/SurrogateCpps"
+header_files = []
+surrogate_files = []
+throw_error = False
+
+def get_files(filetype,dir):
+    filenames = []
+
+    for _, _, files in os.walk(dir):
+        for file in files:
+            if filetype in file:
+                filenames.append(file)
+
+    return filenames
+
+def check_surrogate_exists(headers,surrogates):
+    global throw_error
+    for file in headers:
+
+        filename = "surr_" + file.replace("hpp","cpp")
+        if filename not in surrogates:
+            print("Surrogate not found for %s" % filename)
+            throw_error = True
+
+header_files = get_files("hpp",srcdir)
+surrogate_files = get_files("cpp",surrogates_folder)
+
+check_surrogate_exists(header_files,surrogate_files)
+
+if throw_error is True:
+    sys.exit(-1)


### PR DESCRIPTION
## Description

This PR adds surrogate TUs to test that each header file in the project can be included without depending on other files.

In order for the PR to be complete I have to clean the commit history.
Also 5 files are commented in the CMakeLists.txt of SurrogateCpps since they need to be fixed.

## GitHub Issues

Closes #2106
