### PR TITLE
MatcherMethod: Add virtual destructor and default constructors

### DIFF
--- a/src/catch2/matchers/catch_matchers.hpp
+++ b/src/catch2/matchers/catch_matchers.hpp
@@ -41,6 +41,12 @@ namespace Matchers {
 
     template<typename ObjectT>
     struct MatcherMethod {
+        MatcherMethod() = default;
+        virtual ~MatcherMethod() = default;
+
+        MatcherMethod(MatcherMethod const&) = default;
+        MatcherMethod(MatcherMethod&&) = default;
+
         virtual bool match(ObjectT const& arg) const = 0;
     };
 


### PR DESCRIPTION
The lack of virtual destructor raises warnings with Visual Studio 2019
16.7 and later. Declaring this then requires the constructor, copy
constructor and move constructor to be provided.

I notice `-Wnon-virtual-dtor` is explicitly disabled for clang just
above the declaration of this struct, but it's not clear from this
file's history why that was done rather than adding the destructor.