### PR TITLE
Fix clang analyzer warning about FilterGenerator in v2.x

### DIFF
--- a/include/internal/catch_generators_generic.hpp
+++ b/include/internal/catch_generators_generic.hpp
@@ -63,7 +63,7 @@ namespace Generators {
             if (!m_predicate(m_generator.get())) {
                 // It might happen that there are no values that pass the
                 // filter. In that case we throw an exception.
-                auto has_initial_value = next();
+                auto has_initial_value = nextImpl();
                 if (!has_initial_value) {
                     Catch::throw_exception(GeneratorException("No valid value found in filtered generator"));
                 }
@@ -75,6 +75,11 @@ namespace Generators {
         }
 
         bool next() override {
+            return nextImpl();
+        }
+
+    private:
+        bool nextImpl() {
             bool success = m_generator.next();
             if (!success) {
                 return false;

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -628,6 +628,7 @@ GeneratorsImpl.tests.cpp:<line number>: passed: gen.next() for: true
 GeneratorsImpl.tests.cpp:<line number>: passed: gen.get() == 3 for: 3 == 3
 GeneratorsImpl.tests.cpp:<line number>: passed: !(gen.next()) for: !false
 GeneratorsImpl.tests.cpp:<line number>: passed: filter([] (int) { return false; }, value(1)), Catch::GeneratorException
+GeneratorsImpl.tests.cpp:<line number>: passed: filter( []( int ) { return false; }, values( { 1, 2, 3 } ) ), Catch::GeneratorException
 GeneratorsImpl.tests.cpp:<line number>: passed: gen.get() == 1 for: 1 == 1
 GeneratorsImpl.tests.cpp:<line number>: passed: gen.next() for: true
 GeneratorsImpl.tests.cpp:<line number>: passed: gen.get() == 2 for: 2 == 2

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -1421,5 +1421,5 @@ due to unexpected exception with message:
 
 ===============================================================================
 test cases:  323 |  248 passed |  70 failed |  5 failed as expected
-assertions: 1763 | 1607 passed | 131 failed | 25 failed as expected
+assertions: 1764 | 1608 passed | 131 failed | 25 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -4968,6 +4968,9 @@ with expansion:
 GeneratorsImpl.tests.cpp:<line number>: PASSED:
   REQUIRE_THROWS_AS( filter([] (int) { return false; }, value(1)), Catch::GeneratorException )
 
+GeneratorsImpl.tests.cpp:<line number>: PASSED:
+  REQUIRE_THROWS_AS( filter( []( int ) { return false; }, values( { 1, 2, 3 } ) ), Catch::GeneratorException )
+
 -------------------------------------------------------------------------------
 Generators internals
   Take generator
@@ -14179,5 +14182,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  323 |  232 passed |  86 failed |  5 failed as expected
-assertions: 1780 | 1607 passed | 148 failed | 25 failed as expected
+assertions: 1781 | 1608 passed | 148 failed | 25 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="132" tests="1781" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="132" tests="1782" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="filters" value="~[!nonportable]~[!benchmark]~[approvals]"/>
       <property name="random-seed" value="1"/>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -5720,7 +5720,15 @@ Nor would this
             filter([] (int) { return false; }, value(1)), Catch::GeneratorException
           </Expanded>
         </Expression>
-        <OverallResults successes="5" failures="0" expectedFailures="0"/>
+        <Expression success="true" type="REQUIRE_THROWS_AS" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
+          <Original>
+            filter( []( int ) { return false; }, values( { 1, 2, 3 } ) ), Catch::GeneratorException
+          </Original>
+          <Expanded>
+            filter( []( int ) { return false; }, values( { 1, 2, 3 } ) ), Catch::GeneratorException
+          </Expanded>
+        </Expression>
+        <OverallResults successes="6" failures="0" expectedFailures="0"/>
       </Section>
       <Section name="Take generator" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
         <Section name="Take less" filename="projects/<exe-name>/IntrospectiveTests/GeneratorsImpl.tests.cpp" >
@@ -16759,9 +16767,9 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="1607" failures="149" expectedFailures="25"/>
+    <OverallResults successes="1608" failures="149" expectedFailures="25"/>
     <OverallResultsCases successes="232" failures="86" expectedFailures="5"/>
   </Group>
-  <OverallResults successes="1607" failures="148" expectedFailures="25"/>
+  <OverallResults successes="1608" failures="148" expectedFailures="25"/>
   <OverallResultsCases successes="232" failures="86" expectedFailures="5"/>
 </Catch>

--- a/projects/SelfTest/IntrospectiveTests/GeneratorsImpl.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/GeneratorsImpl.tests.cpp
@@ -53,6 +53,9 @@ TEST_CASE("Generators internals", "[generators][internals]") {
 
         // Completely filtered-out generator should throw on construction
         REQUIRE_THROWS_AS(filter([] (int) { return false; }, value(1)), Catch::GeneratorException);
+        REQUIRE_THROWS_AS(
+            filter( []( int ) { return false; }, values( { 1, 2, 3 } ) ),
+            Catch::GeneratorException );
     }
     SECTION("Take generator") {
         SECTION("Take less") {


### PR DESCRIPTION
PR #2313 backported to v2.x since that's the one I'm actually using.