### PR TITLE
Apply PR #2297 to devel branch

### DIFF
--- a/tests/SelfTest/UsageTests/Message.tests.cpp
+++ b/tests/SelfTest/UsageTests/Message.tests.cpp
@@ -247,6 +247,7 @@ std::ostream& operator<<(std::ostream& out, helper_1436<T1, T2> const& helper) {
 #elif defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma clang diagnostic ignored "-Wdeprecated-comma-subscript"
 #pragma clang diagnostic ignored "-Wunused-value"
 #endif

--- a/tests/SelfTest/UsageTests/Message.tests.cpp
+++ b/tests/SelfTest/UsageTests/Message.tests.cpp
@@ -242,9 +242,11 @@ std::ostream& operator<<(std::ostream& out, helper_1436<T1, T2> const& helper) {
 // warns about an unused value. This warning must be disabled for C++20.
 #if defined(__GNUG__) && !defined(__clang__)
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wcomma-subscript"
 #elif defined(__clang__)
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wdeprecated-comma-subscript"
 #pragma clang diagnostic ignored "-Wunused-value"
 #endif

--- a/tests/SelfTest/UsageTests/Message.tests.cpp
+++ b/tests/SelfTest/UsageTests/Message.tests.cpp
@@ -238,6 +238,17 @@ std::ostream& operator<<(std::ostream& out, helper_1436<T1, T2> const& helper) {
     return out;
 }
 
+// Clang and gcc have different names for this warning, and clang also
+// warns about an unused value. This warning must be disabled for C++20.
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcomma-subscript"
+#elif defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-comma-subscript"
+#pragma clang diagnostic ignored "-Wunused-value"
+#endif
+
 TEST_CASE("CAPTURE can deal with complex expressions involving commas", "[messages][capture]") {
     CAPTURE(std::vector<int>{1, 2, 3}[0, 1, 2],
             std::vector<int>{1, 2, 3}[(0, 1)],
@@ -247,6 +258,10 @@ TEST_CASE("CAPTURE can deal with complex expressions involving commas", "[messag
     CAPTURE( (1, 2), (2, 3) );
     SUCCEED();
 }
+
+#ifdef __GNUG__
+#pragma GCC diagnostic pop
+#endif
 
 TEST_CASE("CAPTURE parses string and character constants", "[messages][capture]") {
     CAPTURE(("comma, in string", "escaped, \", "), "single quote in string,',", "some escapes, \\,\\\\");


### PR DESCRIPTION
## Description
It turns out that Issue #2272 partially affected the devel branch. When building tests with C++20, the compiler emits a warning that top-level comma expressions in array subscripts are depricated. Warnings are treated as errors, so this caused the build to fail.

This commit adds localized warning suppression [in accordance with this recommendation here.](https://github.com/catchorg/Catch2/pull/2297#discussion_r720848392)

## GitHub Issues
It turns out that Issue #2272 also partially applied to the devel branch. This issue was marked as closed, but the fix was only ever applied to the 2.x release branch, and still exists on the devel branch. 