### PR TITLE
test-fixtures.md: Line-wrap code examples

### DIFF
--- a/docs/test-fixtures.md
+++ b/docs/test-fixtures.md
@@ -61,8 +61,8 @@ struct Template_Fixture {
 
 TEMPLATE_TEST_CASE_METHOD(Template_Fixture,
                           "A TEMPLATE_TEST_CASE_METHOD based test run that succeeds",
-                          "[class][template]", int, float, double)
-{
+                          "[class][template]",
+                          int, float, double) {
     REQUIRE( Template_Fixture<TestType>::m_a == 1 );
 }
 
@@ -82,8 +82,9 @@ struct Foo_class {
 
 TEMPLATE_PRODUCT_TEST_CASE_METHOD(Template_Template_Fixture,
                                   "A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test succeeds",
-                                  "[class][template]", (Foo_class, std::vector), int)
-{
+                                  "[class][template]",
+                                  (Foo_class, std::vector),
+                                  int) {
     REQUIRE( Template_Template_Fixture<TestType>::m_a.size() == 0 );
 }
 ```
@@ -110,8 +111,9 @@ struct Nttp_Fixture{
 TEMPLATE_TEST_CASE_METHOD_SIG(
     Nttp_Fixture,
     "A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds",
-    "[class][template][nttp]",((int V), V), 1, 3, 6)
-{
+    "[class][template][nttp]",
+    ((int V), V),
+    1, 3, 6) {
     REQUIRE(Nttp_Fixture<V>::value > 0);
 }
 
@@ -131,8 +133,9 @@ TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG(
     Template_Fixture_2, 
     "A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds", 
     "[class][template][product][nttp]", 
-    ((typename T, size_t S), T, S),(std::array, Template_Foo_2), ((int,2), (float,6)))
-{
+    ((typename T, size_t S), T, S),
+    (std::array, Template_Foo_2),
+    ((int,2), (float,6))) {
     REQUIRE(Template_Fixture_2<TestType>{}.m_a.size() >= 2);
 }
 ```
@@ -148,8 +151,8 @@ Example:
 using MyTypes = std::tuple<int, char, double>;
 TEMPLATE_LIST_TEST_CASE_METHOD(Template_Fixture,
                                "Template test case method with test types specified inside std::tuple",
-                               "[class][template][list]", MyTypes)
-{
+                               "[class][template][list]",
+                               MyTypes) {
     REQUIRE( Template_Fixture<TestType>::m_a == 1 );
 }
 ```

--- a/docs/test-fixtures.md
+++ b/docs/test-fixtures.md
@@ -59,7 +59,10 @@ struct Template_Fixture {
     T m_a;
 };
 
-TEMPLATE_TEST_CASE_METHOD(Template_Fixture,"A TEMPLATE_TEST_CASE_METHOD based test run that succeeds", "[class][template]", int, float, double) {
+TEMPLATE_TEST_CASE_METHOD(Template_Fixture,
+                          "A TEMPLATE_TEST_CASE_METHOD based test run that succeeds",
+                          "[class][template]", int, float, double)
+{
     REQUIRE( Template_Fixture<TestType>::m_a == 1 );
 }
 
@@ -77,7 +80,10 @@ struct Foo_class {
     }
 };
 
-TEMPLATE_PRODUCT_TEST_CASE_METHOD(Template_Template_Fixture, "A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test succeeds", "[class][template]", (Foo_class, std::vector), int) {
+TEMPLATE_PRODUCT_TEST_CASE_METHOD(Template_Template_Fixture,
+                                  "A TEMPLATE_PRODUCT_TEST_CASE_METHOD based test succeeds",
+                                  "[class][template]", (Foo_class, std::vector), int)
+{
     REQUIRE( Template_Template_Fixture<TestType>::m_a.size() == 0 );
 }
 ```
@@ -101,7 +107,11 @@ struct Nttp_Fixture{
     int value = V;
 };
 
-TEMPLATE_TEST_CASE_METHOD_SIG(Nttp_Fixture, "A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds", "[class][template][nttp]",((int V), V), 1, 3, 6) {
+TEMPLATE_TEST_CASE_METHOD_SIG(
+    Nttp_Fixture,
+    "A TEMPLATE_TEST_CASE_METHOD_SIG based test run that succeeds",
+    "[class][template][nttp]",((int V), V), 1, 3, 6)
+{
     REQUIRE(Nttp_Fixture<V>::value > 0);
 }
 
@@ -117,7 +127,11 @@ struct Template_Foo_2 {
     size_t size() { return V; }
 };
 
-TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG(Template_Fixture_2, "A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds", "[class][template][product][nttp]", ((typename T, size_t S), T, S),(std::array, Template_Foo_2), ((int,2), (float,6)))
+TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG(
+    Template_Fixture_2, 
+    "A TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG based test run that succeeds", 
+    "[class][template][product][nttp]", 
+    ((typename T, size_t S), T, S),(std::array, Template_Foo_2), ((int,2), (float,6)))
 {
     REQUIRE(Template_Fixture_2<TestType>{}.m_a.size() >= 2);
 }
@@ -132,7 +146,9 @@ only difference is the source of types. This allows you to reuse the template ty
 Example:
 ```cpp
 using MyTypes = std::tuple<int, char, double>;
-TEMPLATE_LIST_TEST_CASE_METHOD(Template_Fixture, "Template test case method with test types specified inside std::tuple", "[class][template][list]", MyTypes)
+TEMPLATE_LIST_TEST_CASE_METHOD(Template_Fixture,
+                               "Template test case method with test types specified inside std::tuple",
+                               "[class][template][list]", MyTypes)
 {
     REQUIRE( Template_Fixture<TestType>::m_a == 1 );
 }


### PR DESCRIPTION
## Description
Horizontal scrolling is the devil, particularly in documentation, and some of the code examples are formatted REALLY wide.

This documentation-only change line-wraps most of the examples in `test-fixtures.md` to fit within 80-100ish columns, as things like GitHub's formatted MarkDown renderer and most documentation site templates will struggle to fit anything wider into their page templates without the dreaded scrollbar appearing at the bottom of the block.