### PR TITLE
Fix clang analyzer warning about FilterGenerator

### DIFF
--- a/src/catch2/generators/catch_generators_adapters.hpp
+++ b/src/catch2/generators/catch_generators_adapters.hpp
@@ -67,7 +67,7 @@ namespace Generators {
             if (!m_predicate(m_generator.get())) {
                 // It might happen that there are no values that pass the
                 // filter. In that case we throw an exception.
-                auto has_initial_value = next();
+                auto has_initial_value = m_generator.next();
                 if (!has_initial_value) {
                     Detail::throw_generator_exception("No valid value found in filtered generator");
                 }

--- a/tests/SelfTest/IntrospectiveTests/GeneratorsImpl.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/GeneratorsImpl.tests.cpp
@@ -58,6 +58,9 @@ TEST_CASE("Generators internals", "[generators][internals]") {
 
         // Completely filtered-out generator should throw on construction
         REQUIRE_THROWS_AS(filter([] (int) { return false; }, value(1)), Catch::GeneratorException);
+        REQUIRE_THROWS_AS(
+            filter( []( int ) { return false; }, values( { 1, 2, 3 } ) ),
+            Catch::GeneratorException );
     }
     SECTION("Take generator") {
         SECTION("Take less") {


### PR DESCRIPTION
**Describe the bug**
When using a filter generator, clang analyzer (called through clang-tidy) produces a diagnostic about `FilterGenerator::next`.

```
/Users/xw/Projects/mays/build/_deps/catch2-src/single_include/catch2/catch.hpp:4166:42: warning: Call to virtual method 'FilterGenerator::next' during construction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]
                auto has_initial_value = next();
                                         ^
/Users/xw/Projects/mays/mays/scale_test.cc:164:16: note: Calling 'filter<int, (lambda at /Users/xw/Projects/mays/mays/scale_test.cc:163:25)>'
          100, filter([](int i) { return i != 0; },
               ^
/Users/xw/Projects/mays/build/_deps/catch2-src/single_include/catch2/catch.hpp:4101:97: note: expanded from macro 'GENERATE'
                                 [ ]{ using namespace Catch::Generators; return makeGenerators( __VA_ARGS__ ); } ) //NOLINT(google-build-using-namespace)
                                                                                                ^~~~~~~~~~~
/Users/xw/Projects/mays/build/_deps/catch2-src/single_include/catch2/catch.hpp:4189:67: note: Calling 'make_unique<Catch::Generators::FilterGenerator<int, (lambda at /Users/xw/Projects/mays/mays/scale_test.cc:163:25)>, (lambda at /Users/xw/Projects/mays/mays/scale_test.cc:163:25), Catch::Generators::GeneratorWrapper<int>>'
        return GeneratorWrapper<T>(std::unique_ptr<IGenerator<T>>(pf::make_unique<FilterGenerator<T, Predicate>>(std::forward<Predicate>(pred), std::move(generator))));
                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/xw/Projects/mays/build/_deps/catch2-src/single_include/catch2/catch.hpp:3934:43: note: Calling constructor for 'FilterGenerator<int, (lambda at /Users/xw/Projects/mays/mays/scale_test.cc:163:25)>'
            return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/xw/Projects/mays/build/_deps/catch2-src/single_include/catch2/catch.hpp:4163:13: note: Taking true branch
            if (!m_predicate(m_generator.get())) {
            ^
/Users/xw/Projects/mays/build/_deps/catch2-src/single_include/catch2/catch.hpp:4166:42: note: Call to virtual method 'FilterGenerator::next' during construction bypasses virtual dispatch
                auto has_initial_value = next();
                                         ^~~~~~
```

**Expected behavior**
Catch2 does not cause clang-tidy diagnostics to pop up.

**Reproduction steps**
```
const int value =
          GENERATE(take(100, filter([](int i) { return i != 0; }, random(-128, 127))));
```

**Platform information:**
<!-- Fill in any extra information that might be important for your issue. -->
 - OS: **macOS 12.0.1**
 - Compiler+version: **Apple clang version 13.0.0 (clang-1300.0.29.3)**
 - Catch version: **v2.13.7**