### PR TITLE
Fixed noexcept benchmark build for gcc.

### DIFF
--- a/include/internal/benchmark/detail/catch_run_for_at_least.hpp
+++ b/include/internal/benchmark/detail/catch_run_for_at_least.hpp
@@ -56,7 +56,7 @@ namespace Catch {
                     }
                     iters *= 2;
                 }
-                throw optimized_away_error{};
+                Catch::throw_exception(optimized_away_error{});
             }
         } // namespace Detail
     } // namespace Benchmark


### PR DESCRIPTION
## Description
Hi, Catch team.
I see compilation problem with benchmark & catch2 in noexcept gcc mode:

usr/bin/c++  -DCATCH_CONFIG_MAIN -I_deps/catch2-src/single_include -I../memory/include -I../constant/include -std=c++20 -fno-rtti -fno-exceptions -Wall -Werror -Wextra -pedantic -pedantic-errors -Wunused -Wconversion -Wsign-conversion -D_GLIBCXX_USE_CXX11_ABI=1 -fdiagnostics-color=always -O3 -DNDEBUG   -std=c++2a -MD -MT memory/test/CMakeFiles/test_stream_fixed_pool_allocator.dir/test_stream_fixed_pool_allocator.cpp.o -MF memory/test/CMakeFiles/test_stream_fixed_pool_allocator.dir/test_stream_fixed_pool_allocator.cpp.o.d -o memory/test/CMakeFiles/test_stream_fixed_pool_allocator.dir/test_stream_fixed_pool_allocator.cpp.o -c ../memory/test/test_stream_fixed_pool_allocator.cpp
In file included from ../memory/test/test_stream_fixed_pool_allocator.cpp:3:
_deps/catch2-src/single_include/catch2/catch.hpp: In instantiation of ‘Catch::Benchmark::TimingOf<Clock, Fun, Catch::Benchmark::Detail::run_for_at_least_argument_t<Clock, Fun> > Catch::Benchmark::Detail::run_for_at_least(Catch::Benchmark::ClockDuration<Clock>, int, Fun&&) [with Clock = std::chrono::_V2::steady_clock; Fun = const Catch::Benchmark::Detail::BenchmarkFunction&; Catch::Benchmark::TimingOf<Clock, Fun, Catch::Benchmark::Detail::run_for_at_least_argument_t<Clock, Fun> > = Catch::Benchmark::Timing<std::chrono::duration<long int, std::ratio<1, 1000000000> >, Catch::Benchmark::Detail::CompleteType<void>::type>; Catch::Benchmark::Detail::run_for_at_least_argument_t<Clock, Fun> = Catch::Benchmark::Chronometer; Catch::Benchmark::ClockDuration<Clock> = std::chrono::duration<long int, std::ratio<1, 1000000000> >]’:
_deps/catch2-src/single_include/catch2/catch.hpp:7299:62:   required from ‘Catch::Benchmark::ExecutionPlan<std::chrono::duration<double, typename Clock::period> > Catch::Benchmark::Benchmark::prepare(const Catch::IConfig&, Catch::Benchmark::Environment<std::chrono::duration<double, typename Clock::period> >) const [with Clock = std::chrono::_V2::steady_clock; typename Clock::period = std::ratio<1, 1000000000>]’
_deps/catch2-src/single_include/catch2/catch.hpp:7313:46:   required from ‘void Catch::Benchmark::Benchmark::run() [with Clock = std::chrono::_V2::steady_clock]’
_deps/catch2-src/single_include/catch2/catch.hpp:7347:20:   required from ‘Catch::Benchmark::Benchmark& Catch::Benchmark::Benchmark::operator=(Fun) [with Fun = ____C_A_T_C_H____T_E_S_T____8()::<lambda(int)>; typename std::enable_if<(! Catch::Benchmark::Detail::is_related<Fun, Catch::Benchmark::Benchmark>::value), int>::type <anonymous> = 0]’
../memory/test/test_stream_fixed_pool_allocator.cpp:83:5:   required from here
_deps/catch2-src/single_include/catch2/catch.hpp:6882:17: error: exception handling disabled, use ‘-fexceptions’ to enable
 6882 |                 throw optimized_away_error{};
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
[30/46] Building CXX object platform/example/CMakeFiles/platform_core_2_core_latancy.dir/core_2_core_latancy.cpp.o^C

Could you review & accept my changes, pls ?
