### PR TITLE
fix ${specs} placement for correct test discovery

### DIFF
--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -36,7 +36,7 @@ if(NOT EXISTS "${TEST_EXECUTABLE}")
   )
 endif()
 execute_process(
-  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-tests --verbosity quiet
+  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --list-tests --verbosity quiet ${spec}
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
   WORKING_DIRECTORY "${TEST_WORKING_DIR}"

--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -38,6 +38,7 @@ endif()
 execute_process(
   COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --list-tests --verbosity quiet ${spec}
   OUTPUT_VARIABLE output
+  ERROR_VARIABLE error
   RESULT_VARIABLE result
   WORKING_DIRECTORY "${TEST_WORKING_DIR}"
 )
@@ -46,6 +47,7 @@ if(NOT ${result} EQUAL 0)
     "Error running test executable '${TEST_EXECUTABLE}':\n"
     "  Result: ${result}\n"
     "  Output: ${output}\n"
+    "  Error: ${error}\n"
   )
 endif()
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
When a *TEST_SPEC* is passed to `catch_discovery_tests` the arguments seems to be ignored when it is not at the end of the argument list.

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
