### PR TITLE
fix: a single _ should not be used for a name

### DIFF
--- a/include/internal/catch_run_context.cpp
+++ b/include/internal/catch_run_context.cpp
@@ -452,7 +452,7 @@ namespace Catch {
     }
 
     void RunContext::invokeActiveTestCase() {
-        FatalConditionHandlerGuard _(&m_fatalConditionhandler);
+        FatalConditionHandlerGuard _gaurd(&m_fatalConditionhandler);
         m_activeTestCase->invoke();
     }
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

This avoids using a single underscore for a name, which can conflict with defining `_` for translation. One idea for a test would be to add `-D_=1` when building Catch, to help ensure that this is not rebroken in the future. Another could be to do a static check for a single underscore, though that is allowed in comments and such. Something like this:

```console
$ git grep '\<_\>' src/*
src/catch2/internal/catch_run_context.cpp:        FatalConditionHandlerGuard _(&m_fatalConditionhandler);
```

(that's on `devel`)

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->

Closes #2363.
