### PR TITLE
Added Cytopia to opensource-users.md

### DIFF
--- a/docs/opensource-users.md
+++ b/docs/opensource-users.md
@@ -118,6 +118,9 @@ A high available cloud native micro-service application management platform impl
 ### [ArangoDB](https://github.com/arangodb/arangodb)
 ArangoDB is a native multi-model database with flexible data models for documents, graphs, and key-values.
 
+### [Cytopia](https://github.com/CytopiaTeam/Cytopia)
+Cytopia is a free, open source retro pixel-art city building game with a big focus on mods. It utilizes a custom isometric rendering engine based on SDL2.
+
 ### [d-SEAMS](https://github.com/d-SEAMS/seams-core)
 Open source molecular dynamics simulation structure analysis suite of tools in modern C++.
 


### PR DESCRIPTION
## Description
I added the game Cytopia to the list of open source projects that use Catch2. I am a maintainer for that code and can confirm we use Catch2, since I've used it to write unittests for the game many times.

## GitHub Issues
n/a