### PR TITLE
Make Approx::operator() const to fix #2273 for 2.x

### DIFF
--- a/include/internal/catch_approx.h
+++ b/include/internal/catch_approx.h
@@ -33,7 +33,7 @@ namespace Detail {
         Approx operator-() const;
 
         template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        Approx operator()( T const& value ) {
+        Approx operator()( T const& value ) const {
             Approx approx( static_cast<double>(value) );
             approx.m_epsilon = m_epsilon;
             approx.m_margin = m_margin;

--- a/projects/SelfTest/UsageTests/Approx.tests.cpp
+++ b/projects/SelfTest/UsageTests/Approx.tests.cpp
@@ -212,4 +212,11 @@ TEST_CASE( "Comparison with explicitly convertible types", "[Approx]" )
 
 }
 
+TEST_CASE("Approx::operator() is const correct", "[Approx][.approvals]") {
+  const Approx ap = Approx(0.0).margin(0.01);
+
+  // As long as this compiles, the test should be considered passing
+  REQUIRE(1.0 == ap(1.0));
+}
+
 }} // namespace ApproxTests


### PR DESCRIPTION
## Description
Backport @horenmar's fix for 2.x branch

## GitHub Issues
#2273
