### PR TITLE
Update CMake doc for automatic test registration

### DIFF
--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -88,6 +88,18 @@ include(Catch)
 catch_discover_tests(foo)
 ```
 
+When using `FetchContent`, `include(Catch)` will fail unless 
+`CMAKE_MODULE_PATH` is explicitly updated to include the contrib
+directory.
+
+```cmake
+# ... FetchContent ...
+#
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(CTest)
+include(Catch)
+catch_discover_tests()
+```
 
 #### Customization
 `catch_discover_tests` can be given several extra argumets:


### PR DESCRIPTION
## Description

`FetchContent` doesn't include `contrib` directory as part of `CMAKE_MODULE_PATH`. This results into `include(Catch)` to fail. This patch just updates the documentation describing how to do include the path, so the new users don't have to figure this out themselves.

Source: https://github.com/catchorg/Catch2/issues/2103#issuecomment-730626324

## GitHub Issues

#2103 