### PR TITLE
Differentiate between debug and release outputs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -249,6 +249,8 @@ if (ANDROID)
     target_link_libraries(Catch2 INTERFACE log)
 endif()
 
+set_target_properties(Catch2 PROPERTIES DEBUG_POSTFIX "d")
+
 # depend on bunch of C++11 and C++14 features to have C++14 enabled by default
 target_compile_features(Catch2
   PUBLIC
@@ -291,6 +293,7 @@ set_target_properties(Catch2WithMain
   PROPERTIES
     OUTPUT_NAME "Catch2Main"
 )
+set_target_properties(Catch2WithMain PROPERTIES DEBUG_POSTFIX "d")
 
 if (NOT_SUBPROJECT)
     # create and install an export set for catch target as Catch2::Catch


### PR DESCRIPTION
## Description
I was trying to use Catch2 as an imported library (not a subproject) in my project's cmake (visual studio) and when the build configuration didn't match the one used to build Catch2 it complained about mismatched `_ITERATOR_DEBUG_LEVEL` and `/MDd` vs `/MD`. This PR adds a postfix to the lib files produced by building Catch so that the debug and release versions are differentiated and it can then be imported without the issue.

