### PR TITLE
Rename contrib/ to extras/ in the docs

### DIFF
--- a/docs/ci-and-misc.md
+++ b/docs/ci-and-misc.md
@@ -95,7 +95,7 @@ can use `pkg-config` to get its include path: `pkg-config --cflags catch2`.
 
 ### gdb and lldb scripts
 
-Catch2's `contrib` folder also contains two simple debugger scripts,
+Catch2's `extras` folder also contains two simple debugger scripts,
 `gdbinit` for `gdb` and `lldbinit` for `lldb`. If loaded into their
 respective debugger, these will tell it to step over Catch2's internals
 when stepping through code.

--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -96,13 +96,13 @@ catch_discover_tests(foo)
 ```
 
 When using `FetchContent`, `include(Catch)` will fail unless
-`CMAKE_MODULE_PATH` is explicitly updated to include the contrib
+`CMAKE_MODULE_PATH` is explicitly updated to include the extras
 directory.
 
 ```cmake
 # ... FetchContent ...
 #
-list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(CTest)
 include(Catch)
 catch_discover_tests()
@@ -265,7 +265,7 @@ that consume it. These are:
 Catch2's test binary will be built. Defaults to `ON`.
 * `CATCH_INSTALL_DOCS` -- When `ON`, Catch2's documentation will be
 included in the installation. Defaults to `ON`.
-* `CATCH_INSTALL_HELPERS` -- When `ON`, Catch2's contrib folder will be
+* `CATCH_INSTALL_HELPERS` -- When `ON`, Catch2's extras folder will be
 included in the installation. Defaults to `ON`.
 * `CATCH_DEVELOPMENT_BUILD` -- When `ON`, configures the build for development
 of Catch2. This means enabling test projects, warnings and so on.


### PR DESCRIPTION
The directory has been renamed in 918aa32 but the doc was not updated yet.