### PR TITLE
Fix typos in the code base

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,7 +26,7 @@ Ongoing development happens in the `devel` branch for Catch2 v3, and in
 
 Commits should be small and atomic. A commit is atomic when, after it is
 applied, the codebase, tests and all, still works as expected. Small
-commits are also prefered, as they make later operations with git history,
+commits are also preferred, as they make later operations with git history,
 whether it is bisecting, reverting, or something else, easier.
 
 _When submitting a pull request please do not include changes to the

--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -101,7 +101,7 @@ string is equal to `str`.
 
 Finally, the `Matches` matcher performs an ECMASCript regex match using
 `str` against the argument string. It is important to know that
-the match is performed agains the string as a whole, meaning that
+the match is performed against the string as a whole, meaning that
 the regex `"abc"` will not match input string `"abcd"`. To match
 `"abcd"`, you need to use e.g. `"abc.*"` as your regex.
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -74,7 +74,7 @@ new design.
 * Will Catch2 again distribute single-header version in the future?
   * No. But we do provide sqlite-style amalgamated distribution option. This means that you can download just 1 .cpp file and 1 header and place them next to your own sources. However, doing this has downsides similar to using the `catch_all.hpp` header.
 * Why the big breaking change caused by replacing `catch.hpp` with `catch_all.hpp`?
-  * The convenience header `catch_all.hpp` exists for two reasons. One of them is to provide a way for quick migration from Catch2, the second one is to provide a simple way to test things with Catch2. Using it for migration has one drawback in that it is **big**. This means that including it _will_ cause significant compile time drag, and so using it to migrate should be a concious decision by the user, not something they can just stumble into unknowingly.
+  * The convenience header `catch_all.hpp` exists for two reasons. One of them is to provide a way for quick migration from Catch2, the second one is to provide a simple way to test things with Catch2. Using it for migration has one drawback in that it is **big**. This means that including it _will_ cause significant compile time drag, and so using it to migrate should be a conscious decision by the user, not something they can just stumble into unknowingly.
 
 
 ### (Potentially) Breaking changes

--- a/examples/302-Gen-Table.cpp
+++ b/examples/302-Gen-Table.cpp
@@ -48,7 +48,7 @@ TEST_CASE("Table allows pre-computed test inputs and outputs", "[example][genera
  * (technically C++17 but does not require -std in GCC/Clang). See
  *   https://stackoverflow.com/questions/12436586/tuple-vector-and-initializer-list
  *
- * - In C++17 mode std::tie() and the preceeding variable delcarations can be
+ * - In C++17 mode std::tie() and the preceding variable delcarations can be
  * replaced by structured bindings: auto [test_input, expected] = GENERATE(
  * table<std::string, size_t>({ ...
  */

--- a/extras/ParseAndAddCatchTests.cmake
+++ b/extras/ParseAndAddCatchTests.cmake
@@ -200,7 +200,7 @@ function(ParseAndAddCatchTests_ParseFile SourceFile TestTarget)
             # Escape commas in the test spec
             string(REPLACE "," "\\," Name ${Name})
 
-            # Work around CMake 3.18.0 change in `add_test()`, before the escaped quotes were neccessary,
+            # Work around CMake 3.18.0 change in `add_test()`, before the escaped quotes were necessary,
             # only with CMake 3.18.0 the escaped double quotes confuse the call. This change is reverted in 3.18.1
             # And properly introduced in 3.19 with the CMP0110 policy
             if(_cmp0110_value STREQUAL "NEW" OR ${CMAKE_VERSION} VERSION_EQUAL "3.18")

--- a/extras/catch_amalgamated.cpp
+++ b/extras/catch_amalgamated.cpp
@@ -3550,7 +3550,7 @@ namespace Catch {
             // Extracts the actual name part of an enum instance
             // In other words, it returns the Blue part of Bikeshed::Colour::Blue
             StringRef extractInstanceName(StringRef enumInstance) {
-                // Find last occurence of ":"
+                // Find last occurrence of ":"
                 size_t name_start = enumInstance.size();
                 while (name_start > 0 && enumInstance[name_start - 1] != ':') {
                     --name_start;

--- a/extras/catch_amalgamated.cpp
+++ b/extras/catch_amalgamated.cpp
@@ -3550,7 +3550,7 @@ namespace Catch {
             // Extracts the actual name part of an enum instance
             // In other words, it returns the Blue part of Bikeshed::Colour::Blue
             StringRef extractInstanceName(StringRef enumInstance) {
-                // Find last occurrence of ":"
+                // Find last occurence of ":"
                 size_t name_start = enumInstance.size();
                 while (name_start > 0 && enumInstance[name_start - 1] != ':') {
                     --name_start;

--- a/src/catch2/internal/catch_enum_values_registry.cpp
+++ b/src/catch2/internal/catch_enum_values_registry.cpp
@@ -21,7 +21,7 @@ namespace Catch {
             // Extracts the actual name part of an enum instance
             // In other words, it returns the Blue part of Bikeshed::Colour::Blue
             StringRef extractInstanceName(StringRef enumInstance) {
-                // Find last occurence of ":"
+                // Find last occurrence of ":"
                 size_t name_start = enumInstance.size();
                 while (name_start > 0 && enumInstance[name_start - 1] != ':') {
                     --name_start;


### PR DESCRIPTION
## Description
Fix few typos in the code base.
Note that only documentation and comments are impacted by this change.