### PR TITLE
When used as subproject, treat Catch2 cmake target include paths as SYSTEM

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -271,11 +271,20 @@ target_compile_features(Catch2
     cxx_variadic_macros
 )
 
-target_include_directories(Catch2
-  PUBLIC
-    $<BUILD_INTERFACE:${SOURCES_DIR}/..>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
+
+if (NOT_SUBPROJECT)
+    target_include_directories(Catch2
+      PUBLIC
+        $<BUILD_INTERFACE:${SOURCES_DIR}/..>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+else()
+    target_include_directories(Catch2
+      SYSTEM PUBLIC
+        $<BUILD_INTERFACE:${SOURCES_DIR}/..>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+endif()
 
 
 add_library(Catch2WithMain STATIC


### PR DESCRIPTION
… to avoid compiler warnings in Catch2 headers.

## Description
When embedding Catch2 into a cmake project using `add_subdirectory()`, `Catch2` target include paths are simply PUBLIC.
If a user project has many compiler warnings enabled, they may get triggered simply by including Catch2 headers.

This PR marks the Catch2 include paths as SYSTEM when it's used as a subproject, so that these include paths are treated as system header locations. This makes the compilers avoid user-enabled warnings from Catch2 headers.
