### PR TITLE
Disable JIT debug for ctest.ext

### DIFF
--- a/tools/misc/appveyorTestRunScript.bat
+++ b/tools/misc/appveyorTestRunScript.bat
@@ -1,5 +1,7 @@
 SETLOCAL EnableDelayedExpansion
 
+rem Disable launching the JIT debugger for ctest.exe
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug\AutoExclusionList" /v "ctest.ext" /t REG_DWORD /d 1
 cd Build
 if "%CONFIGURATION%"=="Debug" (
   if "%coverage%"=="1" (


### PR DESCRIPTION
## Description
Windows launches the debugger listed under the registry key:
```HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug```

After installing Visual Studio, this is set to the value:
```"C:\WINDOWS\system32\vsjitdebugger.exe" -p %ld -e %ld -j 0x%p```

While this is useful during interactive sessions as it permits the developer to attach to the failing process, this causes issues when the user is not present (as an example during a CI/CD run).

This behavior can be overridden via registry key:
```HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug\AutoExclusionList```
Where the value includes the name of the process to exclude.

See: [Excluding an Application from Automatic Debugging](https://docs.microsoft.com/en-us/windows/win32/debug/configuring-automatic-debugging#excluding-an-application-from-automatic-debugging)

## GitHub Issues
No issue that I know of, this is purely an improvement to the CI/CD pipeline.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>