### PR TITLE
Fix implicit long to double conversion

### DIFF
--- a/src/catch2/benchmark/detail/catch_stats.hpp
+++ b/src/catch2/benchmark/detail/catch_stats.hpp
@@ -115,7 +115,7 @@ namespace Catch {
                 double z1 = normal_quantile((1. - confidence_level) / 2.);
 
                 auto cumn = [n]( double x ) -> long {
-                    return std::lround( normal_cdf( x ) * n );
+                    return std::lround( normal_cdf( x ) * static_cast<double>(n) );
                 };
                 auto a = [bias, accel](double b) { return bias + b / (1. - accel * b); };
                 double b1 = bias + z1;


### PR DESCRIPTION
## Description

The existing code raised a compiler warning when compiled with `-Wimplicit-int-float-conversion` using clang.
