### PR TITLE
CAPTURE not variadic when disabled

### DIFF
--- a/include/catch.hpp
+++ b/include/catch.hpp
@@ -433,7 +433,7 @@ using Catch::Detail::Approx;
 #define INFO( msg ) (void)(0)
 #define UNSCOPED_INFO( msg ) (void)(0)
 #define WARN( msg ) (void)(0)
-#define CAPTURE( msg ) (void)(0)
+#define CAPTURE( ... ) (void)(0)
 
 #define TEST_CASE( ... )  INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
 #define TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))

--- a/projects/ExtraTests/X01-PrefixedMacros.cpp
+++ b/projects/ExtraTests/X01-PrefixedMacros.cpp
@@ -53,6 +53,7 @@ CATCH_TEST_CASE("PrefixedMacros") {
     CATCH_SECTION("some section") {
         int i = 1;
         CATCH_CAPTURE( i );
+        CATCH_CAPTURE( i, i + 1 );
         CATCH_DYNAMIC_SECTION("Dynamic section: " << i) {
             CATCH_FAIL_CHECK( "failure" );
         }

--- a/projects/ExtraTests/X02-DisabledMacros.cpp
+++ b/projects/ExtraTests/X02-DisabledMacros.cpp
@@ -26,6 +26,10 @@ foo f;
 
 // This test should not be run, because it won't be registered
 TEST_CASE( "Disabled Macros" ) {
+
+    CAPTURE( 1 );
+    CAPTURE( 1, "captured" );
+
     std::cout << "This should not happen\n";
     FAIL();
 }


### PR DESCRIPTION
This caused errors on CAPTURE(a,b) when CATCH_CONFIG_DISABLE
is set.

Closes: #2316