### PR TITLE
Change Bazel XML support to depend upon BAZEL_TEST

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,10 +98,12 @@ is equivalent with the out-of-the-box experience.
 
 
 ## Bazel support
-When `CATCH_CONFIG_BAZEL_SUPPORT` is defined, Catch2 will register a `JUnit`
-reporter writing to a path pointed by `XML_OUTPUT_FILE` provided by Bazel.
+When `CATCH_CONFIG_BAZEL_SUPPORT` is defined or when `BAZEL_TEST=1` (which is set by the Bazel inside of a test environment), 
+Catch2 will register a `JUnit` reporter writing to a path pointed by `XML_OUTPUT_FILE` provided by Bazel.
 
 > `CATCH_CONFIG_BAZEL_SUPPORT` was [introduced](https://github.com/catchorg/Catch2/pull/2399) in Catch2 3.0.1.
+
+> `CATCH_CONFIG_BAZEL_SUPPORT` was [deprecated](https://github.com/catchorg/Catch2/pull/2459) in Catch2 X.Y.Z.
 
 ## C++11 toggles
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -17,6 +17,15 @@ as it can be replaced by `Catch.cmake` that provides the function
 command line interface instead of parsing C++ code with regular expressions.
 
 
+### `CATCH_CONFIG_BAZEL_SUPPORT`
+
+Catch2 supports writing the Bazel JUnit XML output file when it is aware
+that is within a bazel testing environment. Originally there was no way
+to accurately probe the environment for this information so the flag
+`CATCH_CONFIG_BAZEL_SUPPORT` was added. This now deprecated. Bazel has now had a change
+where it will export `BAZEL_TEST=1` for purposes like the above. Catch2
+will now instead inspect the environment instead of relying on build configuration.
+
 ---
 
 [Home](Readme.md#top)

--- a/tests/ExtraTests/CMakeLists.txt
+++ b/tests/ExtraTests/CMakeLists.txt
@@ -137,6 +137,18 @@ set_tests_properties(CATCH_CONFIG_BAZEL_REPORTER-1
     LABELS "uses-python"
 )
 
+# We must now test this works without the build flag.
+add_executable( BazelReporterNoCatchConfig ${TESTS_DIR}/X30-BazelReporter.cpp )
+target_link_libraries(BazelReporterNoCatchConfig Catch2WithMain)
+add_test(NAME NO_CATCH_CONFIG_BAZEL_REPORTER-1
+  COMMAND
+  "${PYTHON_EXECUTABLE}" "${CATCH_DIR}/tests/TestScripts/testBazelReporter.py" $<TARGET_FILE:BazelReporterNoCatchConfig> "${CMAKE_CURRENT_BINARY_DIR}"
+)
+set_tests_properties(NO_CATCH_CONFIG_BAZEL_REPORTER-1
+  PROPERTIES
+    LABELS "uses-python"
+    ENVIRONMENT "BAZEL_TEST=1"
+)
 
 # The default handler on Windows leads to the just-in-time debugger firing,
 # which makes this test unsuitable for CI and headless runs, as it opens


### PR DESCRIPTION
Relating to the original issue https://github.com/catchorg/Catch2/pull/2399 here;

Bazel has now been updated to have a cleaner environment variable for catch2 to know when to output to JUnit XML. 
Seen here: https://github.com/bazelbuild/bazel/pull/15393

Instead of relying on `CATCH_CONFIG_BAZEL_SUPPORT` we can now inspect the environment variable `BAZEL_TEST`. This is better as it allows for 'native' detection of both JUnit XML and Bazel. Originally not done as the detection mechanism was using too generic of a environment name.
