### PR TITLE
fixed inconsistent semicolon expansion in catch_discover_tests (Bug #2214)

### DIFF
--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -16,7 +16,10 @@ set(tests)
 
 function(add_command NAME)
   set(_args "")
-  foreach(_arg ${ARGN})
+  # use ARGV* instead of ARGN, because ARGN splits arrays into multiple arguments
+  math(EXPR _last_arg ${ARGC}-1)
+  foreach(_n RANGE 1 ${_last_arg})
+    set(_arg "${ARGV${_n}}")
     if(_arg MATCHES "[^-./:a-zA-Z0-9_]")
       set(_args "${_args} [==[${_arg}]==]") # form a bracket_argument
     else()


### PR DESCRIPTION
## Description
Changed the parameter parsing in the function `add_command` in `CatchAddTests.cmake` so that parameters that contain semicolons are not split into several arguments in the generated `*_tests.cmake` file. This fixes broken tests for targets whose cross-compiling generators contain arguments with escaped semicolons.

## GitHub Issues
Closes #2214