### PR TITLE
Fix template args to avoid conversion warnings

### DIFF
--- a/src/catch2/catch_tostring.hpp
+++ b/src/catch2/catch_tostring.hpp
@@ -205,7 +205,7 @@ namespace Catch {
     };
 #endif // CATCH_CONFIG_WCHAR
 
-    template<int SZ>
+    template<size_t SZ>
     struct StringMaker<char[SZ]> {
         static std::string convert(char const* str) {
             // Note that `strnlen` is not actually part of standard C++,
@@ -214,7 +214,7 @@ namespace Catch {
                 StringRef( str, strnlen( str, SZ ) ) );
         }
     };
-    template<int SZ>
+    template<size_t SZ>
     struct StringMaker<signed char[SZ]> {
         static std::string convert(signed char const* str) {
             // See the plain `char const*` overload
@@ -223,7 +223,7 @@ namespace Catch {
                 StringRef(reinterpreted, strnlen(reinterpreted, SZ)));
         }
     };
-    template<int SZ>
+    template<size_t SZ>
     struct StringMaker<unsigned char[SZ]> {
         static std::string convert(unsigned char const* str) {
             // See the plain `char const*` overload
@@ -522,7 +522,7 @@ namespace Catch {
         }
     };
 
-    template <typename T, int SZ>
+    template <typename T, size_t SZ>
     struct StringMaker<T[SZ]> {
         static std::string convert(T const(&arr)[SZ]) {
             return rangeToString(arr);


### PR DESCRIPTION
Fix avoids a warning about sign conversion when included from a file compiled with -Wsign-conversion.

## Description
Changed integer template parameter from int to size_t. This avoids a warning when header is included into a file using -Wsign-conversion.
