### PR TITLE
include <iterator> for using std::back_inserter

### DIFF
--- a/single_include/catch2/catch.hpp
+++ b/single_include/catch2/catch.hpp
@@ -5612,6 +5612,8 @@ namespace Catch {
         double clockCost;
     };
 
+#include <iterator>
+	
     template <class Duration>
     struct BenchmarkStats {
         BenchmarkInfo info;


### PR DESCRIPTION
`<iterator>` should be included explicitly for using std::back_inserter. My test code cannot be compiled without including `<iterator>` on my platform.

Sorry, I do not know where `#include <iterator>` should be added except in this header file. Would you mind telling me where `#include <iterator>` should be added if the single-include `catch.hpp` should not be changed by pull requests?

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
