### PR TITLE
Don't include CTest in non-development builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,9 @@ project(Catch2 LANGUAGES CXX VERSION 3.0.0)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
-include(CTest)
+if(CATCH_DEVELOPMENT_BUILD)
+  include(CTest)
+endif()
 
 # This variable is used in some subdirectories, so we need it here, rather
 # than later in the install block


### PR DESCRIPTION
## Description

When Catch2 is used as a CMake subproject (via add_subdirectory) and is not built in development mode (CATCH_DEVELOPMENT_BUILD) CTest is not required for the build, as testing is off. When CTest is included it creates various targets (around 20) which are shown in IDEs such as Clion and pollute the list of configurations.

This patch conditionally includes CTest only if Catch2 is built in development mode.
