### PR TITLE
Allow changing the format of StringMaker<float> and StringMaker<double>

### DIFF
--- a/docs/tostring.md
+++ b/docs/tostring.md
@@ -127,6 +127,17 @@ inside the `StringMaker` specialization, like so:
 This assertion will fail and print out the `testFloat1` and `testFloat2`
 to 15 decimal places.
 
+`StringMaker<float>` and `StringMaker<double>` default to using fixed output,
+but can be set to use scientific notation by modifying the `format` static
+variable:
+
+```cpp
+        Catch::StringMaker<float>::format = std::scientific;
+        const float testFloat1 = 1e-5f;
+        const float testFloat2 = 1e-6f;
+        REQUIRE(testFloat1 == testFloat2);
+```
+
 ---
 
 [Home](Readme.md#top)

--- a/src/catch2/catch_tostring.cpp
+++ b/src/catch2/catch_tostring.cpp
@@ -42,14 +42,14 @@ namespace Detail {
         };
 
         template<typename T>
-        std::string fpToString(T value, int precision) {
+        std::string fpToString(T value, int precision, std::ios_base &(*format)(std::ios_base &)) {
             if (Catch::isnan(value)) {
                 return "nan";
             }
 
             ReusableStringStream rss;
             rss << std::setprecision(precision)
-                << std::fixed
+                << format
                 << value;
             std::string d = rss.str();
             std::size_t i = d.find_last_not_of('0');
@@ -225,15 +225,17 @@ std::string StringMaker<unsigned char>::convert(unsigned char c) {
 }
 
 int StringMaker<float>::precision = 5;
+std::ios_base &(*StringMaker<float>::format)(std::ios_base &) = std::fixed;
 
 std::string StringMaker<float>::convert(float value) {
-    return Detail::fpToString(value, precision) + 'f';
+    return Detail::fpToString(value, precision, format) + 'f';
 }
 
 int StringMaker<double>::precision = 10;
+std::ios_base &(*StringMaker<double>::format)(std::ios_base &) = std::fixed;
 
 std::string StringMaker<double>::convert(double value) {
-    return Detail::fpToString(value, precision);
+    return Detail::fpToString(value, precision, format);
 }
 
 } // end namespace Catch
@@ -241,4 +243,3 @@ std::string StringMaker<double>::convert(double value) {
 #if defined(__clang__)
 #    pragma clang diagnostic pop
 #endif
-

--- a/src/catch2/catch_tostring.hpp
+++ b/src/catch2/catch_tostring.hpp
@@ -271,12 +271,14 @@ namespace Catch {
     struct StringMaker<float> {
         static std::string convert(float value);
         static int precision;
+        static std::ios_base &(*format)(std::ios_base &);
     };
 
     template<>
     struct StringMaker<double> {
         static std::string convert(double value);
         static int precision;
+        static std::ios_base &(*format)(std::ios_base &);
     };
 
     template <typename T>


### PR DESCRIPTION
## Description

Allows the user to change the output of `StringMaker<float>` and `StringMaker<double>` from `std::fixed` to `std::scientific`.

This can be useful when comparing very small numbers, which in fixed notation requires counting zeros, but in scientific notation is clear.

The user can make this change by setting the static `format` variable, e.g. `Catch::StringMaker<float>::format = std::scientific;`.