### PR TITLE
Fixed compilation under MinGW - use gmtime_s() instead of gmtime_r().

### DIFF
--- a/src/catch2/reporters/catch_reporter_junit.cpp
+++ b/src/catch2/reporters/catch_reporter_junit.cpp
@@ -26,7 +26,7 @@ namespace Catch {
             std::time(&rawtime);
 
             std::tm timeInfo = {};
-#ifdef _MSC_VER
+#if defined (_MSC_VER) || defined (__MINGW32__)
             gmtime_s(&timeInfo, &rawtime);
 #else
             gmtime_r(&rawtime, &timeInfo);


### PR DESCRIPTION
## Description
When building with MinGW (cross-compiling from openSUSE Linux using i686-w64-mingw32-g++) I get:
```
catch2/reporters/catch_reporter_junit.cpp: In function 'std::string Catch::{anonymous}::getCurrentTimestamp()':
catch2/reporters/catch_reporter_junit.cpp:32:13: error: 'gmtime_r' was not declared in this scope; did you mean 'gmtime_s'?
   32 |             gmtime_r(&rawtime, &timeInfo);
      |             ^~~~~~~~
      |             gmtime_s
```
This PR fixes the error by making MinGW use gmtime_s(), just like MSVC.

Perhaps simply doing `#ifdef _WIN32` would be better, but I did it the conservative way.
