### PR TITLE
fixes catchorg/Catch2#2401

### DIFF
--- a/include/internal/catch_session.cpp
+++ b/include/internal/catch_session.cpp
@@ -293,7 +293,7 @@ namespace Catch {
 
             // Handle list request
             if( Option<std::size_t> listed = list( m_config ) )
-                return static_cast<int>( *listed );
+                return (std::min) (MaxExitCode, static_cast<int>(*listed));
 
             TestGroup tests { m_config };
             auto const totals = tests.execute();


### PR DESCRIPTION
Fix return code when catch2 list options are used. The devel branch does not suffer from this problem, only v2.x.
All tests passed locally.

Closes #2401 

