### PR TITLE
Fix performance when printing strings w/o newlines

### DIFF
--- a/src/catch2/internal/catch_textflow.cpp
+++ b/src/catch2/internal/catch_textflow.cpp
@@ -42,14 +42,16 @@ namespace Catch {
         void Column::iterator::calcLength() {
             m_suffix = false;
             auto width = m_column.m_width - indent();
-            m_end = m_pos;
             std::string const& current_line = m_column.m_string;
-            if ( current_line[m_pos] == '\n' ) {
-                ++m_end;
-            }
-            while ( m_end < current_line.size() &&
-                    current_line[m_end] != '\n' ) {
-                ++m_end;
+            if ( m_end <= m_pos ) {
+                m_end = m_pos;
+                if ( current_line[m_pos] == '\n' ) {
+                    ++m_end;
+                }
+                while ( m_end < current_line.size() &&
+                        current_line[m_end] != '\n' ) {
+                    ++m_end;
+                }
             }
 
             if ( m_end < m_pos + width ) {


### PR DESCRIPTION
## Description
When generating columns from long strings, as e.g. done when we
`REQUIRE(str == other_str)`, every single column would calculate the
length of the current line. This can be very slow if used for large
strings, due to the O(n²) performance. We had a test comparing two 2
megabyte long strings, and even when logging directly to file, this test
took over an hour to run with `-s` on 2.x. With this change, it takes
~4s.

This change makes us only recalculate the length of the current line
when we've consumed the current line, which means that unbroken strings
will only have a single iteration over the line (and that each line will
only be traversed once). `m_end` would always be the same after every
`calcLength` until we encounter the next newline in our output.
