### PR TITLE
Add surrogate TUs option to CMake

### DIFF
--- a/.github/workflows/linux-builds.yml
+++ b/.github/workflows/linux-builds.yml
@@ -20,6 +20,7 @@ jobs:
           - clang++-10
         build_type: [Debug, Release]
         std: [14]
+        surrogates: [OFF]
         include:
         # cannot be installed on ubuntu-20.04 be default?
 #          - cxx: g++-6
@@ -30,6 +31,13 @@ jobs:
             other_pkgs: clang-7
           - cxx: clang++-10
             other_pkgs: clang-10
+        # We want one build to build surrogates -- but not more, to
+        # avoid trouble with long compilation/CI times.
+          - cxx: clang++-10
+            build_type: Debug
+            std: 14
+            other_pkgs: clang-10
+            surrogates: ON
 
     steps:
     - uses: actions/checkout@v2
@@ -47,7 +55,7 @@ jobs:
       run: |
         cmake -Bbuild -H$GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
               -DCMAKE_CXX_STANDARD=${{matrix.std}} -DCATCH_DEVELOPMENT_BUILD=ON \
-              -G Ninja
+              -DCATCH_BUILD_SURROGATES=${{matrix.surrogates}} -G Ninja
 
     - name: Build tests + lib
       working-directory: ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ cmake_dependent_option(CATCH_BUILD_EXTRA_TESTS "Build extra tests" OFF "CATCH_DE
 cmake_dependent_option(CATCH_BUILD_FUZZERS "Build fuzzers" OFF "CATCH_DEVELOPMENT_BUILD" OFF)
 cmake_dependent_option(CATCH_ENABLE_COVERAGE "Generate coverage for codecov.io" OFF "CATCH_DEVELOPMENT_BUILD" OFF)
 cmake_dependent_option(CATCH_ENABLE_WERROR "Enables Werror during build" ON "CATCH_DEVELOPMENT_BUILD" OFF)
+cmake_dependent_option(CATCH_BUILD_SURROGATES "Enable generating and building surrogate TUs for the main headers" OFF "CATCH_DEVELOPMENT_BUILD" OFF)
+
 
 # Catch2's build breaks if done in-tree. You probably should not build
 # things in tree anyway, but we can allow projects that include Catch2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,8 +51,9 @@ test_script:
 # build explicitly.
 environment:
   matrix:
-    - FLAVOR: VS 2019 x64 Debug
+    - FLAVOR: VS 2019 x64 Debug Surrogates
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      surrogates: 1
       platform: x64
       configuration: Debug
     

--- a/src/catch2/benchmark/catch_constructor.hpp
+++ b/src/catch2/benchmark/catch_constructor.hpp
@@ -11,6 +11,7 @@
 #define CATCH_CONSTRUCTOR_HPP_INCLUDED
 
 #include <type_traits>
+#include <utility>
 
 namespace Catch {
     namespace Benchmark {

--- a/src/catch2/benchmark/detail/catch_analyse.hpp
+++ b/src/catch2/benchmark/detail/catch_analyse.hpp
@@ -11,8 +11,10 @@
 #define CATCH_ANALYSE_HPP_INCLUDED
 
 #include <catch2/benchmark/catch_clock.hpp>
+#include <catch2/benchmark/catch_environment.hpp>
 #include <catch2/benchmark/catch_sample_analysis.hpp>
 #include <catch2/benchmark/detail/catch_stats.hpp>
+#include <catch2/interfaces/catch_interfaces_config.hpp>
 
 #include <algorithm>
 #include <iterator>

--- a/src/catch2/catch_reporter_registrars.hpp
+++ b/src/catch2/catch_reporter_registrars.hpp
@@ -9,10 +9,14 @@
 #define CATCH_REPORTER_REGISTRARS_HPP_INCLUDED
 
 #include <catch2/interfaces/catch_interfaces_registry_hub.hpp>
+#include <catch2/interfaces/catch_interfaces_reporter.hpp>
 #include <catch2/interfaces/catch_interfaces_reporter_factory.hpp>
 #include <catch2/internal/catch_unique_ptr.hpp>
 
 namespace Catch {
+
+    struct IStreamingReporter;
+    using IStreamingReporterPtr = Detail::unique_ptr<IStreamingReporter>;
 
     template <typename T>
     class ReporterFactory : public IReporterFactory {

--- a/src/catch2/interfaces/catch_interfaces_reporter_factory.hpp
+++ b/src/catch2/interfaces/catch_interfaces_reporter_factory.hpp
@@ -8,9 +8,16 @@
 #ifndef CATCH_INTERFACES_REPORTER_FACTORY_HPP_INCLUDED
 #define CATCH_INTERFACES_REPORTER_FACTORY_HPP_INCLUDED
 
+#include <catch2/internal/catch_unique_ptr.hpp>
+
+#include <string>
+
 namespace Catch {
 
     struct ReporterConfig;
+    struct IStreamingReporter;
+    using IStreamingReporterPtr = Detail::unique_ptr<IStreamingReporter>;
+
 
     struct IReporterFactory {
         virtual ~IReporterFactory(); // = default

--- a/src/catch2/internal/catch_container_nonmembers.hpp
+++ b/src/catch2/internal/catch_container_nonmembers.hpp
@@ -10,6 +10,8 @@
 
 #include <catch2/internal/catch_compiler_capabilities.hpp>
 
+#include <cstddef>
+#include <initializer_list>
 
 // We want a simple polyfill over `std::empty`, `std::size` and so on
 // for C++14 or C++ libraries with incomplete support.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,66 @@
 include(MiscFunctions)
 
+if (CATCH_BUILD_SURROGATES)
+  message(STATUS "Configuring targets for surrogate TUs")
+
+  # If the folder does not exist before we ask for output redirect to
+  # a file, it won't work.
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/surrogates)
+
+  # Creates target to generate the surrogate TU for provided header.
+  # Returns the path to the generated file.
+  function(createSurrogateFileTarget sourceHeader pathToFile)
+    set(pathPrefix ${PROJECT_SOURCE_DIR}/src)
+
+    file(RELATIVE_PATH includePath ${pathPrefix} ${sourceHeader})
+
+    get_filename_component(basicFileName "${sourceHeader}" NAME_WE)
+
+    set(surrogateFilePath ${CMAKE_CURRENT_BINARY_DIR}/surrogates/surrogate_${basicFileName}.cpp)
+
+    add_custom_command(
+      OUTPUT ${surrogateFilePath}
+      COMMAND cmake -E echo "\#include <${includePath}>" > "${surrogateFilePath}"
+      VERBATIM
+    )
+
+    set(${pathToFile} ${surrogateFilePath} PARENT_SCOPE)
+  endfunction()
+
+  # Extracts all non-helper (e.g. catch_all.hpp) headers from the
+  # Catch2 target, and returns them through the argument.
+  function(ExtractCatch2Headers OutArg)
+    get_target_property(targetSources Catch2 SOURCES)
+    foreach(Source ${targetSources})
+      string(REGEX MATCH "^.*\\.hpp$" isHeader ${Source})
+      string(REGEX MATCH "_all.hpp" isAllHeader ${Source})
+      if(isHeader AND NOT isAllHeader)
+        list(APPEND AllHeaders ${Source})
+      endif()
+    endforeach()
+    set(${OutArg} ${AllHeaders} PARENT_SCOPE)
+  endfunction()
+
+
+  ExtractCatch2Headers(mainHeaders)
+
+  if (NOT mainHeaders)
+    message(FATAL_ERROR "No headers in the main target were detected. Something is broken.")
+  endif()
+
+  foreach(header ${mainHeaders})
+    createSurrogateFileTarget(${header} pathToGeneratedFile)
+    list(APPEND surrogateFiles ${pathToGeneratedFile})
+  endforeach()
+
+
+  add_executable(Catch2SurrogateTarget
+    ${surrogateFiles}
+  )
+  target_link_libraries(Catch2SurrogateTarget PRIVATE Catch2WithMain)
+
+endif(CATCH_BUILD_SURROGATES)
+
 ####
 # Temporary workaround for VS toolset changes in 2017
 # We need to disable <UseFullPaths> property, but CMake doesn't support it

--- a/tools/misc/appveyorBuildConfigurationScript.bat
+++ b/tools/misc/appveyorBuildConfigurationScript.bat
@@ -13,7 +13,7 @@ if "%CONFIGURATION%"=="Debug" (
     cmake -H. -BBuild -A%PLATFORM% -DCATCH_TEST_USE_WMAIN=%wmain% -DMEMORYCHECK_COMMAND=build-misc\Debug\CoverageHelper.exe -DMEMORYCHECK_COMMAND_OPTIONS=--sep-- -DMEMORYCHECK_TYPE=Valgrind -DCATCH_BUILD_EXAMPLES=%examples% -DCATCH_BUILD_EXTRA_TESTS=%examples% -DCATCH_DEVELOPMENT_BUILD=ON || exit /b !ERRORLEVEL!
   ) else (
     @REM # We know that coverage is 0
-    cmake -H. -BBuild -A%PLATFORM% -DCATCH_TEST_USE_WMAIN=%wmain% -DCATCH_BUILD_EXAMPLES=%examples% -DCATCH_BUILD_EXTRA_TESTS=%examples% -DCATCH_DEVELOPMENT_BUILD=ON || exit /b !ERRORLEVEL!
+    cmake -H. -BBuild -A%PLATFORM% -DCATCH_TEST_USE_WMAIN=%wmain% -DCATCH_BUILD_EXAMPLES=%examples% -DCATCH_BUILD_EXTRA_TESTS=%examples% -DCATCH_BUILD_SURROGATES=%surrogates% -DCATCH_DEVELOPMENT_BUILD=ON || exit /b !ERRORLEVEL!
   )
 )
 if "%CONFIGURATION%"=="Release" (


### PR DESCRIPTION
## Description
This PR adds surrogate TUs to Catch2, by having them autogenerated by CMake during build. It also fixes some headers that weren't self-sufficient, and makes surrogate TU builds part of the CI.

To build is dependent on the `CATCH_BUILD_SURROGATES` CMake option (which is in turn dependent on `CATCH_DEVELOPMENT_BUILD`).

## GitHub Issues
#2106 