### PR TITLE
Refactor MatchersRanges test utils

### DIFF
--- a/tests/SelfTest/Baselines/compact.sw.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.approved.txt
@@ -1967,47 +1967,47 @@ MatchersRanges.tests.cpp:<line number>: passed: data, AllMatch(SizeIs(5)) for: {
 MatchersRanges.tests.cpp:<line number>: passed: data, !AllMatch(Contains(0) && Contains(1)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } not all match ( contains element 0 and contains element 1 )
 MatchersRanges.tests.cpp:<line number>: passed: needs_adl, AllMatch( Predicate<int>( []( int elem ) { return elem < 6; } ) ) for: { 1, 2, 3, 4, 5 } all match matches undescribed predicate
 MatchersRanges.tests.cpp:<line number>: passed: mocked, allMatch for: { 1, 2, 3, 4, 5 } all match matches undescribed predicate
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[0] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[1] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[2] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[3] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[4] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[0] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[1] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[2] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[3] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[4] for: true
 MatchersRanges.tests.cpp:<line number>: passed: mocked, !allMatch for: { 1, 2, 3, 4, 5 } not all match matches undescribed predicate
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[0] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[1] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[2] for: true
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[3]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[4]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[0] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[1] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[2] for: true
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[3]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[4]) for: !false
 MatchersRanges.tests.cpp:<line number>: passed: data, AnyMatch(SizeIs(5)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } any match has size == 5
 MatchersRanges.tests.cpp:<line number>: passed: data, !AnyMatch(Contains(0) && Contains(10)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } not any match ( contains element 0 and contains element 10 )
 MatchersRanges.tests.cpp:<line number>: passed: needs_adl, AnyMatch( Predicate<int>( []( int elem ) { return elem < 3; } ) ) for: { 1, 2, 3, 4, 5 } any match matches undescribed predicate
 MatchersRanges.tests.cpp:<line number>: passed: mocked, !anyMatch for: { 1, 2, 3, 4, 5 } not any match matches undescribed predicate
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[0] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[1] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[2] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[3] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[4] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[0] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[1] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[2] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[3] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[4] for: true
 MatchersRanges.tests.cpp:<line number>: passed: mocked, anyMatch for: { 1, 2, 3, 4, 5 } any match matches undescribed predicate
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[0] for: true
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[1]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[2]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[3]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[4]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[0] for: true
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[1]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[2]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[3]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[4]) for: !false
 MatchersRanges.tests.cpp:<line number>: passed: data, NoneMatch(SizeIs(6)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } none match has size == 6
 MatchersRanges.tests.cpp:<line number>: passed: data, !NoneMatch(Contains(0) && Contains(1)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } not none match ( contains element 0 and contains element 1 )
 MatchersRanges.tests.cpp:<line number>: passed: needs_adl, NoneMatch( Predicate<int>( []( int elem ) { return elem > 6; } ) ) for: { 1, 2, 3, 4, 5 } none match matches undescribed predicate
 MatchersRanges.tests.cpp:<line number>: passed: mocked, noneMatch for: { 1, 2, 3, 4, 5 } none match matches undescribed predicate
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[0] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[1] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[2] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[3] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[4] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[0] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[1] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[2] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[3] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[4] for: true
 MatchersRanges.tests.cpp:<line number>: passed: mocked, !noneMatch for: { 1, 2, 3, 4, 5 } not none match matches undescribed predicate
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[0] for: true
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[1]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[2]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[3]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[4]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[0] for: true
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[1]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[2]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[3]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[4]) for: !false
 MatchersRanges.tests.cpp:<line number>: passed: empty_vec, SizeIs(0) for: {  } has size == 0
 MatchersRanges.tests.cpp:<line number>: passed: empty_vec, !SizeIs(2) for: {  } not has size == 2
 MatchersRanges.tests.cpp:<line number>: passed: empty_vec, SizeIs(Lt(2)) for: {  } size matches is less than 2

--- a/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
@@ -1960,47 +1960,47 @@ MatchersRanges.tests.cpp:<line number>: passed: data, AllMatch(SizeIs(5)) for: {
 MatchersRanges.tests.cpp:<line number>: passed: data, !AllMatch(Contains(0) && Contains(1)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } not all match ( contains element 0 and contains element 1 )
 MatchersRanges.tests.cpp:<line number>: passed: needs_adl, AllMatch( Predicate<int>( []( int elem ) { return elem < 6; } ) ) for: { 1, 2, 3, 4, 5 } all match matches undescribed predicate
 MatchersRanges.tests.cpp:<line number>: passed: mocked, allMatch for: { 1, 2, 3, 4, 5 } all match matches undescribed predicate
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[0] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[1] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[2] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[3] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[4] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[0] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[1] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[2] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[3] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[4] for: true
 MatchersRanges.tests.cpp:<line number>: passed: mocked, !allMatch for: { 1, 2, 3, 4, 5 } not all match matches undescribed predicate
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[0] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[1] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[2] for: true
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[3]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[4]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[0] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[1] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[2] for: true
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[3]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[4]) for: !false
 MatchersRanges.tests.cpp:<line number>: passed: data, AnyMatch(SizeIs(5)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } any match has size == 5
 MatchersRanges.tests.cpp:<line number>: passed: data, !AnyMatch(Contains(0) && Contains(10)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } not any match ( contains element 0 and contains element 10 )
 MatchersRanges.tests.cpp:<line number>: passed: needs_adl, AnyMatch( Predicate<int>( []( int elem ) { return elem < 3; } ) ) for: { 1, 2, 3, 4, 5 } any match matches undescribed predicate
 MatchersRanges.tests.cpp:<line number>: passed: mocked, !anyMatch for: { 1, 2, 3, 4, 5 } not any match matches undescribed predicate
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[0] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[1] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[2] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[3] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[4] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[0] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[1] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[2] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[3] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[4] for: true
 MatchersRanges.tests.cpp:<line number>: passed: mocked, anyMatch for: { 1, 2, 3, 4, 5 } any match matches undescribed predicate
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[0] for: true
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[1]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[2]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[3]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[4]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[0] for: true
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[1]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[2]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[3]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[4]) for: !false
 MatchersRanges.tests.cpp:<line number>: passed: data, NoneMatch(SizeIs(6)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } none match has size == 6
 MatchersRanges.tests.cpp:<line number>: passed: data, !NoneMatch(Contains(0) && Contains(1)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } not none match ( contains element 0 and contains element 1 )
 MatchersRanges.tests.cpp:<line number>: passed: needs_adl, NoneMatch( Predicate<int>( []( int elem ) { return elem > 6; } ) ) for: { 1, 2, 3, 4, 5 } none match matches undescribed predicate
 MatchersRanges.tests.cpp:<line number>: passed: mocked, noneMatch for: { 1, 2, 3, 4, 5 } none match matches undescribed predicate
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[0] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[1] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[2] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[3] for: true
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[4] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[0] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[1] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[2] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[3] for: true
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[4] for: true
 MatchersRanges.tests.cpp:<line number>: passed: mocked, !noneMatch for: { 1, 2, 3, 4, 5 } not none match matches undescribed predicate
-MatchersRanges.tests.cpp:<line number>: passed: mocked.derefed[0] for: true
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[1]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[2]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[3]) for: !false
-MatchersRanges.tests.cpp:<line number>: passed: !(mocked.derefed[4]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: mocked.m_derefed[0] for: true
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[1]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[2]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[3]) for: !false
+MatchersRanges.tests.cpp:<line number>: passed: !(mocked.m_derefed[4]) for: !false
 MatchersRanges.tests.cpp:<line number>: passed: empty_vec, SizeIs(0) for: {  } has size == 0
 MatchersRanges.tests.cpp:<line number>: passed: empty_vec, !SizeIs(2) for: {  } not has size == 2
 MatchersRanges.tests.cpp:<line number>: passed: empty_vec, SizeIs(Lt(2)) for: {  } size matches is less than 2

--- a/tests/SelfTest/Baselines/console.sw.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.approved.txt
@@ -13955,27 +13955,27 @@ with expansion:
   { 1, 2, 3, 4, 5 } all match matches undescribed predicate
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[0] )
+  REQUIRE( mocked.m_derefed[0] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[1] )
+  REQUIRE( mocked.m_derefed[1] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[2] )
+  REQUIRE( mocked.m_derefed[2] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[3] )
+  REQUIRE( mocked.m_derefed[3] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[4] )
+  REQUIRE( mocked.m_derefed[4] )
 with expansion:
   true
 
@@ -13993,27 +13993,27 @@ with expansion:
   { 1, 2, 3, 4, 5 } not all match matches undescribed predicate
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[0] )
+  REQUIRE( mocked.m_derefed[0] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[1] )
+  REQUIRE( mocked.m_derefed[1] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[2] )
+  REQUIRE( mocked.m_derefed[2] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[3] )
+  REQUIRE_FALSE( mocked.m_derefed[3] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[4] )
+  REQUIRE_FALSE( mocked.m_derefed[4] )
 with expansion:
   !false
 
@@ -14063,27 +14063,27 @@ with expansion:
   { 1, 2, 3, 4, 5 } not any match matches undescribed predicate
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[0] )
+  REQUIRE( mocked.m_derefed[0] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[1] )
+  REQUIRE( mocked.m_derefed[1] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[2] )
+  REQUIRE( mocked.m_derefed[2] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[3] )
+  REQUIRE( mocked.m_derefed[3] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[4] )
+  REQUIRE( mocked.m_derefed[4] )
 with expansion:
   true
 
@@ -14101,27 +14101,27 @@ with expansion:
   { 1, 2, 3, 4, 5 } any match matches undescribed predicate
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[0] )
+  REQUIRE( mocked.m_derefed[0] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[1] )
+  REQUIRE_FALSE( mocked.m_derefed[1] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[2] )
+  REQUIRE_FALSE( mocked.m_derefed[2] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[3] )
+  REQUIRE_FALSE( mocked.m_derefed[3] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[4] )
+  REQUIRE_FALSE( mocked.m_derefed[4] )
 with expansion:
   !false
 
@@ -14171,27 +14171,27 @@ with expansion:
   { 1, 2, 3, 4, 5 } none match matches undescribed predicate
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[0] )
+  REQUIRE( mocked.m_derefed[0] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[1] )
+  REQUIRE( mocked.m_derefed[1] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[2] )
+  REQUIRE( mocked.m_derefed[2] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[3] )
+  REQUIRE( mocked.m_derefed[3] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[4] )
+  REQUIRE( mocked.m_derefed[4] )
 with expansion:
   true
 
@@ -14209,27 +14209,27 @@ with expansion:
   { 1, 2, 3, 4, 5 } not none match matches undescribed predicate
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[0] )
+  REQUIRE( mocked.m_derefed[0] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[1] )
+  REQUIRE_FALSE( mocked.m_derefed[1] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[2] )
+  REQUIRE_FALSE( mocked.m_derefed[2] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[3] )
+  REQUIRE_FALSE( mocked.m_derefed[3] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[4] )
+  REQUIRE_FALSE( mocked.m_derefed[4] )
 with expansion:
   !false
 

--- a/tests/SelfTest/Baselines/console.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.multi.approved.txt
@@ -13948,27 +13948,27 @@ with expansion:
   { 1, 2, 3, 4, 5 } all match matches undescribed predicate
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[0] )
+  REQUIRE( mocked.m_derefed[0] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[1] )
+  REQUIRE( mocked.m_derefed[1] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[2] )
+  REQUIRE( mocked.m_derefed[2] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[3] )
+  REQUIRE( mocked.m_derefed[3] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[4] )
+  REQUIRE( mocked.m_derefed[4] )
 with expansion:
   true
 
@@ -13986,27 +13986,27 @@ with expansion:
   { 1, 2, 3, 4, 5 } not all match matches undescribed predicate
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[0] )
+  REQUIRE( mocked.m_derefed[0] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[1] )
+  REQUIRE( mocked.m_derefed[1] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[2] )
+  REQUIRE( mocked.m_derefed[2] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[3] )
+  REQUIRE_FALSE( mocked.m_derefed[3] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[4] )
+  REQUIRE_FALSE( mocked.m_derefed[4] )
 with expansion:
   !false
 
@@ -14056,27 +14056,27 @@ with expansion:
   { 1, 2, 3, 4, 5 } not any match matches undescribed predicate
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[0] )
+  REQUIRE( mocked.m_derefed[0] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[1] )
+  REQUIRE( mocked.m_derefed[1] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[2] )
+  REQUIRE( mocked.m_derefed[2] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[3] )
+  REQUIRE( mocked.m_derefed[3] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[4] )
+  REQUIRE( mocked.m_derefed[4] )
 with expansion:
   true
 
@@ -14094,27 +14094,27 @@ with expansion:
   { 1, 2, 3, 4, 5 } any match matches undescribed predicate
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[0] )
+  REQUIRE( mocked.m_derefed[0] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[1] )
+  REQUIRE_FALSE( mocked.m_derefed[1] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[2] )
+  REQUIRE_FALSE( mocked.m_derefed[2] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[3] )
+  REQUIRE_FALSE( mocked.m_derefed[3] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[4] )
+  REQUIRE_FALSE( mocked.m_derefed[4] )
 with expansion:
   !false
 
@@ -14164,27 +14164,27 @@ with expansion:
   { 1, 2, 3, 4, 5 } none match matches undescribed predicate
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[0] )
+  REQUIRE( mocked.m_derefed[0] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[1] )
+  REQUIRE( mocked.m_derefed[1] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[2] )
+  REQUIRE( mocked.m_derefed[2] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[3] )
+  REQUIRE( mocked.m_derefed[3] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[4] )
+  REQUIRE( mocked.m_derefed[4] )
 with expansion:
   true
 
@@ -14202,27 +14202,27 @@ with expansion:
   { 1, 2, 3, 4, 5 } not none match matches undescribed predicate
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE( mocked.derefed[0] )
+  REQUIRE( mocked.m_derefed[0] )
 with expansion:
   true
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[1] )
+  REQUIRE_FALSE( mocked.m_derefed[1] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[2] )
+  REQUIRE_FALSE( mocked.m_derefed[2] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[3] )
+  REQUIRE_FALSE( mocked.m_derefed[3] )
 with expansion:
   !false
 
 MatchersRanges.tests.cpp:<line number>: PASSED:
-  REQUIRE_FALSE( mocked.derefed[4] )
+  REQUIRE_FALSE( mocked.m_derefed[4] )
 with expansion:
   !false
 

--- a/tests/SelfTest/Baselines/tap.sw.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.approved.txt
@@ -3488,27 +3488,27 @@ ok {test-number} - needs_adl, AllMatch( Predicate<int>( []( int elem ) { return 
 # Usage of AllMatch range matcher
 ok {test-number} - mocked, allMatch for: { 1, 2, 3, 4, 5 } all match matches undescribed predicate
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[0] for: true
+ok {test-number} - mocked.m_derefed[0] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[1] for: true
+ok {test-number} - mocked.m_derefed[1] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[2] for: true
+ok {test-number} - mocked.m_derefed[2] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[3] for: true
+ok {test-number} - mocked.m_derefed[3] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[4] for: true
+ok {test-number} - mocked.m_derefed[4] for: true
 # Usage of AllMatch range matcher
 ok {test-number} - mocked, !allMatch for: { 1, 2, 3, 4, 5 } not all match matches undescribed predicate
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[0] for: true
+ok {test-number} - mocked.m_derefed[0] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[1] for: true
+ok {test-number} - mocked.m_derefed[1] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[2] for: true
+ok {test-number} - mocked.m_derefed[2] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - !(mocked.derefed[3]) for: !false
+ok {test-number} - !(mocked.m_derefed[3]) for: !false
 # Usage of AllMatch range matcher
-ok {test-number} - !(mocked.derefed[4]) for: !false
+ok {test-number} - !(mocked.m_derefed[4]) for: !false
 # Usage of AnyMatch range matcher
 ok {test-number} - data, AnyMatch(SizeIs(5)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } any match has size == 5
 # Usage of AnyMatch range matcher
@@ -3518,27 +3518,27 @@ ok {test-number} - needs_adl, AnyMatch( Predicate<int>( []( int elem ) { return 
 # Usage of AnyMatch range matcher
 ok {test-number} - mocked, !anyMatch for: { 1, 2, 3, 4, 5 } not any match matches undescribed predicate
 # Usage of AnyMatch range matcher
-ok {test-number} - mocked.derefed[0] for: true
+ok {test-number} - mocked.m_derefed[0] for: true
 # Usage of AnyMatch range matcher
-ok {test-number} - mocked.derefed[1] for: true
+ok {test-number} - mocked.m_derefed[1] for: true
 # Usage of AnyMatch range matcher
-ok {test-number} - mocked.derefed[2] for: true
+ok {test-number} - mocked.m_derefed[2] for: true
 # Usage of AnyMatch range matcher
-ok {test-number} - mocked.derefed[3] for: true
+ok {test-number} - mocked.m_derefed[3] for: true
 # Usage of AnyMatch range matcher
-ok {test-number} - mocked.derefed[4] for: true
+ok {test-number} - mocked.m_derefed[4] for: true
 # Usage of AnyMatch range matcher
 ok {test-number} - mocked, anyMatch for: { 1, 2, 3, 4, 5 } any match matches undescribed predicate
 # Usage of AnyMatch range matcher
-ok {test-number} - mocked.derefed[0] for: true
+ok {test-number} - mocked.m_derefed[0] for: true
 # Usage of AnyMatch range matcher
-ok {test-number} - !(mocked.derefed[1]) for: !false
+ok {test-number} - !(mocked.m_derefed[1]) for: !false
 # Usage of AnyMatch range matcher
-ok {test-number} - !(mocked.derefed[2]) for: !false
+ok {test-number} - !(mocked.m_derefed[2]) for: !false
 # Usage of AnyMatch range matcher
-ok {test-number} - !(mocked.derefed[3]) for: !false
+ok {test-number} - !(mocked.m_derefed[3]) for: !false
 # Usage of AnyMatch range matcher
-ok {test-number} - !(mocked.derefed[4]) for: !false
+ok {test-number} - !(mocked.m_derefed[4]) for: !false
 # Usage of NoneMatch range matcher
 ok {test-number} - data, NoneMatch(SizeIs(6)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } none match has size == 6
 # Usage of NoneMatch range matcher
@@ -3548,27 +3548,27 @@ ok {test-number} - needs_adl, NoneMatch( Predicate<int>( []( int elem ) { return
 # Usage of NoneMatch range matcher
 ok {test-number} - mocked, noneMatch for: { 1, 2, 3, 4, 5 } none match matches undescribed predicate
 # Usage of NoneMatch range matcher
-ok {test-number} - mocked.derefed[0] for: true
+ok {test-number} - mocked.m_derefed[0] for: true
 # Usage of NoneMatch range matcher
-ok {test-number} - mocked.derefed[1] for: true
+ok {test-number} - mocked.m_derefed[1] for: true
 # Usage of NoneMatch range matcher
-ok {test-number} - mocked.derefed[2] for: true
+ok {test-number} - mocked.m_derefed[2] for: true
 # Usage of NoneMatch range matcher
-ok {test-number} - mocked.derefed[3] for: true
+ok {test-number} - mocked.m_derefed[3] for: true
 # Usage of NoneMatch range matcher
-ok {test-number} - mocked.derefed[4] for: true
+ok {test-number} - mocked.m_derefed[4] for: true
 # Usage of NoneMatch range matcher
 ok {test-number} - mocked, !noneMatch for: { 1, 2, 3, 4, 5 } not none match matches undescribed predicate
 # Usage of NoneMatch range matcher
-ok {test-number} - mocked.derefed[0] for: true
+ok {test-number} - mocked.m_derefed[0] for: true
 # Usage of NoneMatch range matcher
-ok {test-number} - !(mocked.derefed[1]) for: !false
+ok {test-number} - !(mocked.m_derefed[1]) for: !false
 # Usage of NoneMatch range matcher
-ok {test-number} - !(mocked.derefed[2]) for: !false
+ok {test-number} - !(mocked.m_derefed[2]) for: !false
 # Usage of NoneMatch range matcher
-ok {test-number} - !(mocked.derefed[3]) for: !false
+ok {test-number} - !(mocked.m_derefed[3]) for: !false
 # Usage of NoneMatch range matcher
-ok {test-number} - !(mocked.derefed[4]) for: !false
+ok {test-number} - !(mocked.m_derefed[4]) for: !false
 # Usage of the SizeIs range matcher
 ok {test-number} - empty_vec, SizeIs(0) for: {  } has size == 0
 # Usage of the SizeIs range matcher

--- a/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
@@ -3481,27 +3481,27 @@ ok {test-number} - needs_adl, AllMatch( Predicate<int>( []( int elem ) { return 
 # Usage of AllMatch range matcher
 ok {test-number} - mocked, allMatch for: { 1, 2, 3, 4, 5 } all match matches undescribed predicate
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[0] for: true
+ok {test-number} - mocked.m_derefed[0] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[1] for: true
+ok {test-number} - mocked.m_derefed[1] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[2] for: true
+ok {test-number} - mocked.m_derefed[2] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[3] for: true
+ok {test-number} - mocked.m_derefed[3] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[4] for: true
+ok {test-number} - mocked.m_derefed[4] for: true
 # Usage of AllMatch range matcher
 ok {test-number} - mocked, !allMatch for: { 1, 2, 3, 4, 5 } not all match matches undescribed predicate
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[0] for: true
+ok {test-number} - mocked.m_derefed[0] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[1] for: true
+ok {test-number} - mocked.m_derefed[1] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - mocked.derefed[2] for: true
+ok {test-number} - mocked.m_derefed[2] for: true
 # Usage of AllMatch range matcher
-ok {test-number} - !(mocked.derefed[3]) for: !false
+ok {test-number} - !(mocked.m_derefed[3]) for: !false
 # Usage of AllMatch range matcher
-ok {test-number} - !(mocked.derefed[4]) for: !false
+ok {test-number} - !(mocked.m_derefed[4]) for: !false
 # Usage of AnyMatch range matcher
 ok {test-number} - data, AnyMatch(SizeIs(5)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } any match has size == 5
 # Usage of AnyMatch range matcher
@@ -3511,27 +3511,27 @@ ok {test-number} - needs_adl, AnyMatch( Predicate<int>( []( int elem ) { return 
 # Usage of AnyMatch range matcher
 ok {test-number} - mocked, !anyMatch for: { 1, 2, 3, 4, 5 } not any match matches undescribed predicate
 # Usage of AnyMatch range matcher
-ok {test-number} - mocked.derefed[0] for: true
+ok {test-number} - mocked.m_derefed[0] for: true
 # Usage of AnyMatch range matcher
-ok {test-number} - mocked.derefed[1] for: true
+ok {test-number} - mocked.m_derefed[1] for: true
 # Usage of AnyMatch range matcher
-ok {test-number} - mocked.derefed[2] for: true
+ok {test-number} - mocked.m_derefed[2] for: true
 # Usage of AnyMatch range matcher
-ok {test-number} - mocked.derefed[3] for: true
+ok {test-number} - mocked.m_derefed[3] for: true
 # Usage of AnyMatch range matcher
-ok {test-number} - mocked.derefed[4] for: true
+ok {test-number} - mocked.m_derefed[4] for: true
 # Usage of AnyMatch range matcher
 ok {test-number} - mocked, anyMatch for: { 1, 2, 3, 4, 5 } any match matches undescribed predicate
 # Usage of AnyMatch range matcher
-ok {test-number} - mocked.derefed[0] for: true
+ok {test-number} - mocked.m_derefed[0] for: true
 # Usage of AnyMatch range matcher
-ok {test-number} - !(mocked.derefed[1]) for: !false
+ok {test-number} - !(mocked.m_derefed[1]) for: !false
 # Usage of AnyMatch range matcher
-ok {test-number} - !(mocked.derefed[2]) for: !false
+ok {test-number} - !(mocked.m_derefed[2]) for: !false
 # Usage of AnyMatch range matcher
-ok {test-number} - !(mocked.derefed[3]) for: !false
+ok {test-number} - !(mocked.m_derefed[3]) for: !false
 # Usage of AnyMatch range matcher
-ok {test-number} - !(mocked.derefed[4]) for: !false
+ok {test-number} - !(mocked.m_derefed[4]) for: !false
 # Usage of NoneMatch range matcher
 ok {test-number} - data, NoneMatch(SizeIs(6)) for: { { 0, 1, 2, 3, 5 }, { 4, -3, -2, 5, 0 }, { 0, 0, 0, 5, 0 }, { 0, -5, 0, 5, 0 }, { 1, 0, 0, -1, 5 } } none match has size == 6
 # Usage of NoneMatch range matcher
@@ -3541,27 +3541,27 @@ ok {test-number} - needs_adl, NoneMatch( Predicate<int>( []( int elem ) { return
 # Usage of NoneMatch range matcher
 ok {test-number} - mocked, noneMatch for: { 1, 2, 3, 4, 5 } none match matches undescribed predicate
 # Usage of NoneMatch range matcher
-ok {test-number} - mocked.derefed[0] for: true
+ok {test-number} - mocked.m_derefed[0] for: true
 # Usage of NoneMatch range matcher
-ok {test-number} - mocked.derefed[1] for: true
+ok {test-number} - mocked.m_derefed[1] for: true
 # Usage of NoneMatch range matcher
-ok {test-number} - mocked.derefed[2] for: true
+ok {test-number} - mocked.m_derefed[2] for: true
 # Usage of NoneMatch range matcher
-ok {test-number} - mocked.derefed[3] for: true
+ok {test-number} - mocked.m_derefed[3] for: true
 # Usage of NoneMatch range matcher
-ok {test-number} - mocked.derefed[4] for: true
+ok {test-number} - mocked.m_derefed[4] for: true
 # Usage of NoneMatch range matcher
 ok {test-number} - mocked, !noneMatch for: { 1, 2, 3, 4, 5 } not none match matches undescribed predicate
 # Usage of NoneMatch range matcher
-ok {test-number} - mocked.derefed[0] for: true
+ok {test-number} - mocked.m_derefed[0] for: true
 # Usage of NoneMatch range matcher
-ok {test-number} - !(mocked.derefed[1]) for: !false
+ok {test-number} - !(mocked.m_derefed[1]) for: !false
 # Usage of NoneMatch range matcher
-ok {test-number} - !(mocked.derefed[2]) for: !false
+ok {test-number} - !(mocked.m_derefed[2]) for: !false
 # Usage of NoneMatch range matcher
-ok {test-number} - !(mocked.derefed[3]) for: !false
+ok {test-number} - !(mocked.m_derefed[3]) for: !false
 # Usage of NoneMatch range matcher
-ok {test-number} - !(mocked.derefed[4]) for: !false
+ok {test-number} - !(mocked.m_derefed[4]) for: !false
 # Usage of the SizeIs range matcher
 ok {test-number} - empty_vec, SizeIs(0) for: {  } has size == 0
 # Usage of the SizeIs range matcher

--- a/tests/SelfTest/Baselines/xml.sw.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.approved.txt
@@ -16378,7 +16378,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[0]
+            mocked.m_derefed[0]
           </Original>
           <Expanded>
             true
@@ -16386,7 +16386,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[1]
+            mocked.m_derefed[1]
           </Original>
           <Expanded>
             true
@@ -16394,7 +16394,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[2]
+            mocked.m_derefed[2]
           </Original>
           <Expanded>
             true
@@ -16402,7 +16402,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[3]
+            mocked.m_derefed[3]
           </Original>
           <Expanded>
             true
@@ -16410,7 +16410,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[4]
+            mocked.m_derefed[4]
           </Original>
           <Expanded>
             true
@@ -16432,7 +16432,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[0]
+            mocked.m_derefed[0]
           </Original>
           <Expanded>
             true
@@ -16440,7 +16440,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[1]
+            mocked.m_derefed[1]
           </Original>
           <Expanded>
             true
@@ -16448,7 +16448,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[2]
+            mocked.m_derefed[2]
           </Original>
           <Expanded>
             true
@@ -16456,7 +16456,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[3])
+            !(mocked.m_derefed[3])
           </Original>
           <Expanded>
             !false
@@ -16464,7 +16464,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[4])
+            !(mocked.m_derefed[4])
           </Original>
           <Expanded>
             !false
@@ -16519,7 +16519,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[0]
+            mocked.m_derefed[0]
           </Original>
           <Expanded>
             true
@@ -16527,7 +16527,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[1]
+            mocked.m_derefed[1]
           </Original>
           <Expanded>
             true
@@ -16535,7 +16535,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[2]
+            mocked.m_derefed[2]
           </Original>
           <Expanded>
             true
@@ -16543,7 +16543,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[3]
+            mocked.m_derefed[3]
           </Original>
           <Expanded>
             true
@@ -16551,7 +16551,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[4]
+            mocked.m_derefed[4]
           </Original>
           <Expanded>
             true
@@ -16573,7 +16573,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[0]
+            mocked.m_derefed[0]
           </Original>
           <Expanded>
             true
@@ -16581,7 +16581,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[1])
+            !(mocked.m_derefed[1])
           </Original>
           <Expanded>
             !false
@@ -16589,7 +16589,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[2])
+            !(mocked.m_derefed[2])
           </Original>
           <Expanded>
             !false
@@ -16597,7 +16597,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[3])
+            !(mocked.m_derefed[3])
           </Original>
           <Expanded>
             !false
@@ -16605,7 +16605,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[4])
+            !(mocked.m_derefed[4])
           </Original>
           <Expanded>
             !false
@@ -16660,7 +16660,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[0]
+            mocked.m_derefed[0]
           </Original>
           <Expanded>
             true
@@ -16668,7 +16668,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[1]
+            mocked.m_derefed[1]
           </Original>
           <Expanded>
             true
@@ -16676,7 +16676,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[2]
+            mocked.m_derefed[2]
           </Original>
           <Expanded>
             true
@@ -16684,7 +16684,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[3]
+            mocked.m_derefed[3]
           </Original>
           <Expanded>
             true
@@ -16692,7 +16692,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[4]
+            mocked.m_derefed[4]
           </Original>
           <Expanded>
             true
@@ -16714,7 +16714,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[0]
+            mocked.m_derefed[0]
           </Original>
           <Expanded>
             true
@@ -16722,7 +16722,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[1])
+            !(mocked.m_derefed[1])
           </Original>
           <Expanded>
             !false
@@ -16730,7 +16730,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[2])
+            !(mocked.m_derefed[2])
           </Original>
           <Expanded>
             !false
@@ -16738,7 +16738,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[3])
+            !(mocked.m_derefed[3])
           </Original>
           <Expanded>
             !false
@@ -16746,7 +16746,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[4])
+            !(mocked.m_derefed[4])
           </Original>
           <Expanded>
             !false

--- a/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
@@ -16378,7 +16378,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[0]
+            mocked.m_derefed[0]
           </Original>
           <Expanded>
             true
@@ -16386,7 +16386,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[1]
+            mocked.m_derefed[1]
           </Original>
           <Expanded>
             true
@@ -16394,7 +16394,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[2]
+            mocked.m_derefed[2]
           </Original>
           <Expanded>
             true
@@ -16402,7 +16402,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[3]
+            mocked.m_derefed[3]
           </Original>
           <Expanded>
             true
@@ -16410,7 +16410,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[4]
+            mocked.m_derefed[4]
           </Original>
           <Expanded>
             true
@@ -16432,7 +16432,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[0]
+            mocked.m_derefed[0]
           </Original>
           <Expanded>
             true
@@ -16440,7 +16440,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[1]
+            mocked.m_derefed[1]
           </Original>
           <Expanded>
             true
@@ -16448,7 +16448,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[2]
+            mocked.m_derefed[2]
           </Original>
           <Expanded>
             true
@@ -16456,7 +16456,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[3])
+            !(mocked.m_derefed[3])
           </Original>
           <Expanded>
             !false
@@ -16464,7 +16464,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[4])
+            !(mocked.m_derefed[4])
           </Original>
           <Expanded>
             !false
@@ -16519,7 +16519,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[0]
+            mocked.m_derefed[0]
           </Original>
           <Expanded>
             true
@@ -16527,7 +16527,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[1]
+            mocked.m_derefed[1]
           </Original>
           <Expanded>
             true
@@ -16535,7 +16535,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[2]
+            mocked.m_derefed[2]
           </Original>
           <Expanded>
             true
@@ -16543,7 +16543,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[3]
+            mocked.m_derefed[3]
           </Original>
           <Expanded>
             true
@@ -16551,7 +16551,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[4]
+            mocked.m_derefed[4]
           </Original>
           <Expanded>
             true
@@ -16573,7 +16573,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[0]
+            mocked.m_derefed[0]
           </Original>
           <Expanded>
             true
@@ -16581,7 +16581,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[1])
+            !(mocked.m_derefed[1])
           </Original>
           <Expanded>
             !false
@@ -16589,7 +16589,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[2])
+            !(mocked.m_derefed[2])
           </Original>
           <Expanded>
             !false
@@ -16597,7 +16597,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[3])
+            !(mocked.m_derefed[3])
           </Original>
           <Expanded>
             !false
@@ -16605,7 +16605,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[4])
+            !(mocked.m_derefed[4])
           </Original>
           <Expanded>
             !false
@@ -16660,7 +16660,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[0]
+            mocked.m_derefed[0]
           </Original>
           <Expanded>
             true
@@ -16668,7 +16668,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[1]
+            mocked.m_derefed[1]
           </Original>
           <Expanded>
             true
@@ -16676,7 +16676,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[2]
+            mocked.m_derefed[2]
           </Original>
           <Expanded>
             true
@@ -16684,7 +16684,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[3]
+            mocked.m_derefed[3]
           </Original>
           <Expanded>
             true
@@ -16692,7 +16692,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[4]
+            mocked.m_derefed[4]
           </Original>
           <Expanded>
             true
@@ -16714,7 +16714,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            mocked.derefed[0]
+            mocked.m_derefed[0]
           </Original>
           <Expanded>
             true
@@ -16722,7 +16722,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[1])
+            !(mocked.m_derefed[1])
           </Original>
           <Expanded>
             !false
@@ -16730,7 +16730,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[2])
+            !(mocked.m_derefed[2])
           </Original>
           <Expanded>
             !false
@@ -16738,7 +16738,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[3])
+            !(mocked.m_derefed[3])
           </Original>
           <Expanded>
             !false
@@ -16746,7 +16746,7 @@ There is no extra whitespace here
         </Expression>
         <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
           <Original>
-            !(mocked.derefed[4])
+            !(mocked.m_derefed[4])
           </Original>
           <Expanded>
             !false

--- a/tests/SelfTest/UsageTests/MatchersRanges.tests.cpp
+++ b/tests/SelfTest/UsageTests/MatchersRanges.tests.cpp
@@ -115,10 +115,9 @@ template <typename T> struct with_mocked_iterator_access {
     std::vector<T> m_elements;
 
     // use plain arrays to have nicer printouts with CHECK(...)
-    mutable std::unique_ptr<bool[]> m_touched;
     mutable std::unique_ptr<bool[]> m_derefed;
 
-    // We want to check which elements were touched when iterating, so
+    // We want to check which elements were dereferenced when iterating, so
     // we can check whether iterator-using code traverses range correctly
     template <bool is_const> class basic_iterator {
         template <typename U>
@@ -147,10 +146,6 @@ template <typename T> struct with_mocked_iterator_access {
         }
         basic_iterator& operator++() {
             ++m_origin_idx;
-            assert( m_origin_idx < m_origin->m_elements.size() + 1 && "Outside of valid alloc" );
-            if ( m_origin_idx < m_origin->m_elements.size() ) {
-                m_origin->m_touched[m_origin_idx] = true;
-            }
             return *this;
         }
         basic_iterator operator++( int ) {
@@ -174,7 +169,6 @@ template <typename T> struct with_mocked_iterator_access {
 
     with_mocked_iterator_access( std::initializer_list<T> init ):
         m_elements( init ),
-        m_touched( std::make_unique<bool[]>( m_elements.size() ) ),
         m_derefed( std::make_unique<bool[]>( m_elements.size() ) ) {}
 
     const_iterator begin() const { return { this, 0 }; }

--- a/tests/SelfTest/UsageTests/MatchersRanges.tests.cpp
+++ b/tests/SelfTest/UsageTests/MatchersRanges.tests.cpp
@@ -24,9 +24,8 @@
 namespace {
 
 template <typename Arg, typename... Args>
-std::array<Arg, sizeof...( Args ) + 1> make_array( Arg&& arg,
-                                                    Args&&... args ) {
-    return std::array<Arg, sizeof...( Args ) + 1>{
+auto make_array( Arg&& arg, Args&&... args ) {
+    return std::array<std::decay_t<Arg>, sizeof...( Args ) + 1>{
         { CATCH_FORWARD( arg ), CATCH_FORWARD( args )... } };
 }
 
@@ -39,7 +38,7 @@ namespace unrelated {
         using const_iterator = typename std::array<T, N>::const_iterator;
 
         template <typename... Args>
-        needs_ADL_begin(Args&&... args) : m_elements{make_array(CATCH_FORWARD(args)...)} {}
+        needs_ADL_begin(Args&&... args) : m_elements(make_array(CATCH_FORWARD(args)...)) {}
 
         const_iterator Begin() const { return m_elements.begin(); }
         const_iterator End() const { return m_elements.end(); }
@@ -104,7 +103,7 @@ class has_different_begin_end_types {
 public:
     template <typename... Args>
     explicit has_different_begin_end_types( Args&&... args ):
-        m_elements{ make_array( CATCH_FORWARD( args )... ) } {}
+        m_elements( make_array( CATCH_FORWARD( args )... ) ) {}
 
     iterator begin() const {
         return { m_elements.data(), m_elements.data() + m_elements.size() };
@@ -180,7 +179,7 @@ template <typename T, std::size_t N> struct with_mocked_iterator_access {
 
     template <typename... Args>
     with_mocked_iterator_access( Args&&... args ):
-        m_elements{ make_array( CATCH_FORWARD( args )... ) } {}
+        m_elements( make_array( CATCH_FORWARD( args )... ) ) {}
 
     const_iterator begin() const { return { this, 0 }; }
     const_iterator end() const { return { this, N }; }

--- a/tests/SelfTest/UsageTests/MatchersRanges.tests.cpp
+++ b/tests/SelfTest/UsageTests/MatchersRanges.tests.cpp
@@ -18,18 +18,31 @@
 #include <cmath>
 #include <list>
 #include <map>
+#include <type_traits>
 #include <vector>
 
 namespace {
-namespace unrelated {
-    class needs_ADL_begin {
-        std::array<int, 5> elements{ {1, 2, 3, 4, 5} };
-    public:
-        using iterator = std::array<int, 5>::iterator;
-        using const_iterator = std::array<int, 5>::const_iterator;
 
-        const_iterator Begin() const { return elements.begin(); }
-        const_iterator End() const { return elements.end(); }
+template <typename Arg, typename... Args>
+std::array<Arg, sizeof...( Args ) + 1> make_array( Arg&& arg,
+                                                    Args&&... args ) {
+    return std::array<Arg, sizeof...( Args ) + 1>{
+        { CATCH_FORWARD( arg ), CATCH_FORWARD( args )... } };
+}
+
+namespace unrelated {
+    template <typename T, std::size_t N>
+    class needs_ADL_begin {
+        std::array<T, N> m_elements;
+    public:
+        using iterator = typename std::array<T, N>::iterator;
+        using const_iterator = typename std::array<T, N>::const_iterator;
+
+        template <typename... Args>
+        needs_ADL_begin(Args&&... args) : m_elements{make_array(CATCH_FORWARD(args)...)} {}
+
+        const_iterator Begin() const { return m_elements.begin(); }
+        const_iterator End() const { return m_elements.end(); }
 
         friend const_iterator begin(needs_ADL_begin const& lhs) {
             return lhs.Begin();
@@ -45,22 +58,23 @@ namespace unrelated {
 #  pragma clang diagnostic ignored "-Wunused-function"
 #endif
 
+template <typename T, std::size_t N>
 class has_different_begin_end_types {
-    std::array<int, 5> elements{ {1, 2, 3, 4, 5} };
+    std::array<T, N> m_elements;
 
     // Different type for the "end" iterator
     struct iterator_end {};
     // Just a fake forward iterator, that only compares to a different
     // type (so we can test two-type ranges).
     struct iterator {
-        int const* start;
-        int const* end;
+        T const* start;
+        T const* end;
 
         using iterator_category = std::forward_iterator_tag;
         using difference_type = std::ptrdiff_t;
-        using value_type = int;
-        using reference = int const&;
-        using pointer = int const*;
+        using value_type = T;
+        using reference = T const&;
+        using pointer = T const*;
 
 
         friend bool operator==( iterator iter, iterator_end ) {
@@ -88,8 +102,12 @@ class has_different_begin_end_types {
 
 
 public:
+    template <typename... Args>
+    explicit has_different_begin_end_types( Args&&... args ):
+        m_elements{ make_array( CATCH_FORWARD( args )... ) } {}
+
     iterator begin() const {
-        return { elements.data(), elements.data() + elements.size() };
+        return { m_elements.data(), m_elements.data() + m_elements.size() };
     }
 
     iterator_end end() const {
@@ -101,80 +119,93 @@ public:
 #  pragma clang diagnostic pop
 #endif
 
-
-struct with_mocked_iterator_access {
-    static constexpr size_t data_size = 5;
-    std::array<int, data_size> elements{ {1, 2, 3, 4, 5} };
-    std::array<bool, data_size> touched{};
-    std::array<bool, data_size> derefed{};
+template <typename T, std::size_t N> struct with_mocked_iterator_access {
+    std::array<T, N> m_elements;
+    mutable std::array<bool, N> m_touched{};
+    mutable std::array<bool, N> m_derefed{};
 
     // We want to check which elements were touched when iterating, so
     // we can check whether iterator-using code traverses range correctly
-    struct iterator {
-        with_mocked_iterator_access* m_origin;
+    template <bool is_const> class basic_iterator {
+        template <typename U>
+        using constify_t = std::conditional_t<is_const, std::add_const_t<U>, U>;
+
+        constify_t<with_mocked_iterator_access>* m_origin;
         size_t m_origin_idx;
 
+    public:
         using iterator_category = std::forward_iterator_tag;
         using difference_type = std::ptrdiff_t;
-        using value_type = int;
-        using reference = int const&;
-        using pointer = int const*;
+        using value_type = constify_t<T>;
+        using reference = value_type&;
+        using pointer = value_type*;
 
-        friend bool operator==(iterator lhs, iterator rhs) {
-            return lhs.m_origin == rhs.m_origin
-                && lhs.m_origin_idx == rhs.m_origin_idx;
+        basic_iterator( constify_t<with_mocked_iterator_access>* origin,
+                        std::size_t origin_idx ):
+            m_origin{ origin }, m_origin_idx{ origin_idx } {}
+
+        friend bool operator==( basic_iterator lhs, basic_iterator rhs ) {
+            return lhs.m_origin == rhs.m_origin &&
+                   lhs.m_origin_idx == rhs.m_origin_idx;
         }
-        friend bool operator!=(iterator lhs, iterator rhs) {
-            return !(lhs == rhs);
+        friend bool operator!=( basic_iterator lhs, basic_iterator rhs ) {
+            return !( lhs == rhs );
         }
-        iterator& operator++() {
+        basic_iterator& operator++() {
             ++m_origin_idx;
-            assert(m_origin_idx < data_size + 1 && "Outside of valid alloc");
-            if (m_origin_idx < data_size) {
-                m_origin->touched[m_origin_idx] = true;
+            assert( m_origin_idx < N + 1 && "Outside of valid alloc" );
+            if ( m_origin_idx < N ) {
+                m_origin->m_touched[m_origin_idx] = true;
             }
             return *this;
         }
-        iterator operator++(int) {
-            auto tmp(*this);
-            ++(*this);
+        basic_iterator operator++( int ) {
+            auto tmp( *this );
+            ++( *this );
             return tmp;
         }
         reference operator*() const {
-            assert(m_origin_idx < data_size && "Attempted to deref invalid position");
-            m_origin->derefed[m_origin_idx] = true;
-            return m_origin->elements[m_origin_idx];
+            assert( m_origin_idx < N && "Attempted to deref invalid position" );
+            m_origin->m_derefed[m_origin_idx] = true;
+            return m_origin->m_elements[m_origin_idx];
         }
         pointer operator->() const {
-            assert(m_origin_idx < data_size && "Attempted to deref invalid position");
-            return &m_origin->elements[m_origin_idx];
+            assert( m_origin_idx < N && "Attempted to deref invalid position" );
+            return &m_origin->m_elements[m_origin_idx];
         }
-
     };
 
-    iterator begin() const {
-        // Const-cast away to avoid overcomplicating the iterators
-        // We should actually fix this over time
-        return { const_cast<with_mocked_iterator_access*>(this), 0 };
-    }
-    iterator end() const {
-        return { const_cast<with_mocked_iterator_access*>(this), data_size };
-    }
+    using iterator = basic_iterator<false>;
+    using const_iterator = basic_iterator<true>;
 
+    template <typename... Args>
+    with_mocked_iterator_access( Args&&... args ):
+        m_elements{ make_array( CATCH_FORWARD( args )... ) } {}
+
+    const_iterator begin() const { return { this, 0 }; }
+    const_iterator end() const { return { this, N }; }
+    iterator begin() { return { this, 0 }; }
+    iterator end() { return { this, N }; }
 };
 
 } // end anon namespace
 
 namespace Catch {
-    template <>
-    struct StringMaker<with_mocked_iterator_access> {
-        static std::string convert(with_mocked_iterator_access const& access) {
+    // make sure with_mocked_iterator_access is not considered a range by Catch,
+    // so that below StringMaker is used instead of the default one for ranges
+    template <typename T, std::size_t N>
+    struct is_range<with_mocked_iterator_access<T, N>> : std::false_type {};
+
+    template <typename T, std::size_t N>
+    struct StringMaker<with_mocked_iterator_access<T, N>> {
+        static std::string
+        convert( with_mocked_iterator_access<T, N> const& access ) {
             // We have to avoid the type's iterators, because we check
             // their use in tests
-            return ::Catch::Detail::stringify(access.elements);
+            return ::Catch::Detail::stringify( access.m_elements );
         }
     };
-}
+} // namespace Catch
 
 struct MoveOnlyTestElement {
     int num = 0;
@@ -233,7 +264,7 @@ TEST_CASE("Basic use of the Contains range matcher", "[matchers][templated][cont
     }
 
     SECTION("Can handle type that requires ADL-found free function begin and end") {
-        unrelated::needs_ADL_begin in;
+        unrelated::needs_ADL_begin<int, 5> in{1, 2, 3, 4, 5};
 
         REQUIRE_THAT(in,  Contains(1));
         REQUIRE_THAT(in, !Contains(8));
@@ -383,35 +414,35 @@ TEST_CASE("Usage of AllMatch range matcher", "[matchers][templated][quantifiers]
     }
 
     SECTION("Type requires ADL found begin and end") {
-        unrelated::needs_ADL_begin needs_adl;
+        unrelated::needs_ADL_begin<int, 5> needs_adl{ 1, 2, 3, 4, 5 };
         REQUIRE_THAT( needs_adl, AllMatch( Predicate<int>( []( int elem ) {
                           return elem < 6;
                       } ) ) );
     }
 
     SECTION("Shortcircuiting") {
-        with_mocked_iterator_access mocked;
+        with_mocked_iterator_access<int, 5> mocked{ 1, 2, 3, 4, 5 };
         SECTION("All are read") {
             auto allMatch = AllMatch(Predicate<int>([](int elem) {
                 return elem < 10;
             }));
             REQUIRE_THAT(mocked, allMatch);
-            REQUIRE(mocked.derefed[0]);
-            REQUIRE(mocked.derefed[1]);
-            REQUIRE(mocked.derefed[2]);
-            REQUIRE(mocked.derefed[3]);
-            REQUIRE(mocked.derefed[4]);
+            REQUIRE(mocked.m_derefed[0]);
+            REQUIRE(mocked.m_derefed[1]);
+            REQUIRE(mocked.m_derefed[2]);
+            REQUIRE(mocked.m_derefed[3]);
+            REQUIRE(mocked.m_derefed[4]);
         }
         SECTION("Short-circuited") {
             auto allMatch = AllMatch(Predicate<int>([](int elem) {
                 return elem < 3;
             }));
             REQUIRE_THAT(mocked, !allMatch);
-            REQUIRE(mocked.derefed[0]);
-            REQUIRE(mocked.derefed[1]);
-            REQUIRE(mocked.derefed[2]);
-            REQUIRE_FALSE(mocked.derefed[3]);
-            REQUIRE_FALSE(mocked.derefed[4]);
+            REQUIRE(mocked.m_derefed[0]);
+            REQUIRE(mocked.m_derefed[1]);
+            REQUIRE(mocked.m_derefed[2]);
+            REQUIRE_FALSE(mocked.m_derefed[3]);
+            REQUIRE_FALSE(mocked.m_derefed[4]);
         }
     }
 }
@@ -436,34 +467,34 @@ TEST_CASE("Usage of AnyMatch range matcher", "[matchers][templated][quantifiers]
         REQUIRE_THAT(data, !AnyMatch(Contains(0) && Contains(10)));
     }
 
-    SECTION("Type requires ADL found begin and end") {
-        unrelated::needs_ADL_begin needs_adl;
+    SECTION( "Type requires ADL found begin and end" ) {
+        unrelated::needs_ADL_begin<int, 5> needs_adl{ 1, 2, 3, 4, 5 };
         REQUIRE_THAT( needs_adl, AnyMatch( Predicate<int>( []( int elem ) {
                           return elem < 3;
                       } ) ) );
     }
 
     SECTION("Shortcircuiting") {
-        with_mocked_iterator_access mocked;
+        with_mocked_iterator_access<int, 5> mocked{ 1, 2, 3, 4, 5 };
         SECTION("All are read") {
             auto anyMatch = AnyMatch(
                 Predicate<int>( []( int elem ) { return elem > 10; } ) );
             REQUIRE_THAT( mocked, !anyMatch );
-            REQUIRE( mocked.derefed[0] );
-            REQUIRE( mocked.derefed[1] );
-            REQUIRE( mocked.derefed[2] );
-            REQUIRE( mocked.derefed[3] );
-            REQUIRE( mocked.derefed[4] );
+            REQUIRE( mocked.m_derefed[0] );
+            REQUIRE( mocked.m_derefed[1] );
+            REQUIRE( mocked.m_derefed[2] );
+            REQUIRE( mocked.m_derefed[3] );
+            REQUIRE( mocked.m_derefed[4] );
         }
         SECTION("Short-circuited") {
             auto anyMatch = AnyMatch(
                 Predicate<int>( []( int elem ) { return elem < 3; } ) );
             REQUIRE_THAT( mocked, anyMatch );
-            REQUIRE( mocked.derefed[0] );
-            REQUIRE_FALSE( mocked.derefed[1] );
-            REQUIRE_FALSE( mocked.derefed[2] );
-            REQUIRE_FALSE( mocked.derefed[3] );
-            REQUIRE_FALSE( mocked.derefed[4] );
+            REQUIRE( mocked.m_derefed[0] );
+            REQUIRE_FALSE( mocked.m_derefed[1] );
+            REQUIRE_FALSE( mocked.m_derefed[2] );
+            REQUIRE_FALSE( mocked.m_derefed[3] );
+            REQUIRE_FALSE( mocked.m_derefed[4] );
         }
     }
 }
@@ -489,33 +520,33 @@ TEST_CASE("Usage of NoneMatch range matcher", "[matchers][templated][quantifiers
     }
 
     SECTION( "Type requires ADL found begin and end" ) {
-        unrelated::needs_ADL_begin needs_adl;
+        unrelated::needs_ADL_begin<int, 5> needs_adl{ 1, 2, 3, 4, 5 };
         REQUIRE_THAT( needs_adl, NoneMatch( Predicate<int>( []( int elem ) {
                           return elem > 6;
                       } ) ) );
     }
 
     SECTION("Shortcircuiting") {
-        with_mocked_iterator_access mocked;
+        with_mocked_iterator_access<int, 5> mocked{ 1, 2, 3, 4, 5 };
         SECTION("All are read") {
             auto noneMatch = NoneMatch(
                 Predicate<int>([](int elem) { return elem > 10; }));
             REQUIRE_THAT(mocked, noneMatch);
-            REQUIRE(mocked.derefed[0]);
-            REQUIRE(mocked.derefed[1]);
-            REQUIRE(mocked.derefed[2]);
-            REQUIRE(mocked.derefed[3]);
-            REQUIRE(mocked.derefed[4]);
+            REQUIRE(mocked.m_derefed[0]);
+            REQUIRE(mocked.m_derefed[1]);
+            REQUIRE(mocked.m_derefed[2]);
+            REQUIRE(mocked.m_derefed[3]);
+            REQUIRE(mocked.m_derefed[4]);
         }
         SECTION("Short-circuited") {
             auto noneMatch = NoneMatch(
                 Predicate<int>([](int elem) { return elem < 3; }));
             REQUIRE_THAT(mocked, !noneMatch);
-            REQUIRE(mocked.derefed[0]);
-            REQUIRE_FALSE(mocked.derefed[1]);
-            REQUIRE_FALSE(mocked.derefed[2]);
-            REQUIRE_FALSE(mocked.derefed[3]);
-            REQUIRE_FALSE(mocked.derefed[4]);
+            REQUIRE(mocked.m_derefed[0]);
+            REQUIRE_FALSE(mocked.m_derefed[1]);
+            REQUIRE_FALSE(mocked.m_derefed[2]);
+            REQUIRE_FALSE(mocked.m_derefed[3]);
+            REQUIRE_FALSE(mocked.m_derefed[4]);
         }
     }
 }
@@ -533,7 +564,7 @@ TEST_CASE( "The quantifier range matchers support types with different types ret
 
     using Catch::Matchers::Predicate;
 
-    has_different_begin_end_types diff_types;
+    has_different_begin_end_types<int, 5> diff_types{1, 2, 3, 4, 5};
     REQUIRE_THAT( diff_types, !AllMatch( Predicate<int>( []( int elem ) {
                       return elem < 3;
                   } ) ) );


### PR DESCRIPTION
## Description
Refactor test util classes in MatchersRanges.tests. This is preparatory work for #2319.

- do not hard-code element type and content of mock containers
- prefix members with `m_`
- add const and non-const iterators to `with_mocked_iterator_access`
