### PR TITLE
Prepare to prevent Catch2 v3's tests from being run, and CTest targets from being added, if Catch2 is configured as a sub-project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.5)
 # disable testsuite in that case
 if(NOT DEFINED PROJECT_NAME)
   set(NOT_SUBPROJECT ON)
+else()
+    set(NOT_SUBPROJECT OFF)
 endif()
 
 option(CATCH_INSTALL_DOCS "Install documentation alongside library" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.5)
 if(NOT DEFINED PROJECT_NAME)
   set(NOT_SUBPROJECT ON)
 else()
-    set(NOT_SUBPROJECT OFF)
+  set(NOT_SUBPROJECT OFF)
 endif()
 
 option(CATCH_INSTALL_DOCS "Install documentation alongside library" ON)


### PR DESCRIPTION
## Description

What: Prevent Catch2 v3's tests from setting `NOT_SUBPROJECT` to ON when running as a sub-project.

Why: In projects that use Catch2 via `add_subdirectory` or `FetchContent`, this prevents the IDE's lists of targets fro being cluttered up with all CTest's targets - and it also makes CLion's "Run all CTest targets" a lot more useful, as it then only runs the user's tests, and not Catc2 ones as well.

**NOTE** This does not fully prevent the #2202 problem from occurring, when using Catch2's `devel` branch, as the fixes in PR #1986 have not yet been ported to `devel` - that is the subject of #2203.

## GitHub Issues

See #2202.

Once this PR is merged, I'll create a separate PR to fix #2203.

Also, there as a separate PR for the `v2.x` branch: #2204

