### PR TITLE
Use DYLD_LIBRARY_PATH for DL_PATH on Apple platforms.

### DIFF
--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -17,6 +17,8 @@ set(tests)
 
 if(WIN32)
   set(dl_paths_variable_name PATH)
+elseif(APPLE)
+  set(dl_paths_variable_name DYLD_LIBRARY_PATH)
 else()
   set(dl_paths_variable_name LD_LIBRARY_PATH)
 endif()


### PR DESCRIPTION
## Description

In #2467 I have added the `DL_PATH` option to `catch_discover_tests()`. This PR makes sure we set `DYLD_LIBRARY_PATH` instead of `LD_LIBRARY_PATH` on Apple platforms.
