### PR TITLE
CMake: Exclude empty header dirs from install

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,6 +263,12 @@ set(REPORTER_SOURCES
 )
 set(REPORTER_FILES ${REPORTER_HEADERS} ${REPORTER_SOURCES})
 
+set(ALL_HEADERS
+  ${BENCHMARK_HEADERS}
+  ${INTERNAL_HEADERS}
+  ${REPORTER_HEADERS}
+)
+
 # Fixme: STATIC because for dynamic, we would need to handle visibility
 # and I don't want to do the annotations right now
 add_library(Catch2 STATIC
@@ -342,7 +348,6 @@ if (NOT_SUBPROJECT)
         ${CMAKE_INSTALL_LIBDIR}
     )
 
-
     install(
       EXPORT
         Catch2Targets
@@ -351,17 +356,87 @@ if (NOT_SUBPROJECT)
       DESTINATION
         ${CATCH_CMAKE_CONFIG_DESTINATION}
     )
+
     # Install the headers
-    install(
-      DIRECTORY
-        "${SOURCES_DIR}"
-        "${CMAKE_BINARY_DIR}/generated-includes/catch2" # Also install the generated header
-      DESTINATION
-        "${CMAKE_INSTALL_INCLUDEDIR}"
-      FILES_MATCHING
-        PATTERN "*.hpp"
-    )
-endif()
+    if (CMAKE_VERSION VERSION_LESS "3.20")
+        # Just glob for files in the tree (note: creates empty directories)
+        install(
+          DIRECTORY
+            "${SOURCES_DIR}"
+            "${CMAKE_BINARY_DIR}/generated-includes/catch2" # Also install the generated header
+          DESTINATION
+            "${CMAKE_INSTALL_INCLUDEDIR}"
+          FILES_MATCHING
+          PATTERN "*.hpp"
+        )
+    else()
+        # Construct per-directory install commands from lists of header files
+        set(_header_targets )
+        foreach(_h ${ALL_HEADERS})
+            cmake_path(
+              RELATIVE_PATH _h
+              BASE_DIRECTORY "${CATCH_DIR}"
+              OUTPUT_VARIABLE _h_rel)
+
+            message(DEBUG "Processing ${_h_rel}...")
+
+            # Skip any "*.hpp.in" files listed with the headers
+            string(REGEX MATCH ".*\.in$" _infile "${_h}")
+            if (_infile)
+                message(DEBUG "Skipping non-header file ${_h_rel}!\n")
+                continue()
+            endif()
+
+            # Figure out if this header is in the source or build tree
+            cmake_path(SET _build_prefix "${CMAKE_BINARY_DIR}/generated-includes")
+            cmake_path(IS_PREFIX _build_prefix "${_h}" NORMALIZE _in_build)
+            cmake_path(IS_PREFIX CATCH_DIR "${_h}" NORMALIZE _in_source)
+
+            # Set _h_dir to the normalized parent path for the header
+            cmake_path(GET _h PARENT_PATH _h_dir)
+            cmake_path(NORMAL_PATH _h_dir)
+
+            # Make that normalized path relative, starting from "catch2/..."
+            if (_in_build)
+                cmake_path(RELATIVE_PATH _h_dir
+                  BASE_DIRECTORY "${_build_prefix}")
+            elseif (_in_source)
+                cmake_path(RELATIVE_PATH _h_dir
+                  BASE_DIRECTORY "${CATCH_DIR}/src")
+            else()
+                message(WARNING "\nNo install path for: ${_h}")
+                continue()
+            endif()
+
+            # Create a target for each header install directory,
+            # named "_headers_<relative_include_path>".
+            # That target will have two properties:
+            #   DESTINATION_DIR = "relative/include/path"
+            #   HEADER_FILES = a list of the headers to install into that dir
+            string(REPLACE "/" "_" _tgt_name "${_h_dir}")
+            string(PREPEND _tgt_name "_headers_")
+            if (NOT TARGET ${_tgt_name})
+                message(DEBUG "  Creating header install target ${_tgt_name}")
+                list(APPEND _header_targets "${_tgt_name}")
+                add_custom_target(${_tgt_name})
+                set_property(TARGET ${_tgt_name} PROPERTY
+                  DESTINATION_DIR "${_h_dir}")
+            endif()
+            message(DEBUG "  Will install ${_h_rel}\n     to <include_dir>/${_h_dir}")
+            set_property(TARGET ${_tgt_name} APPEND PROPERTY
+              HEADER_FILES "${_h}")
+        endforeach()
+
+        # Create an install(FILES...) command for each custom target
+        foreach(_tgt ${_header_targets})
+            set(_dest_path $<TARGET_PROPERTY:${_tgt},DESTINATION_DIR>)
+            install(FILES
+              $<TARGET_PROPERTY:${_tgt},HEADER_FILES>
+              DESTINATION
+                "${CMAKE_INSTALL_INCLUDEDIR}/${_dest_path}")
+        endforeach()
+    endif()  # CMAKE_VERSION VERSION_LESS
+endif()  # NOT_SUBPROJECT
 
 # Some tests require a full recompilation of Catch2 lib with different
 # compilation flags. They can link against this target to recompile all


### PR DESCRIPTION
## Revised description

Replacing the first version of this PR (which had the weakness, as @horenmar correctly noted, that it would cause any header files placed in the excluded dirs to be left out of the install), this version... well, at least it isn't susceptible to **that**.

You may **HATE** this, and I'd completely understand, but the only thing I can say is that I've tested it heavily, it works perfectly, and the resulting install is identical to the old one _except_ for the lack of empty directories.

There is one new caveat. Because it makes heavy use of the `cmake_path()` command, it only works in CMake 3.20+. (It does a version check, and the old globbed install command is still there and will be used if the CMake version is too old.)

With CMake 3.20+, though, it takes a completely different approach.

There are ample comments in the (added) source, so I won't talk it up any more as it's easier to just read the code. There are also `message(DEBUG)` commands scattered throughout, for now, so if you run `cmake` with the `--log-level=DEBUG` flag you can watch it process every header file, which might help build confidence in the logic.

Logic which, again, **I'm** very confident in, myself... but I also recognize that it's an awfully complex method of installing a bunch of header files, and I would completely accept a reaction along the lines of, "Oh, hell no!" :rofl: 

## GitHub Issues
Fixes #2457
