### PR TITLE
Modify the install directories into convention.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -359,8 +359,12 @@ if (NOT_SUBPROJECT)
         Catch2WithMain
       EXPORT
         Catch2Targets
-      DESTINATION
+      LIBRARY DESTINATION 
         ${CMAKE_INSTALL_LIBDIR}
+      ARCHIVE DESTINATION
+        ${CMAKE_INSTALL_LIBDIR}
+      RUNTIME DESTINATION
+        ${CMAKE_INSTALL_BINDIR}
     )
 
 


### PR DESCRIPTION
## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

Before the modification, `*.dll` files will be installed to the `lib` folder together with `*.lib` files. However, `*.dll` files should be placed in the `bin` folder on Windows platform by convention. Therefore, I modified the install directories of `LIBRARY`, `ARCHIVE`, `RUNTIME`.
