### PR TITLE
Fix catch_discover_tests cmake function error

### DIFF
--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -55,11 +55,7 @@ execute_process(
   RESULT_VARIABLE reporters_result
   WORKING_DIRECTORY "${TEST_WORKING_DIR}"
 )
-if(${reporters_result} EQUAL 0)
-  message(WARNING
-    "Test executable '${TEST_EXECUTABLE}' contains no reporters!\n"
-  )
-elseif(${reporters_result} LESS 0)
+if(NOT ${reporters_result} EQUAL 0)
   message(FATAL_ERROR
     "Error running test executable '${TEST_EXECUTABLE}':\n"
     "  Result: ${reporters_result}\n"


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
Changes the `catch_discover_tests` function to accept a 0 return code as success.

In the change from V2 to V3, the `--list-tests` argument was changed to return 0 on success instead of a positive number listing the number of tests. This causes the CTest integration to break, as it believes no tests can be found.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
Closes #2232
