### PR TITLE
Added long double support for printing values

### DIFF
--- a/include/internal/catch_polyfills.cpp
+++ b/include/internal/catch_polyfills.cpp
@@ -18,12 +18,18 @@ namespace Catch {
     bool isnan(double d) {
         return std::isnan(d);
     }
+    bool isnan(long double d) {
+        return std::isnan(d);
+    }
 #else
     // For now we only use this for embarcadero
     bool isnan(float f) {
         return std::_isnan(f);
     }
     bool isnan(double d) {
+        return std::_isnan(d);
+    }
+    bool isnan(long double d) {
         return std::_isnan(d);
     }
 #endif

--- a/include/internal/catch_polyfills.hpp
+++ b/include/internal/catch_polyfills.hpp
@@ -10,6 +10,7 @@
 namespace Catch {
     bool isnan(float f);
     bool isnan(double d);
+    bool isnan(long double d);
 }
 
 #endif // TWOBLUECUBES_CATCH_POLYFILLS_HPP_INCLUDED

--- a/include/internal/catch_tostring.cpp
+++ b/include/internal/catch_tostring.cpp
@@ -73,7 +73,8 @@ std::string fpToString( T value, int precision ) {
 
     ReusableStringStream rss;
     rss << std::setprecision( precision )
-        << std::fixed
+		<< std::fixed
+//        << std::scientific    // would be nice if we could switch between these two !
         << value;
     std::string d = rss.str();
     std::size_t i = d.find_last_not_of( '0' );
@@ -249,6 +250,13 @@ int StringMaker<double>::precision = 10;
 std::string StringMaker<double>::convert(double value) {
     return fpToString(value, precision);
 }
+
+int StringMaker<long double>::precision = 15;
+
+std::string StringMaker<long double>::convert(long double value) {
+    return fpToString(value, precision);
+}
+
 
 std::string ratio_string<std::atto>::symbol() { return "a"; }
 std::string ratio_string<std::femto>::symbol() { return "f"; }

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -276,6 +276,12 @@ namespace Catch {
         static int precision;
     };
 
+    template<>
+    struct StringMaker<long double> {
+        static std::string convert(long double value);
+        static int precision;
+    };
+
     template <typename T>
     struct StringMaker<T*> {
         template <typename U>


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
This adds `long double` support when printing values, see #1731.
Had to add specialization for `isnan()` also, to make it build.


## GitHub Issues

see #1731 , up to me it should close the issue (but may need checking, I'm not well aware of potential issues).
