### PR TITLE
Handle dynamic stack size on GLIBC > 2.33

### DIFF
--- a/extras/catch_amalgamated.cpp
+++ b/extras/catch_amalgamated.cpp
@@ -3750,8 +3750,14 @@ namespace Catch {
     };
 
     // 32kb for the alternate stack seems to be sufficient. However, this value
-    // is experimentally determined, so that's not guaranteed.
+    // is experimentally determines, so that's not guaranteed.
+#if defined(_SC_SIGSTKSZ_SOURCE) || defined(_GNU_SOURCE)
+    // on glibc > 2.33 this is no longer constant, see
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;h=85e84fe53699fe9e392edffa993612ce08b2954a;hb=HEAD
+    static constexpr std::size_t sigStackSize = 32768;
+#else
     static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+#endif
 
     static SignalDefs signalDefs[] = {
         { SIGINT,  "SIGINT - Terminal interrupt signal" },


### PR DESCRIPTION
## Description
On GLIBC 2.33, `MINSIGSTKSZ` is not a constant. This can be detected
at compile time by the presence of either `_SC_SIGSTKSZ_SOURCE` or
`_GNU_SOURCE`.

If either are define, hardcode the size we want rather than compare it,
since we can't do that in a constant expression anymore.

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

## GitHub Issues
Closes #2178 
