### PR TITLE
ObjectStorage: port away from std::aligned_storage

### DIFF
--- a/include/internal/benchmark/catch_constructor.hpp
+++ b/include/internal/benchmark/catch_constructor.hpp
@@ -19,8 +19,6 @@ namespace Catch {
             template <typename T, bool Destruct>
             struct ObjectStorage
             {
-                using TStorage = typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type;
-
                 ObjectStorage() : data() {}
 
                 ObjectStorage(const ObjectStorage& other)
@@ -64,7 +62,7 @@ namespace Catch {
                 }
 
 
-                TStorage data;
+                struct { alignas(T) unsigned char data[sizeof(T)]; }  data;
             };
         }
 


### PR DESCRIPTION
It's deprecated in C++23. Just use alignas on a char array, wrapped in
a struct to avoid decaying to char*, which is the canonical
implementation of aligned_storage:
https://en.cppreference.com/w/cpp/types/aligned_storage#Possible_implementation

Fixes https://github.com/catchorg/Catch2/issues/2419

Catch3 is not affected.