### PR TITLE
Fix disengage failure logs for FatalConditionHandlerGuard

### DIFF
--- a/src/catch2/internal/catch_fatal_condition_handler.cpp
+++ b/src/catch2/internal/catch_fatal_condition_handler.cpp
@@ -78,10 +78,10 @@ namespace Catch {
     // Windows can easily distinguish between SO and SigSegV,
     // but SigInt, SigTerm, etc are handled differently.
     static SignalDefs signalDefs[] = {
-        { static_cast<DWORD>(EXCEPTION_ILLEGAL_INSTRUCTION),  "SIGILL - Illegal instruction signal" },
-        { static_cast<DWORD>(EXCEPTION_STACK_OVERFLOW), "SIGSEGV - Stack overflow" },
-        { static_cast<DWORD>(EXCEPTION_ACCESS_VIOLATION), "SIGSEGV - Segmentation violation signal" },
-        { static_cast<DWORD>(EXCEPTION_INT_DIVIDE_BY_ZERO), "Divide by zero error" },
+        { EXCEPTION_ILLEGAL_INSTRUCTION,  "SIGILL - Illegal instruction signal" },
+        { EXCEPTION_STACK_OVERFLOW, "SIGSEGV - Stack overflow" },
+        { EXCEPTION_ACCESS_VIOLATION, "SIGSEGV - Segmentation violation signal" },
+        { EXCEPTION_INT_DIVIDE_BY_ZERO, "Divide by zero error" },
     };
 
     static LONG CALLBACK topLevelExceptionFilter(PEXCEPTION_POINTERS ExceptionInfo) {
@@ -125,7 +125,7 @@ namespace Catch {
     }
 
     void FatalConditionHandler::disengage_platform() {
-        if (SetUnhandledExceptionFilter(reinterpret_cast<LPTOP_LEVEL_EXCEPTION_FILTER>(previousTopLevelExceptionFilter)) != topLevelExceptionFilter) {
+        if (SetUnhandledExceptionFilter(previousTopLevelExceptionFilter) != topLevelExceptionFilter) {
             CATCH_RUNTIME_ERROR("Could not restore previous top level exception filter");
         }
         previousTopLevelExceptionFilter = nullptr;

--- a/src/catch2/internal/catch_fatal_condition_handler.hpp
+++ b/src/catch2/internal/catch_fatal_condition_handler.hpp
@@ -32,7 +32,7 @@ namespace Catch {
         // Should be if-defed to work on current platform, can assume
         // engage-disengage 1:1 pairing.
         void engage_platform();
-        void disengage_platform();
+        void disengage_platform() noexcept;
     public:
         // Should also have platform-specific implementations as needed
         FatalConditionHandler();
@@ -44,7 +44,7 @@ namespace Catch {
             engage_platform();
         }
 
-        void disengage() {
+        void disengage() noexcept {
             assert(m_started && "Handler cannot be uninstalled without being installed first");
             m_started = false;
             disengage_platform();

--- a/tests/SelfTest/UsageTests/Misc.tests.cpp
+++ b/tests/SelfTest/UsageTests/Misc.tests.cpp
@@ -537,4 +537,16 @@ TEST_CASE("Validate SEH behavior - unhandled", "[.approvals][FatalConditionHandl
     // Validate that Catch2 framework correctly handles tests raising and not handling SEH exceptions.
     throw_no_catch();
 }
+
+static LONG CALLBACK dummyExceptionFilter(PEXCEPTION_POINTERS ExceptionInfo) {
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+TEST_CASE("Validate SEH behavior - no crash for stack unwinding", "[approvals][!throws][!shouldfail][FatalConditionHandler][CATCH_PLATFORM_WINDOWS]")
+{
+    // Trigger stack unwinding with SEH top-level filter changed and validate the test fails expectedly with no application crash
+    SetUnhandledExceptionFilter(dummyExceptionFilter);
+    throw 1;
+}
+
 #endif


### PR DESCRIPTION
## Description
`FatalConditionHandlerGuard` is used within `RunContext::invokeActiveTestCase()`.
The intent of this guard is to avoid binary crash without failed test being
reported.
Still in case FatalConditionHandlerGuard destructor being called during stack
unwinding AND finds unexpected top-level filter for SEH unhandled exception,
the binary may still crash. As result of such crash the original exception
details are being hidden.

As the Catch2 provides only `CATCH_CATCH_ANON` macro, with no access to
exception details by design, looks like the best way to handle issue is to:
 - state requirements explicitly by `noexcept` specifier
 - use `Catch::cerr()` to print out possible issue notification
