### PR TITLE
Ignoring VSCode settings dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ benchmark-dir
 bazel-*
 build-fuzzers
 debug-build
+.vscode


### PR DESCRIPTION
## Description
Changing .gitignore file to ignore the default VSCode settings dir.

This is importat so developers and testers can use VSCode to 
work on Catch without having toi worry about accidently 
commiting unrelevant VSCode local settings.

