### PR TITLE
Avoid "warning C4702: unreachable code" with MSVC

### DIFF
--- a/src/catch2/internal/catch_console_colour.cpp
+++ b/src/catch2/internal/catch_console_colour.cpp
@@ -252,11 +252,12 @@ namespace Catch {
             } else {
                 return Detail::make_unique<NoColourImpl>( stream );
             }
-#endif
+#else
             if ( ANSIColourImpl::useImplementationForStream( *stream ) ) {
                 return Detail::make_unique<ANSIColourImpl>( stream );
             }
             return Detail::make_unique<NoColourImpl>( stream );
+#endif
         }
 
         CATCH_ERROR( "Could not create colour impl for selection " << static_cast<int>(implSelection) );


### PR DESCRIPTION
Small fix to avoid "warning C4702: unreachable code" on MSVC which can with /W4 can lead to error and compilation failure.