### PR TITLE
Compatility fixes for GCC5

### DIFF
--- a/src/catch2/internal/catch_reporter_spec_parser.cpp
+++ b/src/catch2/internal/catch_reporter_spec_parser.cpp
@@ -126,7 +126,7 @@ namespace Catch {
                     return {};
                 }
 
-                auto ret = kvPairs.emplace( kv.key, kv.value );
+                auto ret = kvPairs.emplace( std::string(kv.key), std::string(kv.value) );
                 if ( !ret.second ) {
                     // Duplicated key. We might want to handle this differently,
                     // e.g. by overwriting the existing value?

--- a/src/catch2/reporters/catch_reporter_automake.hpp
+++ b/src/catch2/reporters/catch_reporter_automake.hpp
@@ -18,6 +18,8 @@ namespace Catch {
 
     class AutomakeReporter final : public StreamingReporterBase {
     public:
+        // GCC5 compat: we cannot use inherited constructor, because it
+        //              doesn't implement backport of P0136
         AutomakeReporter(ReporterConfig&& _config):
             StreamingReporterBase(CATCH_MOVE(_config))
         {}

--- a/src/catch2/reporters/catch_reporter_automake.hpp
+++ b/src/catch2/reporters/catch_reporter_automake.hpp
@@ -8,7 +8,9 @@
 #ifndef CATCH_REPORTER_AUTOMAKE_HPP_INCLUDED
 #define CATCH_REPORTER_AUTOMAKE_HPP_INCLUDED
 
+#include <catch2/interfaces/catch_interfaces_reporter.hpp>
 #include <catch2/reporters/catch_reporter_streaming_base.hpp>
+#include <catch2/internal/catch_move_and_forward.hpp>
 
 #include <string>
 
@@ -16,7 +18,9 @@ namespace Catch {
 
     class AutomakeReporter final : public StreamingReporterBase {
     public:
-        using StreamingReporterBase::StreamingReporterBase;
+        AutomakeReporter(ReporterConfig&& _config):
+            StreamingReporterBase(CATCH_MOVE(_config))
+        {}
         ~AutomakeReporter() override;
 
         static std::string getDescription() {

--- a/src/catch2/reporters/catch_reporter_cumulative_base.hpp
+++ b/src/catch2/reporters/catch_reporter_cumulative_base.hpp
@@ -8,7 +8,9 @@
 #ifndef CATCH_REPORTER_CUMULATIVE_BASE_HPP_INCLUDED
 #define CATCH_REPORTER_CUMULATIVE_BASE_HPP_INCLUDED
 
+#include <catch2/interfaces/catch_interfaces_reporter.hpp>
 #include <catch2/reporters/catch_reporter_common_base.hpp>
+#include <catch2/internal/catch_move_and_forward.hpp>
 #include <catch2/internal/catch_unique_ptr.hpp>
 #include <catch2/internal/catch_optional.hpp>
 
@@ -88,7 +90,9 @@ namespace Catch {
         using TestCaseNode = Node<TestCaseStats, SectionNode>;
         using TestRunNode = Node<TestRunStats, TestCaseNode>;
 
-        using ReporterBase::ReporterBase;
+        CumulativeReporterBase(ReporterConfig&& _config):
+            ReporterBase(CATCH_MOVE(_config))
+        {}
         ~CumulativeReporterBase() override;
 
         void benchmarkPreparing( StringRef ) override {}

--- a/src/catch2/reporters/catch_reporter_cumulative_base.hpp
+++ b/src/catch2/reporters/catch_reporter_cumulative_base.hpp
@@ -90,6 +90,8 @@ namespace Catch {
         using TestCaseNode = Node<TestCaseStats, SectionNode>;
         using TestRunNode = Node<TestRunStats, TestCaseNode>;
 
+        // GCC5 compat: we cannot use inherited constructor, because it
+        //              doesn't implement backport of P0136
         CumulativeReporterBase(ReporterConfig&& _config):
             ReporterBase(CATCH_MOVE(_config))
         {}

--- a/src/catch2/reporters/catch_reporter_streaming_base.hpp
+++ b/src/catch2/reporters/catch_reporter_streaming_base.hpp
@@ -8,7 +8,9 @@
 #ifndef CATCH_REPORTER_STREAMING_BASE_HPP_INCLUDED
 #define CATCH_REPORTER_STREAMING_BASE_HPP_INCLUDED
 
+#include <catch2/interfaces/catch_interfaces_reporter.hpp>
 #include <catch2/reporters/catch_reporter_common_base.hpp>
+#include <catch2/internal/catch_move_and_forward.hpp>
 
 #include <vector>
 
@@ -16,7 +18,9 @@ namespace Catch {
 
     class StreamingReporterBase : public ReporterBase {
     public:
-        using ReporterBase::ReporterBase;
+        StreamingReporterBase(ReporterConfig&& _config):
+            ReporterBase(CATCH_MOVE(_config))
+        {}
         ~StreamingReporterBase() override;
 
         void benchmarkPreparing( StringRef ) override {}

--- a/src/catch2/reporters/catch_reporter_streaming_base.hpp
+++ b/src/catch2/reporters/catch_reporter_streaming_base.hpp
@@ -18,6 +18,8 @@ namespace Catch {
 
     class StreamingReporterBase : public ReporterBase {
     public:
+        // GCC5 compat: we cannot use inherited constructor, because it
+        //              doesn't implement backport of P0136
         StreamingReporterBase(ReporterConfig&& _config):
             ReporterBase(CATCH_MOVE(_config))
         {}


### PR DESCRIPTION
I use GCC5 in my projects as the oldest GCC compiler to be C++14 conformant. Of course there are a few small issues, but I believe it is a good "oldest" target for C++14.

This PR contains a few changes to fix Catch2v3 compilation with GCC5, which has been broken since v3.0.0-preview5:
- One that seems linked to some C++17 change to inherited constructors, backported as a DR all the way back to C++11.
- One that's apparently linked to changes to `std::pair` constructor though I did not explore further to understand where it originally came from.