### PR TITLE
Catch tests as dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 option(CATCH_INSTALL_DOCS "Install documentation alongside library" ON)
 option(CATCH_INSTALL_EXTRAS "Install extras alongside library" ON)
 option(CATCH_DEVELOPMENT_BUILD "Build tests, enable warnings, enable Werror, etc" OFF)
+option(CATCH_EXPERIMENTAL_SHARED "Builds Catch2 as shared library and sets WINDOWS_EXPORT_ALL_SYMBOLS on it" OFF)
 
 include(CMakeDependentOption)
 cmake_dependent_option(CATCH_BUILD_TESTING "Build the SelfTest project" ON "CATCH_DEVELOPMENT_BUILD" OFF)
@@ -55,6 +56,9 @@ if(CATCH_TEST_USE_WMAIN)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ENTRY:wmainCRTStartup")
 endif()
 
+if(CATCH_EXPERIMENTAL_SHARED)
+    set(BUILD_SHARED_LIBS ON)
+endif()
 
 # Basic paths
 set(CATCH_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,10 @@ class CatchConan(ConanFile):
     exports_sources = ("src/*", "CMakeLists.txt", "CMake/*", "extras/*")
 
     settings = "os", "compiler", "build_type", "arch"
-
+    
+    options = {"shared": [True, False]}
+    default_options = {"shared": False}
+    
     generators = "cmake"
 
     def _configure_cmake(self):
@@ -21,6 +24,7 @@ class CatchConan(ConanFile):
         cmake.definitions["BUILD_TESTING"] = "OFF"
         cmake.definitions["CATCH_INSTALL_DOCS"] = "OFF"
         cmake.definitions["CATCH_INSTALL_HELPERS"] = "ON"
+        cmake.definitions['CATCH_EXPERIMENTAL_SHARED'] = self.options.shared
         cmake.configure(build_folder="build")
         return cmake
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -234,7 +234,7 @@ set(REPORTER_FILES ${REPORTER_HEADERS} ${REPORTER_SOURCES})
 
 # Fixme: STATIC because for dynamic, we would need to handle visibility
 # and I don't want to do the annotations right now
-add_library(Catch2 STATIC
+add_library(Catch2
   ${REPORTER_FILES}
   ${INTERNAL_FILES}
   ${BENCHMARK_HEADERS}
@@ -245,6 +245,11 @@ add_library(Catch2::Catch2 ALIAS Catch2)
 if (ANDROID)
     target_link_libraries(Catch2 INTERFACE log)
 endif()
+
+if(CATCH_EXPERIMENTAL_SHARED)
+    set_target_properties(Catch2 PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 
 # depend on bunch of C++11 and C++14 features to have C++14 enabled by default
 target_compile_features(Catch2
@@ -288,7 +293,7 @@ set_target_properties(Catch2WithMain
     OUTPUT_NAME "Catch2Main"
 )
 
-if (NOT_SUBPROJECT)
+if (NOT_SUBPROJECT)    
     # create and install an export set for catch target as Catch2::Catch
     install(
       TARGETS
@@ -296,8 +301,6 @@ if (NOT_SUBPROJECT)
         Catch2WithMain
       EXPORT
         Catch2Targets
-      DESTINATION
-        ${CMAKE_INSTALL_LIBDIR}
     )
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -301,6 +301,10 @@ if (NOT_SUBPROJECT)
         Catch2WithMain
       EXPORT
         Catch2Targets
+      # This will not be needed from cmake 3.14 on
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
CMake changes only.
 * Added CATCH_EXPERIMENTAL_SHARED option for setting Catch2 to SHARED and eporting every symbol for windows.
 * ~Removed DESTINATION from install command since the defaults works better.~ Given even more destinations because why the hell not (need cmake 3.14 to get rid of it).

So I can compile the tests to separate dlls and explicitly link them to a runner application. This is especially usefull for integration/system level testing.
## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
