### PR TITLE
Fixed [dis]engage_platform declarations mismatch

### DIFF
--- a/include/internal/catch_fatal_condition.cpp
+++ b/include/internal/catch_fatal_condition.cpp
@@ -40,8 +40,8 @@ namespace Catch {
 
     // If neither SEH nor signal handling is required, the handler impls
     // do not have to do anything, and can be empty.
-    FatalConditionHandler::engage_platform() {}
-    FatalConditionHandler::disengage_platform() {}
+    void FatalConditionHandler::engage_platform() {}
+    void FatalConditionHandler::disengage_platform() {}
     FatalConditionHandler::FatalConditionHandler() = default;
     FatalConditionHandler::~FatalConditionHandler() = default;
 


### PR DESCRIPTION
## Description

Added a missing `void` return type for the `engage_platform()` and `disengage_platform()` declarations, otherwise assumed int. 

## GitHub Issues

Closes #2212 