### PR TITLE
Fix typos in the code base

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -200,7 +200,7 @@ function(ParseAndAddCatchTests_ParseFile SourceFile TestTarget)
             # Escape commas in the test spec
             string(REPLACE "," "\\," Name ${Name})
 
-            # Work around CMake 3.18.0 change in `add_test()`, before the escaped quotes were neccessary,
+            # Work around CMake 3.18.0 change in `add_test()`, before the escaped quotes were necessary,
             # only with CMake 3.18.0 the escaped double quotes confuse the call. This change is reverted in 3.18.1
             # And properly introduced in 3.19 with the CMP0110 policy
             if(_cmp0110_value STREQUAL "NEW" OR ${CMAKE_VERSION} VERSION_EQUAL "3.18")

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,7 +26,7 @@ Ongoing development happens in the `v2.x` branch for Catch2 v2, and in
 
 Commits should be small and atomic. A commit is atomic when, after it is
 applied, the codebase, tests and all, still works as expected. Small
-commits are also prefered, as they make later operations with git history,
+commits are also preferred, as they make later operations with git history,
 whether it is bisecting, reverting, or something else, easier.
 
 _When submitting a pull request please do not include changes to the

--- a/examples/302-Gen-Table.cpp
+++ b/examples/302-Gen-Table.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Table allows pre-computed test inputs and outputs", "[example][genera
 
 /* Possible simplifications where less legacy toolchain support is needed:
  *
- * - With libstdc++6 or newer, the make_tuple() calls can be ommitted
+ * - With libstdc++6 or newer, the make_tuple() calls can be omitted
  * (technically C++17 but does not require -std in GCC/Clang). See
  *   https://stackoverflow.com/questions/12436586/tuple-vector-and-initializer-list
  *

--- a/include/internal/catch_enum_values_registry.cpp
+++ b/include/internal/catch_enum_values_registry.cpp
@@ -22,7 +22,7 @@ namespace Catch {
             // Extracts the actual name part of an enum instance
             // In other words, it returns the Blue part of Bikeshed::Colour::Blue
             StringRef extractInstanceName(StringRef enumInstance) {
-                // Find last occurence of ":"
+                // Find last occurrence of ":"
                 size_t name_start = enumInstance.size();
                 while (name_start > 0 && enumInstance[name_start - 1] != ':') {
                     --name_start;


### PR DESCRIPTION
## Description
Fix few typos in the code base.
Note that only documentation and comments are impacted by this change.
This is a backport of #2206 on v2.x branch.