### PR TITLE
avoid "implicit int" functions

### DIFF
--- a/include/internal/catch_fatal_condition.cpp
+++ b/include/internal/catch_fatal_condition.cpp
@@ -40,8 +40,8 @@ namespace Catch {
 
     // If neither SEH nor signal handling is required, the handler impls
     // do not have to do anything, and can be empty.
-    FatalConditionHandler::engage_platform() {}
-    FatalConditionHandler::disengage_platform() {}
+    void FatalConditionHandler::engage_platform() {}
+    void FatalConditionHandler::disengage_platform() {}
     FatalConditionHandler::FatalConditionHandler() = default;
     FatalConditionHandler::~FatalConditionHandler() = default;
 


### PR DESCRIPTION
The later definitions have a `void` return type, so use the same type in the "do-nothing" alternatives that are used e.g. when compiling for MinGW.