### PR TITLE
Add buildAndTest.cmd for Windows users

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -104,6 +104,8 @@ cd Catch2
 ./tools/scripts/buildAndTest.sh
 ```
 
+A Windows version of the script is available at `tools\scripts\buildAndTest.cmd`.
+
 If you added new tests, you will likely see `ApprovalTests` failure.
 After you check that the output difference is expected, you should
 run `tools/scripts/approve.py` to confirm them, and include these changes

--- a/tools/scripts/buildAndTest.cmd
+++ b/tools/scripts/buildAndTest.cmd
@@ -1,7 +1,7 @@
 rem Start at the root of the Catch project directory, for example:
 rem cd Catch2
 
-rem begin-snippet: catch2-build-and-test
+rem begin-snippet: catch2-build-and-test-win
 rem 1. Regenerate the amalgamated distribution
 python tools\scripts\generateAmalgamatedFiles.py
 

--- a/tools/scripts/buildAndTest.cmd
+++ b/tools/scripts/buildAndTest.cmd
@@ -1,0 +1,17 @@
+rem Start at the root of the Catch project directory, for example:
+rem cd Catch2
+
+rem begin-snippet: catch2-build-and-test
+rem 1. Regenerate the amalgamated distribution
+python tools\scripts\generateAmalgamatedFiles.py
+
+rem 2. Configure the full test build
+cmake -Bdebug-build -H. -DCMAKE_BUILD_TYPE=Debug -DCATCH_BUILD_EXAMPLES=ON -DCATCH_BUILD_EXTRA_TESTS=ON -DCATCH_DEVELOPMENT_BUILD=ON
+
+rem 3. Run the actual build
+cmake --build debug-build
+
+rem 4. Run the tests using CTest
+cd debug-build
+ctest -j 4 --output-on-failure -C Debug
+rem end-snippet


### PR DESCRIPTION
## Description
Contributing guide instructions for validating tests are Linux-specific. Adding a version of the script that works for Windows.

## GitHub Issues
No issue has been created.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>
