### PR TITLE
Prevent Catch2 v2 tests from running if loaded as a sub-project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.5)
 # disable testsuite in that case
 if(NOT DEFINED PROJECT_NAME)
     set(NOT_SUBPROJECT ON)
+else()
+    set(NOT_SUBPROJECT OFF)
 endif()
 
 # Catch2's build breaks if done in-tree. You probably should not build


### PR DESCRIPTION
## Description

What: Prevent Catch2 v2's tests from being run, and CTest targets from being added, if Catch2 is configured as a sub-project.

Why: In projects that use Catch2 via `add_subdirectory` or `FetchContent`, this prevents the IDE's lists of targets fro being cluttered up with all CTest's targets - and it also makes CLion's "Run all CTest targets" a lot more useful, as it then only runs the user's tests, and not Catc2 ones as well.

## GitHub Issues

See #2202 - there will be a separate fix for the `devel` branch.
