### PR TITLE
Fix package recipe for CMake Integration

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -51,6 +51,7 @@ conan_basic_setup()'''.format(line_to_replace, self.install_folder.replace("\\",
         self.cpp_info.components["catch2base"].names["cmake_find_package_multi"] = "Catch2"
         self.cpp_info.components["catch2base"].names["pkg_config"] = "Catch2"
         self.cpp_info.components["catch2base"].libs = ["Catch2" + lib_suffix]
+        self.cpp_info.components["catch2base"].builddirs.append("lib/cmake/Catch2")
         # Catch2WithMain
         self.cpp_info.components["catch2main"].names["cmake_find_package"] = "Catch2WithMain"
         self.cpp_info.components["catch2main"].names["cmake_find_package_multi"] = "Catch2WithMain"


### PR DESCRIPTION
## Description

Updated the Conan package recipe to add `lib/cmake/Catch2` to `cpp_info.components["catch2base"].builddirs`. This ensures that Conan properly copies the `extras/Catch.cmake` and `extras/CatchAddTests.cmake` to the package, which allows [CMake intregration](https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md#automatic-test-registration) to work.

Tested locally with `conan create . 3.0.1@local/test` and verified it works on Mac OS 11.6 and Windows 10.

## GitHub Issues

Closes #2455 
