### PR TITLE
Get Bazel build working again

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,7 +4,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 
 expand_template(
-    name = "catch_user_config.hpp",
+    name = "catch_user_config_hpp",
     out = "catch2/catch_user_config.hpp",
     substitutions = {
         "#cmakedefine CATCH_CONFIG_ANDROID_LOGWRITE": "",
@@ -51,6 +51,7 @@ expand_template(
         "#cmakedefine CATCH_CONFIG_NO_ANDROID_LOGWRITE": "",
         "@CATCH_CONFIG_DEFAULT_REPORTER@": "console",
         "@CATCH_CONFIG_CONSOLE_WIDTH@": "80",
+        "#cmakedefine CATCH_CONFIG_NO_COLOUR_WIN32": "",
     },
     template = "src/catch2/catch_user_config.hpp.in",
 )
@@ -58,9 +59,9 @@ expand_template(
 # Static library, without main.
 cc_library(
     name = "catch2",
-    hdrs = glob(["src/catch2/**/*.hpp"]) + ["catch_user_config.hpp"],
+    hdrs = glob(["src/catch2/**/*.hpp"])+ [":catch_user_config_hpp"],
     srcs = glob(["src/catch2/**/*.cpp"],
-                exclude=[ "src/catch2/internal/catch_main.cpp"]),
+                exclude=[ "src/catch2/internal/catch_main.cpp"]) ,
     visibility = ["//visibility:public"],
     linkstatic = True,
     includes = ["src/"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,11 +1,14 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "bazel_skylib",
+    sha256 = "d847b08d6702d2779e9eb399b54ff8920fa7521dc45e3e53572d1d8907767de7",
+    strip_prefix = "bazel-skylib-2a87d4a62af886fb320883aba102255aba87275e",
     urls = [
-        "https://github.com/Vertexwahn/bazel-skylib/archive/b0cd4bbd4bf4af76c380e1f8fafdbe3964161aff.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/archive/2a87d4a62af886fb320883aba102255aba87275e.tar.gz",
     ],
-    strip_prefix = "bazel-skylib-b0cd4bbd4bf4af76c380e1f8fafdbe3964161aff",
-    sha256 = "e57f3ff541c65678f3c2b344c73945531838e86ea0be71c63eea862ab43e792b",
 )
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
 bazel_skylib_workspace()

--- a/src/catch2/catch_config.cpp
+++ b/src/catch2/catch_config.cpp
@@ -6,7 +6,7 @@
 
 // SPDX-License-Identifier: BSL-1.0
 #include <catch2/catch_config.hpp>
-#include <catch2/catch_user_config.hpp>
+#include "catch2/catch_user_config.hpp"
 #include <catch2/internal/catch_enforce.hpp>
 #include <catch2/internal/catch_stream.hpp>
 #include <catch2/internal/catch_stringref.hpp>

--- a/src/catch2/catch_config.hpp
+++ b/src/catch2/catch_config.hpp
@@ -9,7 +9,7 @@
 #define CATCH_CONFIG_HPP_INCLUDED
 
 #include <catch2/catch_test_spec.hpp>
-#include <catch2/catch_user_config.hpp>
+#include "catch2/catch_user_config.hpp"
 #include <catch2/interfaces/catch_interfaces_config.hpp>
 #include <catch2/internal/catch_unique_ptr.hpp>
 #include <catch2/internal/catch_optional.hpp>

--- a/src/catch2/catch_test_macros.hpp
+++ b/src/catch2/catch_test_macros.hpp
@@ -10,7 +10,7 @@
 
 #include <catch2/internal/catch_test_macro_impl.hpp>
 #include <catch2/catch_message.hpp>
-#include <catch2/catch_user_config.hpp>
+#include "catch2/catch_user_config.hpp"
 #include <catch2/internal/catch_preprocessor.hpp>
 #include <catch2/internal/catch_section.hpp>
 #include <catch2/internal/catch_test_registry.hpp>

--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -25,7 +25,7 @@
 // can be combined, en-mass, with the _NO_ forms later.
 
 #include <catch2/internal/catch_platform.hpp>
-#include <catch2/catch_user_config.hpp>
+#include "catch2/catch_user_config.hpp"
 
 #ifdef __cplusplus
 

--- a/src/catch2/internal/catch_config_android_logwrite.hpp
+++ b/src/catch2/internal/catch_config_android_logwrite.hpp
@@ -17,7 +17,7 @@
 #ifndef CATCH_CONFIG_ANDROID_LOGWRITE_HPP_INCLUDED
 #define CATCH_CONFIG_ANDROID_LOGWRITE_HPP_INCLUDED
 
-#include <catch2/catch_user_config.hpp>
+#include "catch2/catch_user_config.hpp"
 
 #if defined(__ANDROID__)
 #    define CATCH_INTERNAL_CONFIG_ANDROID_LOGWRITE

--- a/src/catch2/internal/catch_run_context.cpp
+++ b/src/catch2/internal/catch_run_context.cpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: BSL-1.0
 #include <catch2/internal/catch_run_context.hpp>
 
-#include <catch2/catch_user_config.hpp>
+#include "catch2/catch_user_config.hpp"
 #include <catch2/interfaces/catch_interfaces_generatortracker.hpp>
 #include <catch2/interfaces/catch_interfaces_config.hpp>
 #include <catch2/internal/catch_compiler_capabilities.hpp>

--- a/src/catch2/internal/catch_test_macro_impl.hpp
+++ b/src/catch2/internal/catch_test_macro_impl.hpp
@@ -8,7 +8,7 @@
 #ifndef CATCH_TEST_MACRO_IMPL_HPP_INCLUDED
 #define CATCH_TEST_MACRO_IMPL_HPP_INCLUDED
 
-#include <catch2/catch_user_config.hpp>
+#include "catch2/catch_user_config.hpp"
 #include <catch2/internal/catch_assertion_handler.hpp>
 #include <catch2/interfaces/catch_interfaces_capture.hpp>
 #include <catch2/internal/catch_stringref.hpp>

--- a/tests/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
@@ -11,7 +11,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <catch2/internal/catch_test_spec_parser.hpp>
-#include <catch2/catch_user_config.hpp>
+#include "catch2/catch_user_config.hpp"
 #include <catch2/catch_test_case_info.hpp>
 #include <catch2/internal/catch_commandline.hpp>
 #include <catch2/generators/catch_generators.hpp>


### PR DESCRIPTION
This PR enables the Bazel build again.

Including generated headers using `<...>` instead of `"..."` does unfortunately not work using Bazel.

I am not  100% sure but I think including via `"..."` should be preferred in cpp files since this guarantees that not a system installed catch header file is included. I would suggest to change everything to `"..."`
