### PR TITLE
Added new DL_PATHS option to catch_discover_tests()

### DIFF
--- a/extras/Catch.cmake
+++ b/extras/Catch.cmake
@@ -116,6 +116,13 @@ same as the Catch name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
     ``--out dir/<test_name>suffix``. This can be used to add a file extension to
     the output e.g. ".xml".
 
+  ``DL_PATHS path...``
+    Specifies paths that need to be set for the dynamic linker to find shared
+    libraries/DLLs when running the test executable (PATH/LD_LIBRARY_PATH respectively).
+    These paths will both be set when retrieving the list of test cases from the
+    test executable and when the tests are executed themselfs. This requires
+    cmake/ctest >= 3.22.
+
 #]=======================================================================]
 
 #------------------------------------------------------------------------------
@@ -124,7 +131,7 @@ function(catch_discover_tests TARGET)
     ""
     ""
     "TEST_PREFIX;TEST_SUFFIX;WORKING_DIRECTORY;TEST_LIST;REPORTER;OUTPUT_DIR;OUTPUT_PREFIX;OUTPUT_SUFFIX"
-    "TEST_SPEC;EXTRA_ARGS;PROPERTIES"
+    "TEST_SPEC;EXTRA_ARGS;PROPERTIES;DL_PATHS"
     ${ARGN}
   )
 
@@ -133,6 +140,12 @@ function(catch_discover_tests TARGET)
   endif()
   if(NOT _TEST_LIST)
     set(_TEST_LIST ${TARGET}_TESTS)
+  endif()
+
+  if (_DL_PATHS)
+    if(${CMAKE_VERSION} VERSION_LESS "3.22.0")
+        message(FATAL_ERROR "The DL_PATHS option requires at least cmake 3.22")
+    endif()
   endif()
 
   ## Generate a unique name based on the extra arguments
@@ -164,6 +177,7 @@ function(catch_discover_tests TARGET)
             -D "TEST_OUTPUT_DIR=${_OUTPUT_DIR}"
             -D "TEST_OUTPUT_PREFIX=${_OUTPUT_PREFIX}"
             -D "TEST_OUTPUT_SUFFIX=${_OUTPUT_SUFFIX}"
+            -D "TEST_DL_PATHS=${_DL_PATHS}"
             -D "CTEST_FILE=${ctest_tests_file}"
             -P "${_CATCH_DISCOVER_TESTS_SCRIPT}"
     VERBATIM

--- a/extras/Catch.cmake
+++ b/extras/Catch.cmake
@@ -120,7 +120,7 @@ same as the Catch name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
     Specifies paths that need to be set for the dynamic linker to find shared
     libraries/DLLs when running the test executable (PATH/LD_LIBRARY_PATH respectively).
     These paths will both be set when retrieving the list of test cases from the
-    test executable and when the tests are executed themselfs. This requires
+    test executable and when the tests are executed themselves. This requires
     cmake/ctest >= 3.22.
 
 #]=======================================================================]

--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -101,7 +101,7 @@ endif()
 if(dl_paths)
   foreach(path ${dl_paths})
     cmake_path(NATIVE_PATH path native_path)
-    list(APPEND environment_modifications "${dl_paths_variable_name}=path_list_append:${native_path}")
+    list(APPEND environment_modifications "${dl_paths_variable_name}=path_list_prepend:${native_path}")
   endforeach()
 endif()
 

--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -10,9 +10,16 @@ set(reporter ${TEST_REPORTER})
 set(output_dir ${TEST_OUTPUT_DIR})
 set(output_prefix ${TEST_OUTPUT_PREFIX})
 set(output_suffix ${TEST_OUTPUT_SUFFIX})
+set(dl_paths ${TEST_DL_PATHS})
 set(script)
 set(suite)
 set(tests)
+
+if(WIN32)
+  set(dl_paths_variable_name PATH)
+else()
+  set(dl_paths_variable_name LD_LIBRARY_PATH)
+endif()
 
 function(add_command NAME)
   set(_args "")
@@ -35,6 +42,12 @@ if(NOT EXISTS "${TEST_EXECUTABLE}")
     "Specified test executable '${TEST_EXECUTABLE}' does not exist"
   )
 endif()
+
+if(dl_paths)
+  cmake_path(CONVERT "${dl_paths}" TO_NATIVE_PATH_LIST paths)
+  set(ENV{${dl_paths_variable_name}} "${paths}")
+endif()
+
 execute_process(
   COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-tests --verbosity quiet
   OUTPUT_VARIABLE output
@@ -85,6 +98,13 @@ if(output_dir AND NOT IS_ABSOLUTE ${output_dir})
   endif()
 endif()
 
+if(dl_paths)
+  foreach(path ${dl_paths})
+    cmake_path(NATIVE_PATH path native_path)
+    list(APPEND environment_modifications "${dl_paths_variable_name}=path_list_append:${native_path}")
+  endforeach()
+endif()
+
 # Parse output
 foreach(line ${output})
   set(test ${line})
@@ -115,6 +135,14 @@ foreach(line ${output})
     WORKING_DIRECTORY "${TEST_WORKING_DIR}"
     ${properties}
   )
+
+   if(environment_modifications)
+     add_command(set_tests_properties
+       "${prefix}${test}${suffix}"
+       PROPERTIES
+       ENVIRONMENT_MODIFICATION "${environment_modifications}")
+   endif()
+
   list(APPEND tests "${prefix}${test}${suffix}")
 endforeach()
 


### PR DESCRIPTION
## Description
This enables setting required `PATH`/`LD_LIBRARY_PATH` environment variables both when retrieving the list of test cases and when executing the tests.

Some test executables depend on shared libraries and thus can only be launched when the dynamic linker can find their dependencies. With `set_tests_properties()` it is possible to extend `PATH`/`LD_LIBRARY_PATH` with the `ENVIRONMENT` property of a test. Unfortunately this does not work with the `PROPERTIES` parameter of `catch_discover_tests()` (especially on Windows because of the `;` seperator). 

At first I tried integrating this by parsing said `ENVIRONMENT` property but ultimately failed due to both my and the cmake language limitations. So I implemented this as a new parameter, which makes it easier to handle the list of paths.

I did not find any existing tests for `catch_discover_tests()`, so I did not extend/add one for this. If there is one, please point me in the right direction and I'll add one.