### PR TITLE
Add STATIC_CHECK and STATIC_CHECK_FALSE

### DIFF
--- a/docs/other-macros.md
+++ b/docs/other-macros.md
@@ -59,7 +59,7 @@ TEST_CASE( "SUCCEED showcase" ) {
 }
 ```
 
-* `STATIC_REQUIRE`
+* `STATIC_REQUIRE` and `STATIC_CHECK`
 
 > [Introduced](https://github.com/catchorg/Catch2/issues/1362) in Catch2 2.4.2.
 
@@ -74,6 +74,18 @@ Example:
 TEST_CASE("STATIC_REQUIRE showcase", "[traits]") {
     STATIC_REQUIRE( std::is_void<void>::value );
     STATIC_REQUIRE_FALSE( std::is_void<int>::value );
+}
+```
+
+`STATIC_CHECK( expr )` is equivalent to `STATIC_REQUIRE( expr )`, with the
+difference that when `CATCH_CONFIG_RUNTIME_STATIC_REQUIRE` is defined, it
+becomes equivalent to `CHECK` instead of `REQUIRE`.
+
+Example:
+```cpp
+TEST_CASE("STATIC_CHECK showcase", "[traits]") {
+    STATIC_CHECK( std::is_void<void>::value );
+    STATIC_CHECK_FALSE( std::is_void<int>::value );
 }
 ```
 

--- a/docs/other-macros.md
+++ b/docs/other-macros.md
@@ -61,7 +61,7 @@ TEST_CASE( "SUCCEED showcase" ) {
 
 * `STATIC_REQUIRE` and `STATIC_CHECK`
 
-> [Introduced](https://github.com/catchorg/Catch2/issues/1362) in Catch2 2.4.2.
+> `STATIC_REQUIRE` was [introduced](https://github.com/catchorg/Catch2/issues/1362) in Catch2 2.4.2.
 
 `STATIC_REQUIRE( expr )` is a macro that can be used the same way as a
 `static_assert`, but also registers the success with Catch2, so it is
@@ -76,6 +76,8 @@ TEST_CASE("STATIC_REQUIRE showcase", "[traits]") {
     STATIC_REQUIRE_FALSE( std::is_void<int>::value );
 }
 ```
+
+> `STATIC_CHECK` was [introduced](https://github.com/catchorg/Catch2/pull/2318) in Catch2 X.Y.Z.
 
 `STATIC_CHECK( expr )` is equivalent to `STATIC_REQUIRE( expr )`, with the
 difference that when `CATCH_CONFIG_RUNTIME_STATIC_REQUIRE` is defined, it

--- a/src/catch2/catch_test_macros.hpp
+++ b/src/catch2/catch_test_macros.hpp
@@ -54,9 +54,13 @@
   #if !defined(CATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
     #define CATCH_STATIC_REQUIRE( ... )       static_assert(   __VA_ARGS__ ,      #__VA_ARGS__ );     CATCH_SUCCEED( #__VA_ARGS__ )
     #define CATCH_STATIC_REQUIRE_FALSE( ... ) static_assert( !(__VA_ARGS__), "!(" #__VA_ARGS__ ")" ); CATCH_SUCCEED( #__VA_ARGS__ )
+    #define CATCH_STATIC_CHECK( ... )       static_assert(   __VA_ARGS__ ,      #__VA_ARGS__ );     CATCH_SUCCEED( #__VA_ARGS__ )
+    #define CATCH_STATIC_CHECK_FALSE( ... ) static_assert( !(__VA_ARGS__), "!(" #__VA_ARGS__ ")" ); CATCH_SUCCEED( #__VA_ARGS__ )
   #else
     #define CATCH_STATIC_REQUIRE( ... )       CATCH_REQUIRE( __VA_ARGS__ )
     #define CATCH_STATIC_REQUIRE_FALSE( ... ) CATCH_REQUIRE_FALSE( __VA_ARGS__ )
+    #define CATCH_STATIC_CHECK( ... )       CATCH_CHECK( __VA_ARGS__ )
+    #define CATCH_STATIC_CHECK_FALSE( ... ) CATCH_CHECK_FALSE( __VA_ARGS__ )
   #endif
 
 
@@ -101,6 +105,8 @@
 
   #define CATCH_STATIC_REQUIRE( ... )       (void)(0)
   #define CATCH_STATIC_REQUIRE_FALSE( ... ) (void)(0)
+  #define CATCH_STATIC_CHECK( ... )       (void)(0)
+  #define CATCH_STATIC_CHECK_FALSE( ... ) (void)(0)
 
   // "BDD-style" convenience wrappers
   #define CATCH_SCENARIO( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( CATCH2_INTERNAL_TEST_ ))
@@ -145,9 +151,13 @@
   #if !defined(CATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
     #define STATIC_REQUIRE( ... )       static_assert(   __VA_ARGS__,  #__VA_ARGS__ ); SUCCEED( #__VA_ARGS__ )
     #define STATIC_REQUIRE_FALSE( ... ) static_assert( !(__VA_ARGS__), "!(" #__VA_ARGS__ ")" ); SUCCEED( "!(" #__VA_ARGS__ ")" )
+    #define STATIC_CHECK( ... )       static_assert(   __VA_ARGS__,  #__VA_ARGS__ ); SUCCEED( #__VA_ARGS__ )
+    #define STATIC_CHECK_FALSE( ... ) static_assert( !(__VA_ARGS__), "!(" #__VA_ARGS__ ")" ); SUCCEED( "!(" #__VA_ARGS__ ")" )
   #else
     #define STATIC_REQUIRE( ... )       REQUIRE( __VA_ARGS__ )
     #define STATIC_REQUIRE_FALSE( ... ) REQUIRE_FALSE( __VA_ARGS__ )
+    #define STATIC_CHECK( ... )       CHECK( __VA_ARGS__ )
+    #define STATIC_CHECK_FALSE( ... ) CHECK_FALSE( __VA_ARGS__ )
   #endif
 
   // "BDD-style" convenience wrappers
@@ -191,6 +201,8 @@
 
   #define STATIC_REQUIRE( ... )       (void)(0)
   #define STATIC_REQUIRE_FALSE( ... ) (void)(0)
+  #define STATIC_CHECK( ... )       (void)(0)
+  #define STATIC_CHECK_FALSE( ... ) (void)(0)
 
   // "BDD-style" convenience wrappers
   #define SCENARIO( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( CATCH2_INTERNAL_TEST_ ) )

--- a/tests/ExtraTests/X01-PrefixedMacros.cpp
+++ b/tests/ExtraTests/X01-PrefixedMacros.cpp
@@ -62,6 +62,8 @@ CATCH_TEST_CASE("PrefixedMacros") {
 
     CATCH_STATIC_REQUIRE( std::is_void<void>::value );
     CATCH_STATIC_REQUIRE_FALSE( std::is_void<int>::value );
+    CATCH_STATIC_CHECK( std::is_void<void>::value );
+    CATCH_STATIC_CHECK_FALSE( std::is_void<int>::value );
     CATCH_FAIL("");
 }
 

--- a/tests/ExtraTests/X02-DisabledMacros.cpp
+++ b/tests/ExtraTests/X02-DisabledMacros.cpp
@@ -32,6 +32,10 @@ foo f;
 TEST_CASE( "Disabled Macros" ) {
     std::cout << "This should not happen\n";
     FAIL();
+
+    // Test that static assertions don't fire when macros are disabled
+    STATIC_CHECK( 0 == 1 );
+    STATIC_REQUIRE( !true );
 }
 
 #if defined(__clang__)

--- a/tests/SelfTest/Baselines/compact.sw.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.approved.txt
@@ -948,6 +948,8 @@ Tricky.tests.cpp:<line number>: passed: !False for: true
 Tricky.tests.cpp:<line number>: passed: !(False) for: !{?}
 Compilation.tests.cpp:<line number>: passed: with 1 message: 'std::is_void<void>::value'
 Compilation.tests.cpp:<line number>: passed: with 1 message: '!(std::is_void<int>::value)'
+Compilation.tests.cpp:<line number>: passed: with 1 message: 'std::is_void<void>::value'
+Compilation.tests.cpp:<line number>: passed: with 1 message: '!(std::is_void<int>::value)'
 Condition.tests.cpp:<line number>: failed: data.int_seven > 7 for: 7 > 7
 Condition.tests.cpp:<line number>: failed: data.int_seven < 7 for: 7 < 7
 Condition.tests.cpp:<line number>: failed: data.int_seven > 8 for: 7 > 8

--- a/tests/SelfTest/Baselines/console.std.approved.txt
+++ b/tests/SelfTest/Baselines/console.std.approved.txt
@@ -1427,5 +1427,5 @@ due to unexpected exception with message:
 
 ===============================================================================
 test cases:  376 |  299 passed |  70 failed |  7 failed as expected
-assertions: 2147 | 1991 passed | 129 failed | 27 failed as expected
+assertions: 2149 | 1993 passed | 129 failed | 27 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.approved.txt
@@ -7320,6 +7320,14 @@ Compilation.tests.cpp:<line number>: PASSED:
 with message:
   !(std::is_void<int>::value)
 
+Compilation.tests.cpp:<line number>: PASSED:
+with message:
+  std::is_void<void>::value
+
+Compilation.tests.cpp:<line number>: PASSED:
+with message:
+  !(std::is_void<int>::value)
+
 -------------------------------------------------------------------------------
 Ordering comparison checks that should fail
 -------------------------------------------------------------------------------
@@ -17268,5 +17276,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  376 |  283 passed |  86 failed |  7 failed as expected
-assertions: 2164 | 1991 passed | 146 failed | 27 failed as expected
+assertions: 2166 | 1993 passed | 146 failed | 27 failed as expected
 

--- a/tests/SelfTest/Baselines/junit.sw.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="129" tests="2164" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="129" tests="2166" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="random-seed" value="1"/>
       <property name="filters" value="~[!nonportable]~[!benchmark]~[approvals] *"/>

--- a/tests/SelfTest/Baselines/tap.sw.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.approved.txt
@@ -1878,6 +1878,10 @@ ok {test-number} - !(False) for: !{?}
 ok {test-number} - with 1 message: 'std::is_void<void>::value'
 # Optionally static assertions
 ok {test-number} - with 1 message: '!(std::is_void<int>::value)'
+# Optionally static assertions
+ok {test-number} - with 1 message: 'std::is_void<void>::value'
+# Optionally static assertions
+ok {test-number} - with 1 message: '!(std::is_void<int>::value)'
 # Ordering comparison checks that should fail
 not ok {test-number} - data.int_seven > 7 for: 7 > 7
 # Ordering comparison checks that should fail
@@ -4330,5 +4334,5 @@ ok {test-number} - q3 == 23. for: 23.0 == 23.0
 ok {test-number} -
 # xmlentitycheck
 ok {test-number} -
-1..2164
+1..2166
 

--- a/tests/SelfTest/Baselines/xml.sw.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.approved.txt
@@ -20238,6 +20238,6 @@ loose text artifact
     </Section>
     <OverallResult success="true"/>
   </TestCase>
-  <OverallResults successes="1991" failures="146" expectedFailures="27"/>
+  <OverallResults successes="1993" failures="146" expectedFailures="27"/>
   <OverallResultsCases successes="283" failures="86" expectedFailures="7"/>
 </Catch2TestRun>

--- a/tests/SelfTest/UsageTests/Compilation.tests.cpp
+++ b/tests/SelfTest/UsageTests/Compilation.tests.cpp
@@ -172,6 +172,8 @@ TEST_CASE("#1403", "[compilation]") {
 TEST_CASE("Optionally static assertions", "[compilation]") {
     STATIC_REQUIRE( std::is_void<void>::value );
     STATIC_REQUIRE_FALSE( std::is_void<int>::value );
+    STATIC_CHECK( std::is_void<void>::value );
+    STATIC_CHECK_FALSE( std::is_void<int>::value );
 }
 
 TEST_CASE("#1548", "[compilation]") {


### PR DESCRIPTION
## Description

This PR adds two new macros to Catch2: `STATIC_CHECK` and `STATIC_CHECK_FALSE`. As mentioned on Discord, my reason to propose those is to allow the following development workflow:
* Run my tests locally and have `static_assert`s so that failures happen soon at compile time, so that I can be noticed early without having to compile and run the rest of the tests.
* Have a complete and readable report in the CI by defining `CATCH_CONFIG_RUNTIME_STATIC_REQUIRE`, transforming those failure into runtime ones that can be aggregated in the reporter.

## Questions

There are two potential design issues with this PR:
* It is called `STATIC_CHECK` but effectively acts as a `REQUIRE` when it fails at compile time. It might be a bit confusing, but it is the behaviour I want so unless we invent a new name there isn't much we can do about it.
* The switch from compile time to runtime reporting currently depends on `CATCH_CONFIG_RUNTIME_STATIC_REQUIRE`. I think that it makes sense to have a single macro for both, but this macro name specifically mentions `STATIC_REQUIRE`, which is mildly confusing. Catch2 v3 isn't out, so it's theoretically still time to change the macro name if you feel like it. I personally don't mind.