### PR TITLE
Fix compatibility with cmake 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,21 +30,23 @@ if (CMAKE_BINARY_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     message(FATAL_ERROR "Building in-source is not supported! Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
 endif()
 
-if(CMAKE_VERSION VERSION_GREATER 3.8)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.9)
   # Enable IPO for CMake versions that support it
   cmake_policy(SET CMP0069 NEW)
+  project(Catch2
+    VERSION 3.1.0 # CML version placeholder, don't delete
+    LANGUAGES CXX
+    # HOMEPAGE_URL is not supported until CMake version 3.12, which
+    # we do not target yet.
+    # HOMEPAGE_URL "https://github.com/catchorg/Catch2"
+    DESCRIPTION "A modern, C++-native, unit test framework."
+  )
+else()
+  project(Catch2
+    VERSION 3.1.0 # CML version placeholder, don't delete
+    LANGUAGES CXX
+  )
 endif()
-
-
-project(Catch2
-  VERSION 3.1.0 # CML version placeholder, don't delete
-  LANGUAGES CXX
-  # HOMEPAGE_URL is not supported until CMake version 3.12, which
-  # we do not target yet.
-  # HOMEPAGE_URL "https://github.com/catchorg/Catch2"
-  DESCRIPTION "A modern, C++-native, unit test framework."
-)
-
 
 # Provide path for scripts. We first add path to the scripts we don't use,
 # but projects including us might, and set the path up to parent scope.


### PR DESCRIPTION
## Description
Fixed bugs in cmake lists file to make it compatible with older cmake version 3.8.
* project description is introduced in 3.9, reference https://cmake.org/cmake/help/latest/command/project.html
* policy cmp0069 introduced in 3.9, reference https://cmake.org/cmake/help/latest/policy/CMP0069.html

The minimum version required is set to 3.5 but the cmake lists file is not compatible with 3.8 which we use in our project. 
Tested with cmake 3.8.


