### PR TITLE
Fix BUILD.bazel in 2.x when used as a submodule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,5 +13,5 @@ cc_library(
     name = "catch2_with_main",
     srcs = ["src/catch_with_main.cpp"],
     visibility = ["//visibility:public"],
-    deps = ["//:catch2"],
+    deps = [":catch2"],
 )


### PR DESCRIPTION
## Description

When Catch2 is imported as a submodule, using an absolute target path is
problematic because it can't be known in advance where the submodule
will be placed.

The `devel` branch already seems to already have a relative rule path,
so a change is not needed for that branch.
