### PR TITLE
Allow CATCH_CONFIG_CONSOLE_WIDTH to specify a function name

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,10 +62,28 @@ Typically you should place the ```#define``` before #including "catch.hpp" in yo
 
 ## Console width
 
-    CATCH_CONFIG_CONSOLE_WIDTH = x // where x is a number
+    CATCH_CONFIG_CONSOLE_WIDTH = x // where x is a number or a function
 
 Catch formats output intended for the console to fit within a fixed number of characters. This is especially important as indentation is used extensively and uncontrolled line wraps break this.
 By default a console width of 80 is assumed but this can be controlled by defining the above identifier to be a different value.
+
+If the above identifier is set to a function, the function will be called to get the width of the console. This may
+be used to set the console width based on the current number of columns of the terminal. The function is required to return
+an integral result. The function must be declared before including the Catch header in the source file hosting the Catch implementation.
+It is not necessary to do this in any othe file.  For example:
+
+    int Catch2GetConsoleWidth();
+    #define CATCH_CONFIG_CONSOLE_WIDTH Catch2GetConsoleWidth()
+    #define CATCH_CONFIG_MAIN
+    #include "catch.hpp"
+
+And then we can define the function elsewhere, or in the same file:
+
+    int Catch2GetConsoleWidth()
+    {
+        return Terminal::GetWidth();
+    }
+
 
 ## stdout
 
@@ -203,7 +221,7 @@ _Inspired by Doctest's `DOCTEST_CONFIG_DISABLE`_
 
 On Windows Catch includes `windows.h`. To minimize global namespace clutter in the implementation file, it defines `NOMINMAX` and `WIN32_LEAN_AND_MEAN` before including it. You can control this behaviour via two macros:
 
-    CATCH_CONFIG_NO_NOMINMAX            // Stops Catch from using NOMINMAX macro 
+    CATCH_CONFIG_NO_NOMINMAX            // Stops Catch from using NOMINMAX macro
     CATCH_CONFIG_NO_WIN32_LEAN_AND_MEAN // Stops Catch from using WIN32_LEAN_AND_MEAN macro
 
 

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -18,6 +18,10 @@
 #include <vector>
 #include <string>
 
+#ifndef CATCH_CONFIG_CONSOLE_MAXIMUM_WIDTH
+#define CATCH_CONFIG_CONSOLE_MAXIMUM_WIDTH 512
+#endif
+
 #ifndef CATCH_CONFIG_CONSOLE_WIDTH
 #define CATCH_CONFIG_CONSOLE_WIDTH 80
 #endif

--- a/include/internal/catch_list.cpp
+++ b/include/internal/catch_list.cpp
@@ -120,6 +120,7 @@ namespace Catch {
             }
         }
 
+        auto consoleWidth = static_cast<size_t> (CATCH_CONFIG_CONSOLE_WIDTH);
         for( auto const& tagCount : tagCounts ) {
             ReusableStringStream rss;
             rss << "  " << std::setw(2) << tagCount.second.count << "  ";
@@ -127,7 +128,7 @@ namespace Catch {
             auto wrapper = Column( tagCount.second.all() )
                                                     .initialIndent( 0 )
                                                     .indent( str.size() )
-                                                    .width( CATCH_CONFIG_CONSOLE_WIDTH-10 );
+                                                    .width( consoleWidth-10 );
             Catch::cout() << str << wrapper << '\n';
         }
         Catch::cout() << pluralise( tagCounts.size(), "tag" ) << '\n' << std::endl;
@@ -141,6 +142,7 @@ namespace Catch {
         for( auto const& factoryKvp : factories )
             maxNameLen = (std::max)( maxNameLen, factoryKvp.first.size() );
 
+        auto consoleWidth = static_cast<size_t> (CATCH_CONFIG_CONSOLE_WIDTH);
         for( auto const& factoryKvp : factories ) {
             Catch::cout()
                     << Column( factoryKvp.first + ":" )
@@ -149,7 +151,7 @@ namespace Catch {
                     +  Column( factoryKvp.second->getDescription() )
                             .initialIndent(0)
                             .indent(2)
-                            .width( CATCH_CONFIG_CONSOLE_WIDTH - maxNameLen-8 )
+                            .width( consoleWidth - maxNameLen-8 )
                     << "\n";
         }
         Catch::cout() << std::endl;

--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -264,8 +264,9 @@ namespace Catch {
     char const* getLineOfChars() {
         static char line[CATCH_CONFIG_CONSOLE_MAXIMUM_WIDTH] = {0};
         if( !*line ) {
-            std::memset( line, C, CATCH_CONFIG_CONSOLE_WIDTH-1 );
-            line[CATCH_CONFIG_CONSOLE_WIDTH-1] = 0;
+            auto consoleWidth = static_cast<size_t> (CATCH_CONFIG_CONSOLE_WIDTH);
+            std::memset( line, C, consoleWidth-1 );
+            line[consoleWidth-1] = 0;
         }
         return line;
     }

--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -262,7 +262,7 @@ namespace Catch {
 
     template<char C>
     char const* getLineOfChars() {
-        static char line[CATCH_CONFIG_CONSOLE_WIDTH] = {0};
+        static char line[CATCH_CONFIG_CONSOLE_MAXIMUM_WIDTH] = {0};
         if( !*line ) {
             std::memset( line, C, CATCH_CONFIG_CONSOLE_WIDTH-1 );
             line[CATCH_CONFIG_CONSOLE_WIDTH-1] = 0;

--- a/include/reporters/catch_reporter_console.cpp
+++ b/include/reporters/catch_reporter_console.cpp
@@ -174,7 +174,7 @@ private:
 };
 
 std::size_t makeRatio(std::size_t number, std::size_t total) {
-    std::size_t ratio = total > 0 ? CATCH_CONFIG_CONSOLE_WIDTH * number / total : 0;
+    std::size_t ratio = total > 0 ? static_cast<size_t> (CATCH_CONFIG_CONSOLE_WIDTH) * number / total : 0;
     return (ratio == 0 && number > 0) ? 1 : ratio;
 }
 
@@ -350,10 +350,11 @@ ConsoleReporter::ConsoleReporter(ReporterConfig const& config)
     : StreamingReporterBase(config),
     m_tablePrinter(new TablePrinter(config.stream(),
         [&config]() -> std::vector<ColumnInfo> {
+        auto consoleWidth = static_cast<int> (CATCH_CONFIG_CONSOLE_WIDTH);
         if (config.fullConfig()->benchmarkNoAnalysis())
         {
             return{
-                { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left },
+                { "benchmark name", consoleWidth - 43, ColumnInfo::Left },
                 { "     samples", 14, ColumnInfo::Right },
                 { "  iterations", 14, ColumnInfo::Right },
                 { "        mean", 14, ColumnInfo::Right }
@@ -362,7 +363,7 @@ ConsoleReporter::ConsoleReporter(ReporterConfig const& config)
         else
         {
             return{
-                { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left },
+                { "benchmark name", consoleWidth - 43, ColumnInfo::Left },
                 { "samples      mean       std dev", 14, ColumnInfo::Right },
                 { "iterations   low mean   low std dev", 14, ColumnInfo::Right },
                 { "estimated    high mean  high std dev", 14, ColumnInfo::Right }
@@ -656,13 +657,14 @@ void ConsoleReporter::printSummaryRow(std::string const& label, std::vector<Summ
 }
 
 void ConsoleReporter::printTotalsDivider(Totals const& totals) {
+    auto consoleWidth = static_cast<size_t> (CATCH_CONFIG_CONSOLE_WIDTH);
     if (totals.testCases.total() > 0) {
         std::size_t failedRatio = makeRatio(totals.testCases.failed, totals.testCases.total());
         std::size_t failedButOkRatio = makeRatio(totals.testCases.failedButOk, totals.testCases.total());
         std::size_t passedRatio = makeRatio(totals.testCases.passed, totals.testCases.total());
-        while (failedRatio + failedButOkRatio + passedRatio < CATCH_CONFIG_CONSOLE_WIDTH - 1)
+        while (failedRatio + failedButOkRatio + passedRatio < consoleWidth - 1)
             findMax(failedRatio, failedButOkRatio, passedRatio)++;
-        while (failedRatio + failedButOkRatio + passedRatio > CATCH_CONFIG_CONSOLE_WIDTH - 1)
+        while (failedRatio + failedButOkRatio + passedRatio > consoleWidth - 1)
             findMax(failedRatio, failedButOkRatio, passedRatio)--;
 
         stream << Colour(Colour::Error) << std::string(failedRatio, '=');
@@ -672,7 +674,7 @@ void ConsoleReporter::printTotalsDivider(Totals const& totals) {
         else
             stream << Colour(Colour::Success) << std::string(passedRatio, '=');
     } else {
-        stream << Colour(Colour::Warning) << std::string(CATCH_CONFIG_CONSOLE_WIDTH - 1, '=');
+        stream << Colour(Colour::Warning) << std::string(consoleWidth - 1, '=');
     }
     stream << '\n';
 }


### PR DESCRIPTION
This is a minor change that allows CATCH_CONFIG_CONSOLE_WIDTH to specify a function call in addition to a numeric constant.  This allows the user to provide a function to dynamically set the console width.  A typical use is to return the the column count from the terminal.