### PR TITLE
Fix crash when running with --list-listeners and no registered listeners

### DIFF
--- a/src/catch2/reporters/catch_reporter_combined_tu.cpp
+++ b/src/catch2/reporters/catch_reporter_combined_tu.cpp
@@ -154,6 +154,12 @@ namespace Catch {
 
     void defaultListListeners( std::ostream& out,
                                std::vector<ListenerDescription> const& descriptions ) {
+        out << "Registered listeners:\n";
+
+        if(descriptions.empty()) {
+            return;
+        }
+
         const auto maxNameLen =
             std::max_element( descriptions.begin(),
                               descriptions.end(),
@@ -163,7 +169,6 @@ namespace Catch {
                               } )
                 ->name.size();
 
-        out << "Registered listeners:\n";
         for ( auto const& desc : descriptions ) {
             out << TextFlow::Column( static_cast<std::string>( desc.name ) +
                                      ':' )

--- a/tests/ExtraTests/CMakeLists.txt
+++ b/tests/ExtraTests/CMakeLists.txt
@@ -459,7 +459,10 @@ add_test(
   NAME TestSpecs::OverrideFailureWithEmptySpec
   COMMAND $<TARGET_FILE:NoTests> --allow-running-no-tests
 )
-
+add_test(
+  NAME List::Listeners::WorksWithoutRegisteredListeners
+  COMMAND $<TARGET_FILE:NoTests> --list-listeners
+)
 set( EXTRA_TEST_BINARIES
     PrefixedMacros
     DisabledMacros


### PR DESCRIPTION
## Description
Running with `--listeners` without registered listeners caused Catch2 programs to crash.

```
$ ./a.out --list-listeners
zsh: segmentation fault (core dumped)  ./a.out --list-listeners
```
The reason was due to dereferencing an iterator pointing past the end of a vector when the vector is empty. 