### PR TITLE
Add Bazel `XML_OUTPUT_FILE` processing to `main`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,7 @@ cc_library(
 # Static library, with main.
 cc_library(
     name = "catch2_main",
+    local_defines = ["CATCH_CONFIG_MAIN_BAZEL_JUNIT_XML_OUTPUT_FILE"],
     srcs = ["src/catch2/internal/catch_main.cpp"],
     deps = [":catch2"],
     visibility = ["//visibility:public"],

--- a/src/catch2/internal/catch_main.cpp
+++ b/src/catch2/internal/catch_main.cpp
@@ -33,7 +33,18 @@ int main (int argc, char * argv[]) {
     // and its constructor, as it (optionally) registers leak detector
     (void)&Catch::leakDetector;
 
-    return Catch::Session().run( argc, argv );
+    Catch::Session session;
+
+#if defined(CATCH_CONFIG_MAIN_BAZEL_JUNIT_XML_OUTPUT_FILE)
+    // Bazel expects test output to be written to this file in JUnit format.
+    auto bazelOutputFile = std::getenv("XML_OUTPUT_FILE");
+    if (bazelOutputFile != nullptr) {
+        session.configData().reporterName = "junit";
+        session.configData().outputFilename = bazelOutputFile;
+    }
+#endif
+
+    return session.run( argc, argv );
 }
 
 #endif // !defined(CATCH_AMALGAMATED_CUSTOM_MAIN


### PR DESCRIPTION
`bazel test` sets the `XML_OUTPUT_FILE` environment variable which
specifies where the JUnit output of the test executable should be
written.

Picking up this variable allows catch2 to naturally integrate into
the Bazel testing ecosystem out-of-the-box.

The environment variable processing is hidden behind the
`CATCH_CONFIG_MAIN_BAZEL_XML_OUTPUT_FILE` define and it _only_
enabled in the `BUILD.bazel`.

This allows the Bazel ecosystem to create a `cc_test` target as
follows:

```
cc_test(
    name = "some_test",
    deps = ["@catch2//:catch2_main"],
    srcs = globs("**/*_test.cpp"),
)
```

The output will be written to `bazel-testlogs/some_test/test.xml`
