### PR TITLE
Fix name of with-main library in .pc file

### DIFF
--- a/CMake/catch2-with-main.pc.in
+++ b/CMake/catch2-with-main.pc.in
@@ -7,4 +7,4 @@ Description: A modern, C++-native test framework for C++14 and above (links in d
 Version: ${pkg_version}
 Requires: catch2 = ${pkg_version}
 Cflags: -I${includedir}
-Libs: -L${libdir} -lCatch2WithMain
+Libs: -L${libdir} -lCatch2Main


### PR DESCRIPTION

## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
`catch2-with-main.pc` has an incorrect library basename in it, which prevents linking when the .pc file is used. This PR fixes the library name in the .pc file.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
This PR fixes #2379.