### PR TITLE
Report generator states for failed assertions

### DIFF
--- a/examples/311-Gen-CustomCapture.cpp
+++ b/examples/311-Gen-CustomCapture.cpp
@@ -29,7 +29,7 @@ TEST_CASE("Generate random doubles across different ranges",
     // This will take r1 by reference and r2 by value.
     // Note that there are no advantages for doing so in this example,
     // it is done only for expository purposes.
-    auto number = Catch::Generators::generate( "custom capture generator", CATCH_INTERNAL_LINEINFO,
+    auto number = Catch::Generators::generate( "custom capture generator", "custom definition", CATCH_INTERNAL_LINEINFO,
         [&r1, r2]{
             using namespace Catch::Generators;
             return makeGenerators(take(50, random(std::get<0>(r1), std::get<1>(r2))));

--- a/examples/311-Gen-CustomCapture.cpp
+++ b/examples/311-Gen-CustomCapture.cpp
@@ -29,7 +29,7 @@ TEST_CASE("Generate random doubles across different ranges",
     // This will take r1 by reference and r2 by value.
     // Note that there are no advantages for doing so in this example,
     // it is done only for expository purposes.
-    auto number = Catch::Generators::generate( "custom capture generator", "custom definition", CATCH_INTERNAL_LINEINFO,
+    auto number = Catch::Generators::generate( "custom capture generator", "custom arguments description", CATCH_INTERNAL_LINEINFO,
         [&r1, r2]{
             using namespace Catch::Generators;
             return makeGenerators(take(50, random(std::get<0>(r1), std::get<1>(r2))));

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,7 @@ set(INTERNAL_HEADERS
     ${SOURCES_DIR}/matchers/catch_matchers_templated.hpp
     ${SOURCES_DIR}/matchers/catch_matchers_vector.hpp
     ${SOURCES_DIR}/catch_message.hpp
+    ${SOURCES_DIR}/internal/catch_generator_info.hpp
     ${SOURCES_DIR}/internal/catch_message_info.hpp
     ${SOURCES_DIR}/internal/catch_meta.hpp
     ${SOURCES_DIR}/internal/catch_move_and_forward.hpp
@@ -236,6 +237,7 @@ set(IMPL_SOURCES
     ${SOURCES_DIR}/internal/catch_errno_guard.cpp
     ${SOURCES_DIR}/internal/catch_lazy_expr.cpp
     ${SOURCES_DIR}/internal/catch_leak_detector.cpp
+    ${SOURCES_DIR}/internal/catch_generator_info.cpp
     ${SOURCES_DIR}/internal/catch_message_info.cpp
     ${SOURCES_DIR}/internal/catch_polyfills.cpp
     ${SOURCES_DIR}/internal/catch_startup_exception_registry.cpp

--- a/src/catch2/catch_all.hpp
+++ b/src/catch2/catch_all.hpp
@@ -68,6 +68,7 @@
 #include <catch2/internal/catch_exception_translator_registry.hpp>
 #include <catch2/internal/catch_fatal_condition_handler.hpp>
 #include <catch2/internal/catch_floating_point_helpers.hpp>
+#include <catch2/internal/catch_generator_info.hpp>
 #include <catch2/internal/catch_istream.hpp>
 #include <catch2/internal/catch_lazy_expr.hpp>
 #include <catch2/internal/catch_leak_detector.hpp>

--- a/src/catch2/generators/catch_generators.hpp
+++ b/src/catch2/generators/catch_generators.hpp
@@ -211,7 +211,7 @@ namespace Detail {
     // Note: The type after -> is weird, because VS2015 cannot parse
     //       the expression used in the typedef inside, when it is in
     //       return type. Yeah.
-    auto generate( StringRef generatorName, StringRef definition, SourceLineInfo const& lineInfo, L const& generatorExpression ) -> decltype(std::declval<decltype(generatorExpression())>().get()) {
+    auto generate( StringRef generatorName, StringRef argumentsDescription, SourceLineInfo const& lineInfo, L const& generatorExpression ) -> decltype(std::declval<decltype(generatorExpression())>().get()) {
         using UnderlyingType = typename decltype(generatorExpression())::type;
 
         IGeneratorTracker& tracker = acquireGeneratorTracker( generatorName, lineInfo );
@@ -220,7 +220,7 @@ namespace Detail {
         }
 
         auto const& generator = static_cast<IGenerator<UnderlyingType> const&>( *tracker.getGenerator() );
-        getResultCapture().trackGeneratorState(GeneratorInfo(definition, lineInfo, generator.currentElementAsString()));
+        getResultCapture().trackGeneratorState(GeneratorInfo(generatorName, argumentsDescription, lineInfo, generator.currentElementAsString()));
         return generator.get();
     }
 

--- a/src/catch2/generators/catch_generators.hpp
+++ b/src/catch2/generators/catch_generators.hpp
@@ -8,7 +8,6 @@
 #ifndef CATCH_GENERATORS_HPP_INCLUDED
 #define CATCH_GENERATORS_HPP_INCLUDED
 
-#include "catch2/interfaces/catch_interfaces_capture.hpp"
 #include <catch2/catch_tostring.hpp>
 #include <catch2/interfaces/catch_interfaces_generatortracker.hpp>
 #include <catch2/internal/catch_generator_info.hpp>

--- a/src/catch2/generators/catch_generators.hpp
+++ b/src/catch2/generators/catch_generators.hpp
@@ -8,8 +8,10 @@
 #ifndef CATCH_GENERATORS_HPP_INCLUDED
 #define CATCH_GENERATORS_HPP_INCLUDED
 
+#include "catch2/interfaces/catch_interfaces_capture.hpp"
 #include <catch2/catch_tostring.hpp>
 #include <catch2/interfaces/catch_interfaces_generatortracker.hpp>
+#include <catch2/internal/catch_generator_info.hpp>
 #include <catch2/internal/catch_source_line_info.hpp>
 #include <catch2/internal/catch_stringref.hpp>
 #include <catch2/internal/catch_move_and_forward.hpp>
@@ -210,7 +212,7 @@ namespace Detail {
     // Note: The type after -> is weird, because VS2015 cannot parse
     //       the expression used in the typedef inside, when it is in
     //       return type. Yeah.
-    auto generate( StringRef generatorName, SourceLineInfo const& lineInfo, L const& generatorExpression ) -> decltype(std::declval<decltype(generatorExpression())>().get()) {
+    auto generate( StringRef generatorName, StringRef definition, SourceLineInfo const& lineInfo, L const& generatorExpression ) -> decltype(std::declval<decltype(generatorExpression())>().get()) {
         using UnderlyingType = typename decltype(generatorExpression())::type;
 
         IGeneratorTracker& tracker = acquireGeneratorTracker( generatorName, lineInfo );
@@ -219,6 +221,7 @@ namespace Detail {
         }
 
         auto const& generator = static_cast<IGenerator<UnderlyingType> const&>( *tracker.getGenerator() );
+        getResultCapture().trackGeneratorState(GeneratorInfo(definition, lineInfo, generator.currentElementAsString()));
         return generator.get();
     }
 
@@ -227,14 +230,17 @@ namespace Detail {
 
 #define GENERATE( ... ) \
     Catch::Generators::generate( INTERNAL_CATCH_STRINGIZE(INTERNAL_CATCH_UNIQUE_NAME(generator)), \
+                                 INTERNAL_CATCH_STRINGIZE( __VA_ARGS__ ), \
                                  CATCH_INTERNAL_LINEINFO, \
                                  [ ]{ using namespace Catch::Generators; return makeGenerators( __VA_ARGS__ ); } ) //NOLINT(google-build-using-namespace)
 #define GENERATE_COPY( ... ) \
     Catch::Generators::generate( INTERNAL_CATCH_STRINGIZE(INTERNAL_CATCH_UNIQUE_NAME(generator)), \
+                                 INTERNAL_CATCH_STRINGIZE( __VA_ARGS__ ), \
                                  CATCH_INTERNAL_LINEINFO, \
                                  [=]{ using namespace Catch::Generators; return makeGenerators( __VA_ARGS__ ); } ) //NOLINT(google-build-using-namespace)
 #define GENERATE_REF( ... ) \
     Catch::Generators::generate( INTERNAL_CATCH_STRINGIZE(INTERNAL_CATCH_UNIQUE_NAME(generator)), \
+                                 INTERNAL_CATCH_STRINGIZE( __VA_ARGS__ ), \
                                  CATCH_INTERNAL_LINEINFO, \
                                  [&]{ using namespace Catch::Generators; return makeGenerators( __VA_ARGS__ ); } ) //NOLINT(google-build-using-namespace)
 

--- a/src/catch2/interfaces/catch_interfaces_capture.hpp
+++ b/src/catch2/interfaces/catch_interfaces_capture.hpp
@@ -44,7 +44,7 @@ namespace Catch {
         virtual void sectionEndedEarly( SectionEndInfo const& endInfo ) = 0;
 
         virtual auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& = 0;
-        virtual void trackGeneratorState( GeneratorInfo info ) = 0;
+        virtual void trackGeneratorState( GeneratorInfo const& info ) = 0;
 
         virtual void benchmarkPreparing( StringRef name ) = 0;
         virtual void benchmarkStarting( BenchmarkInfo const& info ) = 0;

--- a/src/catch2/interfaces/catch_interfaces_capture.hpp
+++ b/src/catch2/interfaces/catch_interfaces_capture.hpp
@@ -20,6 +20,7 @@ namespace Catch {
     struct AssertionInfo;
     struct SectionInfo;
     struct SectionEndInfo;
+    struct GeneratorInfo;
     struct MessageInfo;
     struct MessageBuilder;
     struct Counts;
@@ -43,6 +44,7 @@ namespace Catch {
         virtual void sectionEndedEarly( SectionEndInfo const& endInfo ) = 0;
 
         virtual auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& = 0;
+        virtual void trackGeneratorState( GeneratorInfo info ) = 0;
 
         virtual void benchmarkPreparing( StringRef name ) = 0;
         virtual void benchmarkStarting( BenchmarkInfo const& info ) = 0;

--- a/src/catch2/interfaces/catch_interfaces_reporter.cpp
+++ b/src/catch2/interfaces/catch_interfaces_reporter.cpp
@@ -5,7 +5,6 @@
 //        https://www.boost.org/LICENSE_1_0.txt)
 
 // SPDX-License-Identifier: BSL-1.0
-#include "catch2/interfaces/catch_interfaces_capture.hpp"
 #include <catch2/interfaces/catch_interfaces_reporter.hpp>
 #include <catch2/interfaces/catch_interfaces_config.hpp>
 #include <catch2/internal/catch_console_colour.hpp>

--- a/src/catch2/interfaces/catch_interfaces_reporter.cpp
+++ b/src/catch2/interfaces/catch_interfaces_reporter.cpp
@@ -5,6 +5,7 @@
 //        https://www.boost.org/LICENSE_1_0.txt)
 
 // SPDX-License-Identifier: BSL-1.0
+#include "catch2/interfaces/catch_interfaces_capture.hpp"
 #include <catch2/interfaces/catch_interfaces_reporter.hpp>
 #include <catch2/interfaces/catch_interfaces_config.hpp>
 #include <catch2/internal/catch_console_colour.hpp>
@@ -49,9 +50,11 @@ namespace Catch {
 
     AssertionStats::AssertionStats( AssertionResult const& _assertionResult,
                                     std::vector<MessageInfo> const& _infoMessages,
+                                    std::vector<GeneratorInfo> const& _generatorInfos,
                                     Totals const& _totals )
     :   assertionResult( _assertionResult ),
         infoMessages( _infoMessages ),
+        generatorInfos( _generatorInfos ),
         totals( _totals )
     {
         assertionResult.m_resultData.lazyExpression.m_transientExpression = _assertionResult.m_resultData.lazyExpression.m_transientExpression;

--- a/src/catch2/interfaces/catch_interfaces_reporter.hpp
+++ b/src/catch2/interfaces/catch_interfaces_reporter.hpp
@@ -8,10 +8,12 @@
 #ifndef CATCH_INTERFACES_REPORTER_HPP_INCLUDED
 #define CATCH_INTERFACES_REPORTER_HPP_INCLUDED
 
+#include "catch2/interfaces/catch_interfaces_capture.hpp"
 #include <catch2/catch_section_info.hpp>
 #include <catch2/catch_totals.hpp>
 #include <catch2/catch_assertion_result.hpp>
 #include <catch2/internal/catch_message_info.hpp>
+#include <catch2/internal/catch_generator_info.hpp>
 #include <catch2/internal/catch_stringref.hpp>
 #include <catch2/internal/catch_unique_ptr.hpp>
 #include <catch2/internal/catch_move_and_forward.hpp>
@@ -65,6 +67,7 @@ namespace Catch {
     struct AssertionStats {
         AssertionStats( AssertionResult const& _assertionResult,
                         std::vector<MessageInfo> const& _infoMessages,
+                        std::vector<GeneratorInfo> const& _generatorInfos,
                         Totals const& _totals );
 
         AssertionStats( AssertionStats const& )              = default;
@@ -74,6 +77,7 @@ namespace Catch {
 
         AssertionResult assertionResult;
         std::vector<MessageInfo> infoMessages;
+        std::vector<GeneratorInfo> generatorInfos;
         Totals totals;
     };
 

--- a/src/catch2/interfaces/catch_interfaces_reporter.hpp
+++ b/src/catch2/interfaces/catch_interfaces_reporter.hpp
@@ -8,7 +8,6 @@
 #ifndef CATCH_INTERFACES_REPORTER_HPP_INCLUDED
 #define CATCH_INTERFACES_REPORTER_HPP_INCLUDED
 
-#include "catch2/interfaces/catch_interfaces_capture.hpp"
 #include <catch2/catch_section_info.hpp>
 #include <catch2/catch_totals.hpp>
 #include <catch2/catch_assertion_result.hpp>

--- a/src/catch2/internal/catch_console_colour.hpp
+++ b/src/catch2/internal/catch_console_colour.hpp
@@ -50,6 +50,7 @@ namespace Catch {
 
             OriginalExpression = Cyan,
             ReconstructedExpression = BrightYellow,
+            GeneratorValue = Cyan,
 
             SecondaryText = LightGrey,
             Headers = White

--- a/src/catch2/internal/catch_generator_info.cpp
+++ b/src/catch2/internal/catch_generator_info.cpp
@@ -10,10 +10,12 @@
 
 namespace Catch {
 
-    GeneratorInfo::GeneratorInfo( StringRef _definition,
+    GeneratorInfo::GeneratorInfo( StringRef _name,
+                                  StringRef _arguments,
                                   SourceLineInfo const& _lineInfo,
                                   StringRef _currentElement ):
-        definition( _definition ),
+        name( _name ),
+        arguments( _arguments ),
         lineInfo( _lineInfo ),
         currentElement( _currentElement ) {}
 

--- a/src/catch2/internal/catch_generator_info.cpp
+++ b/src/catch2/internal/catch_generator_info.cpp
@@ -1,0 +1,20 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE_1_0.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+#include <catch2/internal/catch_generator_info.hpp>
+
+namespace Catch {
+
+    GeneratorInfo::GeneratorInfo( StringRef _definition,
+                                  SourceLineInfo const& _lineInfo,
+                                  StringRef _currentElement ):
+        definition( _definition ),
+        lineInfo( _lineInfo ),
+        currentElement( _currentElement ) {}
+
+} // end namespace Catch

--- a/src/catch2/internal/catch_generator_info.hpp
+++ b/src/catch2/internal/catch_generator_info.hpp
@@ -1,0 +1,35 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE_1_0.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+#ifndef CATCH_GENERATOR_INFO_HPP_INCLUDED
+#define CATCH_GENERATOR_INFO_HPP_INCLUDED
+
+#include <catch2/interfaces/catch_interfaces_capture.hpp>
+#include <catch2/internal/catch_source_line_info.hpp>
+#include <string>
+
+namespace Catch {
+
+    struct GeneratorInfo {
+        GeneratorInfo( StringRef _definition,
+                       SourceLineInfo const& _lineInfo,
+                       StringRef currentElement );
+
+        StringRef definition;
+        SourceLineInfo lineInfo;
+        StringRef currentElement;
+
+        bool operator==( GeneratorInfo const& other ) const {
+            return definition == other.definition &&
+                   lineInfo == other.lineInfo &&
+                   currentElement == other.currentElement;
+        }
+    };
+
+} // end namespace Catch
+
+#endif // CATCH_GENERATOR_INFO_HPP_INCLUDED

--- a/src/catch2/internal/catch_generator_info.hpp
+++ b/src/catch2/internal/catch_generator_info.hpp
@@ -15,16 +15,18 @@
 namespace Catch {
 
     struct GeneratorInfo {
-        GeneratorInfo( StringRef _definition,
+        GeneratorInfo( StringRef _name,
+                       StringRef _arguments,
                        SourceLineInfo const& _lineInfo,
                        StringRef currentElement );
 
-        StringRef definition;
+        StringRef name;
+        StringRef arguments;
         SourceLineInfo lineInfo;
         StringRef currentElement;
 
         bool operator==( GeneratorInfo const& other ) const {
-            return definition == other.definition &&
+            return name == other.name && arguments == other.arguments &&
                    lineInfo == other.lineInfo &&
                    currentElement == other.currentElement;
         }

--- a/src/catch2/internal/catch_run_context.cpp
+++ b/src/catch2/internal/catch_run_context.cpp
@@ -283,7 +283,7 @@ namespace Catch {
             m_lastAssertionPassed = true;
         }
 
-        m_reporter->assertionEnded(AssertionStats(result, m_messages, m_totals));
+        m_reporter->assertionEnded(AssertionStats(result, m_messages, m_generatorInfos, m_totals));
 
         if (result.getResultType() != ResultWas::Warning)
             m_messageScopes.clear();
@@ -319,6 +319,16 @@ namespace Catch {
         return tracker;
     }
 
+    void RunContext::trackGeneratorState( GeneratorInfo info ) {
+        // Avoid redundant entries, in case a generator is used within a loop.
+        if ( std::find( m_generatorInfos.cbegin(),
+                        m_generatorInfos.cend(),
+                        info ) != m_generatorInfos.cend() )
+            return;
+
+        m_generatorInfos.push_back( info );
+    }
+
     bool RunContext::testForMissingAssertions(Counts& assertions) {
         if (assertions.total() != 0)
             return false;
@@ -343,6 +353,7 @@ namespace Catch {
         m_reporter->sectionEnded(SectionStats(endInfo.sectionInfo, assertions, endInfo.durationInSeconds, missingAssertions));
         m_messages.clear();
         m_messageScopes.clear();
+        m_generatorInfos.clear();
     }
 
     void RunContext::sectionEndedEarly(SectionEndInfo const & endInfo) {
@@ -490,6 +501,7 @@ namespace Catch {
         handleUnfinishedSections();
         m_messages.clear();
         m_messageScopes.clear();
+        m_generatorInfos.clear();
 
         SectionStats testCaseSectionStats(testCaseSection, assertions, duration, missingAssertions);
         m_reporter->sectionEnded(testCaseSectionStats);

--- a/src/catch2/internal/catch_run_context.cpp
+++ b/src/catch2/internal/catch_run_context.cpp
@@ -319,7 +319,7 @@ namespace Catch {
         return tracker;
     }
 
-    void RunContext::trackGeneratorState( GeneratorInfo info ) {
+    void RunContext::trackGeneratorState( GeneratorInfo const& info ) {
         // Avoid redundant entries, in case a generator is used within a loop.
         if ( std::find( m_generatorInfos.cbegin(),
                         m_generatorInfos.cend(),

--- a/src/catch2/internal/catch_run_context.hpp
+++ b/src/catch2/internal/catch_run_context.hpp
@@ -74,7 +74,7 @@ namespace Catch {
         void sectionEndedEarly( SectionEndInfo const& endInfo ) override;
 
         auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& override;
-        void trackGeneratorState( GeneratorInfo info ) override;
+        void trackGeneratorState( GeneratorInfo const& info ) override;
 
         void benchmarkPreparing( StringRef name ) override;
         void benchmarkStarting( BenchmarkInfo const& info ) override;

--- a/src/catch2/internal/catch_run_context.hpp
+++ b/src/catch2/internal/catch_run_context.hpp
@@ -8,6 +8,7 @@
 #ifndef CATCH_RUN_CONTEXT_HPP_INCLUDED
 #define CATCH_RUN_CONTEXT_HPP_INCLUDED
 
+#include "catch2/interfaces/catch_interfaces_capture.hpp"
 #include <catch2/interfaces/catch_interfaces_reporter.hpp>
 #include <catch2/internal/catch_test_registry.hpp>
 #include <catch2/internal/catch_fatal_condition_handler.hpp>
@@ -74,6 +75,7 @@ namespace Catch {
         void sectionEndedEarly( SectionEndInfo const& endInfo ) override;
 
         auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& override;
+        void trackGeneratorState( GeneratorInfo info ) override;
 
         void benchmarkPreparing( StringRef name ) override;
         void benchmarkStarting( BenchmarkInfo const& info ) override;
@@ -132,6 +134,7 @@ namespace Catch {
         Totals m_totals;
         IEventListenerPtr m_reporter;
         std::vector<MessageInfo> m_messages;
+        std::vector<GeneratorInfo> m_generatorInfos;
         std::vector<ScopedMessage> m_messageScopes; /* Keeps owners of so-called unscoped messages. */
         AssertionInfo m_lastAssertionInfo;
         std::vector<SectionEndInfo> m_unfinishedSections;

--- a/src/catch2/internal/catch_run_context.hpp
+++ b/src/catch2/internal/catch_run_context.hpp
@@ -8,7 +8,6 @@
 #ifndef CATCH_RUN_CONTEXT_HPP_INCLUDED
 #define CATCH_RUN_CONTEXT_HPP_INCLUDED
 
-#include "catch2/interfaces/catch_interfaces_capture.hpp"
 #include <catch2/interfaces/catch_interfaces_reporter.hpp>
 #include <catch2/internal/catch_test_registry.hpp>
 #include <catch2/internal/catch_fatal_condition_handler.hpp>

--- a/src/catch2/reporters/catch_reporter_console.cpp
+++ b/src/catch2/reporters/catch_reporter_console.cpp
@@ -164,7 +164,7 @@ private:
         for ( auto const& info : stats.generatorInfos ) {
             stream << TextFlow::Column( "line:" ).indent( 2 )
                    << info.lineInfo.line << ": "
-                   << "GENERATE(" << info.definition << ")\n"
+                   << "GENERATE(" << info.arguments << ")\n"
                    << TextFlow::Column( "value: " ).indent( 2 )
                    << colourImpl->guardColour( Colour::GeneratorValue )
                    << info.currentElement << '\n';

--- a/src/catch2/reporters/catch_reporter_console.cpp
+++ b/src/catch2/reporters/catch_reporter_console.cpp
@@ -160,14 +160,14 @@ private:
             return;
         }
 
-        stream << "with " << pluralise(stats.generatorInfos.size(), "generator"_sr) << "\n";
+        stream << "with " << pluralise(stats.generatorInfos.size(), "generator"_sr) << '\n';
         for ( auto const& info : stats.generatorInfos ) {
             stream << TextFlow::Column( "line:" ).indent( 2 )
                    << info.lineInfo.line << ": "
                    << "GENERATE(" << info.definition << ")\n"
                    << TextFlow::Column( "value: " ).indent( 2 )
                    << colourImpl->guardColour( Colour::GeneratorValue )
-                   << info.currentElement << "\n";
+                   << info.currentElement << '\n';
         }
     }
     void printMessage() const {

--- a/src/catch2/reporters/catch_reporter_console.cpp
+++ b/src/catch2/reporters/catch_reporter_console.cpp
@@ -127,6 +127,7 @@ public:
             printResultType();
             printOriginalExpression();
             printReconstructedExpression();
+            printGeneratorStates();
         } else {
             stream << '\n';
         }
@@ -152,6 +153,21 @@ private:
                    << TextFlow::Column( result.getExpandedExpression() )
                           .indent( 2 )
                    << '\n';
+        }
+    }
+    void printGeneratorStates() const {
+        if ( stats.generatorInfos.empty() ) {
+            return;
+        }
+
+        stream << "with " << pluralise(stats.generatorInfos.size(), "generator"_sr) << "\n";
+        for ( auto const& info : stats.generatorInfos ) {
+            stream << TextFlow::Column( "line:" ).indent( 2 )
+                   << info.lineInfo.line << ": "
+                   << "GENERATE(" << info.definition << ")\n"
+                   << TextFlow::Column( "value: " ).indent( 2 )
+                   << colourImpl->guardColour( Colour::GeneratorValue )
+                   << info.currentElement << "\n";
         }
     }
     void printMessage() const {

--- a/tests/SelfTest/Baselines/console.sw.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.approved.txt
@@ -228,6 +228,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( counter < 7 )
 with expansion:
   3 < 7
+with 1 generator
+  line:267: GENERATE(1, 2)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1913 - GENERATE inside a for loop should not keep recreating the generator
@@ -239,6 +242,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( counter < 7 )
 with expansion:
   6 < 7
+with 1 generator
+  line:267: GENERATE(1, 2)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1913 - GENERATEs can share a line
@@ -250,6 +256,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i != j )
 with expansion:
   1 != 3
+with 2 generators
+  line:276: GENERATE(1, 2)
+  value: 1
+  line:276: GENERATE(3, 4)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1913 - GENERATEs can share a line
@@ -261,6 +272,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i != j )
 with expansion:
   1 != 4
+with 2 generators
+  line:276: GENERATE(1, 2)
+  value: 1
+  line:276: GENERATE(3, 4)
+  value: 4
 
 -------------------------------------------------------------------------------
 #1913 - GENERATEs can share a line
@@ -272,6 +288,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i != j )
 with expansion:
   2 != 3
+with 2 generators
+  line:276: GENERATE(1, 2)
+  value: 2
+  line:276: GENERATE(3, 4)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1913 - GENERATEs can share a line
@@ -283,6 +304,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i != j )
 with expansion:
   2 != 4
+with 2 generators
+  line:276: GENERATE(1, 2)
+  value: 2
+  line:276: GENERATE(3, 4)
+  value: 4
 
 -------------------------------------------------------------------------------
 #1938 - GENERATE after a section
@@ -306,6 +332,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   1
+with 1 generator
+  line:216: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - GENERATE after a section
@@ -318,6 +347,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 1 generator
+  line:216: GENERATE(1, 2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - GENERATE after a section
@@ -330,6 +362,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 1 generator
+  line:216: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - Section followed by flat generate
@@ -351,6 +386,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 1 generator
+  line:252: GENERATE(2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - Section followed by flat generate
@@ -362,6 +400,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 1 generator
+  line:252: GENERATE(2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - flat generate
@@ -373,6 +414,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   1
+with 1 generator
+  line:223: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - flat generate
@@ -384,6 +428,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 1 generator
+  line:223: GENERATE(1, 2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - flat generate
@@ -395,6 +442,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 1 generator
+  line:223: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - mixed sections and generates
@@ -404,6 +454,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:235: GENERATE(1, 2)
+  value: 1
 with message:
   A
 
@@ -414,6 +467,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:239: GENERATE(3, 4)
+  value: 3
+  line:243: GENERATE(5, 6)
+  value: 5
 with messages:
   i := 1
   j := 3
@@ -427,6 +485,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:235: GENERATE(1, 2)
+  value: 1
+  line:239: GENERATE(3, 4)
+  value: 3
 with message:
   B
 
@@ -437,6 +500,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:243: GENERATE(5, 6)
+  value: 6
 with messages:
   i := 1
   j := 3
@@ -450,6 +516,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:235: GENERATE(1, 2)
+  value: 1
+  line:239: GENERATE(3, 4)
+  value: 4
 with message:
   B
 
@@ -460,6 +531,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:243: GENERATE(5, 6)
+  value: 5
 with messages:
   i := 1
   j := 4
@@ -472,6 +546,13 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 3 generators
+  line:235: GENERATE(1, 2)
+  value: 1
+  line:239: GENERATE(3, 4)
+  value: 4
+  line:243: GENERATE(5, 6)
+  value: 6
 with messages:
   i := 1
   j := 4
@@ -485,6 +566,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:235: GENERATE(1, 2)
+  value: 2
 with message:
   A
 
@@ -495,6 +579,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:239: GENERATE(3, 4)
+  value: 3
+  line:243: GENERATE(5, 6)
+  value: 5
 with messages:
   i := 2
   j := 3
@@ -508,6 +597,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:235: GENERATE(1, 2)
+  value: 2
+  line:239: GENERATE(3, 4)
+  value: 3
 with message:
   B
 
@@ -518,6 +612,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:243: GENERATE(5, 6)
+  value: 6
 with messages:
   i := 2
   j := 3
@@ -531,6 +628,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:235: GENERATE(1, 2)
+  value: 2
+  line:239: GENERATE(3, 4)
+  value: 4
 with message:
   B
 
@@ -541,6 +643,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:243: GENERATE(5, 6)
+  value: 5
 with messages:
   i := 2
   j := 4
@@ -553,6 +658,13 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 3 generators
+  line:235: GENERATE(1, 2)
+  value: 2
+  line:239: GENERATE(3, 4)
+  value: 4
+  line:243: GENERATE(5, 6)
+  value: 6
 with messages:
   i := 2
   j := 4
@@ -568,27 +680,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   1
-
--------------------------------------------------------------------------------
-#1938 - nested generate
--------------------------------------------------------------------------------
-PartTracker.tests.cpp:<line number>
-...............................................................................
-
-PartTracker.tests.cpp:<line number>: PASSED:
-  REQUIRE( m )
-with expansion:
-  1
-
-PartTracker.tests.cpp:<line number>: PASSED:
-  REQUIRE( n )
-with expansion:
-  2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -600,11 +706,47 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 2
+
+PartTracker.tests.cpp:<line number>: PASSED:
+  REQUIRE( n )
+with expansion:
+  2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 2
+
+-------------------------------------------------------------------------------
+#1938 - nested generate
+-------------------------------------------------------------------------------
+PartTracker.tests.cpp:<line number>
+...............................................................................
+
+PartTracker.tests.cpp:<line number>: PASSED:
+  REQUIRE( m )
+with expansion:
+  1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -616,11 +758,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -632,11 +784,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 2
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -648,11 +810,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -664,11 +836,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -680,11 +862,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 2
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -696,11 +888,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1954 - 7 arg template test case sig compiles - 1, 1, 1, 1, 1, 0, 0
@@ -1093,16 +1295,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1114,16 +1337,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1135,16 +1379,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1156,16 +1421,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1177,16 +1463,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1198,16 +1505,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1219,16 +1547,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1240,16 +1589,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1261,16 +1631,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1282,16 +1673,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1303,16 +1715,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1324,16 +1757,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1345,16 +1799,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1366,16 +1841,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1387,16 +1883,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1408,16 +1925,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1429,16 +1967,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1450,16 +2009,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1471,16 +2051,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1492,16 +2093,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1513,16 +2135,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1534,16 +2177,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1555,16 +2219,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1576,16 +2261,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1597,16 +2303,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1618,16 +2345,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1639,16 +2387,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 A METHOD_AS_TEST_CASE based test run that fails
@@ -3714,6 +4483,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:250: GENERATE(from_range(data.begin(), data.end()))
+  value: 1
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3726,6 +4498,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:250: GENERATE(from_range(data.begin(), data.end()))
+  value: 3
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3738,6 +4513,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:250: GENERATE(from_range(data.begin(), data.end()))
+  value: 5
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3750,6 +4528,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:250: GENERATE(from_range(data.begin(), data.end()))
+  value: 7
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3762,6 +4543,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:250: GENERATE(from_range(data.begin(), data.end()))
+  value: 9
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3774,6 +4558,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:250: GENERATE(from_range(data.begin(), data.end()))
+  value: 11
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3786,6 +4573,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:254: GENERATE(from_range(make_data_counted()))
+  value: 1
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3798,6 +4588,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:254: GENERATE(from_range(make_data_counted()))
+  value: 3
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3810,6 +4603,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:254: GENERATE(from_range(make_data_counted()))
+  value: 5
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3822,6 +4618,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:254: GENERATE(from_range(make_data_counted()))
+  value: 7
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3834,6 +4633,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:254: GENERATE(from_range(make_data_counted()))
+  value: 9
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3846,6 +4648,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:254: GENERATE(from_range(make_data_counted()))
+  value: 11
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -4831,6 +5636,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i % 2 == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:133: GENERATE(filter([] (int val) { return val % 2 == 0; }, values({ 1, 2, 3, 4, 5, 6 })))
+  value: 2
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4844,6 +5652,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i % 2 == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:133: GENERATE(filter([] (int val) { return val % 2 == 0; }, values({ 1, 2, 3, 4, 5, 6 })))
+  value: 4
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4857,6 +5668,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i % 2 == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:133: GENERATE(filter([] (int val) { return val % 2 == 0; }, values({ 1, 2, 3, 4, 5, 6 })))
+  value: 6
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4880,6 +5694,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 4 )
 with expansion:
   1 < 4
+with 1 generator
+  line:143: GENERATE(take(3, values({ 1, 2, 3, 4, 5, 6 })))
+  value: 1
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4892,6 +5709,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 4 )
 with expansion:
   2 < 4
+with 1 generator
+  line:143: GENERATE(take(3, values({ 1, 2, 3, 4, 5, 6 })))
+  value: 2
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4904,6 +5724,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 4 )
 with expansion:
   3 < 4
+with 1 generator
+  line:143: GENERATE(take(3, values({ 1, 2, 3, 4, 5, 6 })))
+  value: 3
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4917,6 +5740,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i % 2 == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:149: GENERATE(map([] (int val) { return val * 2; }, values({ 1, 2, 3 })))
+  value: 2
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4930,6 +5756,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i % 2 == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:149: GENERATE(map([] (int val) { return val * 2; }, values({ 1, 2, 3 })))
+  value: 4
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4943,6 +5772,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i % 2 == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:149: GENERATE(map([] (int val) { return val * 2; }, values({ 1, 2, 3 })))
+  value: 6
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4956,6 +5788,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i.size() == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:154: GENERATE(map<std::string>([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })))
+  value: "1"
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4969,6 +5804,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i.size() == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:154: GENERATE(map<std::string>([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })))
+  value: "2"
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4982,6 +5820,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i.size() == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:154: GENERATE(map<std::string>([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })))
+  value: "3"
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4995,6 +5836,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i.size() == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:159: GENERATE(map([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })))
+  value: "1"
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5008,6 +5852,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i.size() == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:159: GENERATE(map([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })))
+  value: "2"
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5021,6 +5868,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i.size() == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:159: GENERATE(map([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })))
+  value: "3"
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5033,6 +5883,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j > 0 )
 with expansion:
   1 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 1
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5045,6 +5898,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j > 0 )
 with expansion:
   2 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 2
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5057,6 +5913,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j > 0 )
 with expansion:
   3 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 3
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5069,6 +5928,24 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j > 0 )
 with expansion:
   1 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 1
+
+-------------------------------------------------------------------------------
+Generators -- adapters
+  Repeating a generator
+-------------------------------------------------------------------------------
+Generators.tests.cpp:<line number>
+...............................................................................
+
+Generators.tests.cpp:<line number>: PASSED:
+  REQUIRE( j > 0 )
+with expansion:
+  1 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 1
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5081,6 +5958,24 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j > 0 )
 with expansion:
   2 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 2
+
+-------------------------------------------------------------------------------
+Generators -- adapters
+  Repeating a generator
+-------------------------------------------------------------------------------
+Generators.tests.cpp:<line number>
+...............................................................................
+
+Generators.tests.cpp:<line number>: PASSED:
+  REQUIRE( j > 0 )
+with expansion:
+  2 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 2
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5093,6 +5988,24 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j > 0 )
 with expansion:
   3 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 3
+
+-------------------------------------------------------------------------------
+Generators -- adapters
+  Repeating a generator
+-------------------------------------------------------------------------------
+Generators.tests.cpp:<line number>
+...............................................................................
+
+Generators.tests.cpp:<line number>: PASSED:
+  REQUIRE( j > 0 )
+with expansion:
+  3 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 3
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5106,11 +6019,17 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 2 )
 with expansion:
   2 == 2
+with 1 generator
+  line:170: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3, 3 })))
+  value: { 1, 1 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() == chunk2.back() )
 with expansion:
   1 == 1
+with 1 generator
+  line:170: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3, 3 })))
+  value: { 1, 1 }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5124,11 +6043,17 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 2 )
 with expansion:
   2 == 2
+with 1 generator
+  line:170: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3, 3 })))
+  value: { 2, 2 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() == chunk2.back() )
 with expansion:
   2 == 2
+with 1 generator
+  line:170: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3, 3 })))
+  value: { 2, 2 }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5142,11 +6067,17 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 2 )
 with expansion:
   2 == 2
+with 1 generator
+  line:170: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3, 3 })))
+  value: { 3, 3 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() == chunk2.back() )
 with expansion:
   3 == 3
+with 1 generator
+  line:170: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3, 3 })))
+  value: { 3, 3 }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5160,16 +6091,25 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 2 )
 with expansion:
   2 == 2
+with 1 generator
+  line:175: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3 })))
+  value: { 1, 1 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() == chunk2.back() )
 with expansion:
   1 == 1
+with 1 generator
+  line:175: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3 })))
+  value: { 1, 1 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() < 3 )
 with expansion:
   1 < 3
+with 1 generator
+  line:175: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3 })))
+  value: { 1, 1 }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5183,16 +6123,25 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 2 )
 with expansion:
   2 == 2
+with 1 generator
+  line:175: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3 })))
+  value: { 2, 2 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() == chunk2.back() )
 with expansion:
   2 == 2
+with 1 generator
+  line:175: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3 })))
+  value: { 2, 2 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() < 3 )
 with expansion:
   2 < 3
+with 1 generator
+  line:175: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3 })))
+  value: { 2, 2 }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5206,6 +6155,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:181: GENERATE(take(3, chunk(0, value(1))))
+  value: {  }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5219,6 +6171,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:181: GENERATE(take(3, chunk(0, value(1))))
+  value: {  }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5232,6 +6187,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:181: GENERATE(take(3, chunk(0, value(1))))
+  value: {  }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5255,6 +6213,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -3 < 1
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 1
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -3
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5267,6 +6230,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -2 < 1
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 1
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -2
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5279,6 +6247,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -1 < 1
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 1
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -1
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5291,6 +6264,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   4 > 1
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 1
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "a"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5303,6 +6281,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   4 > 2
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 1
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "bb"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5315,6 +6298,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   4 > 3
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 1
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "ccc"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5327,6 +6315,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -3 < 2
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 2
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -3
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5339,6 +6332,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -2 < 2
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 2
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -2
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5351,6 +6349,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -1 < 2
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 2
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -1
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5363,6 +6366,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   8 > 1
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 2
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "a"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5375,6 +6383,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   8 > 2
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 2
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "bb"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5387,6 +6400,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   8 > 3
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 2
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "ccc"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5399,6 +6417,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -3 < 3
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 3
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -3
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5411,6 +6434,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -2 < 3
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 3
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -2
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5423,6 +6451,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -1 < 3
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 3
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -1
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5435,6 +6468,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   12 > 1
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 3
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "a"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5447,6 +6485,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   12 > 2
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 3
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "bb"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5459,6 +6502,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   12 > 3
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 3
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "ccc"
 
 -------------------------------------------------------------------------------
 Generators internals
@@ -7473,6 +8521,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   3 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 3
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7484,6 +8537,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   4 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 4
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7495,6 +8553,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   5 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 5
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7506,6 +8569,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   6 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 6
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7517,6 +8585,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   -5 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: -5
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7528,6 +8601,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   -4 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: -4
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7539,6 +8617,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   90 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 90
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7550,6 +8633,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   91 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 91
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7561,6 +8649,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   92 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 92
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7572,6 +8665,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   93 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 93
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7583,6 +8681,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   94 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 94
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7594,6 +8697,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   95 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 95
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7605,6 +8713,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   96 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 96
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7616,6 +8729,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   97 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 97
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7627,6 +8745,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   98 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 98
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7638,6 +8761,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   99 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 99
 
 -------------------------------------------------------------------------------
 Nice descriptive name
@@ -9191,6 +10319,9 @@ TestSpecParser.tests.cpp:<line number>: PASSED:
   REQUIRE( spec.hasFilters() )
 with expansion:
   true
+with 1 generator
+  line:36: GENERATE(as<std::string>{}, "[tag with spaces]", "[I said \"good day\" sir!]")
+  value: "[tag with spaces]"
 with message:
   tagString := "[tag with spaces]"
 
@@ -9198,6 +10329,9 @@ TestSpecParser.tests.cpp:<line number>: PASSED:
   REQUIRE( spec.getInvalidSpecs().empty() )
 with expansion:
   true
+with 1 generator
+  line:36: GENERATE(as<std::string>{}, "[tag with spaces]", "[I said \"good day\" sir!]")
+  value: "[tag with spaces]"
 with message:
   tagString := "[tag with spaces]"
 
@@ -9205,6 +10339,9 @@ TestSpecParser.tests.cpp:<line number>: PASSED:
   REQUIRE( spec.matches( testCase ) )
 with expansion:
   true
+with 1 generator
+  line:36: GENERATE(as<std::string>{}, "[tag with spaces]", "[I said \"good day\" sir!]")
+  value: "[tag with spaces]"
 with message:
   tagString := "[tag with spaces]"
 
@@ -9218,6 +10355,9 @@ TestSpecParser.tests.cpp:<line number>: PASSED:
   REQUIRE( spec.hasFilters() )
 with expansion:
   true
+with 1 generator
+  line:36: GENERATE(as<std::string>{}, "[tag with spaces]", "[I said \"good day\" sir!]")
+  value: "[I said "good day" sir!]"
 with message:
   tagString := "[I said "good day" sir!]"
 
@@ -9225,6 +10365,9 @@ TestSpecParser.tests.cpp:<line number>: PASSED:
   REQUIRE( spec.getInvalidSpecs().empty() )
 with expansion:
   true
+with 1 generator
+  line:36: GENERATE(as<std::string>{}, "[tag with spaces]", "[I said \"good day\" sir!]")
+  value: "[I said "good day" sir!]"
 with message:
   tagString := "[I said "good day" sir!]"
 
@@ -9232,6 +10375,9 @@ TestSpecParser.tests.cpp:<line number>: PASSED:
   REQUIRE( spec.matches( testCase ) )
 with expansion:
   true
+with 1 generator
+  line:36: GENERATE(as<std::string>{}, "[tag with spaces]", "[I said \"good day\" sir!]")
+  value: "[I said "good day" sir!]"
 with message:
   tagString := "[I said "good day" sir!]"
 
@@ -9826,11 +10972,17 @@ CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) )
 with expansion:
   {?}
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.waitForKeypress == std::get<1>(input) )
 with expansion:
   0 == 0
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 Process can be configured on command line
@@ -9845,11 +10997,17 @@ CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) )
 with expansion:
   {?}
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.waitForKeypress == std::get<1>(input) )
 with expansion:
   1 == 1
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 Process can be configured on command line
@@ -9864,11 +11022,17 @@ CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) )
 with expansion:
   {?}
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.waitForKeypress == std::get<1>(input) )
 with expansion:
   2 == 2
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 Process can be configured on command line
@@ -9883,11 +11047,17 @@ CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) )
 with expansion:
   {?}
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.waitForKeypress == std::get<1>(input) )
 with expansion:
   3 == 3
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 Process can be configured on command line
@@ -10231,6 +11401,9 @@ RandomNumberGeneration.tests.cpp:<line number>
 
 RandomNumberGeneration.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( Catch::generateRandomSeed(method) )
+with 1 generator
+  line:59: GENERATE(GenerateFrom::Time, GenerateFrom::RandomDevice, GenerateFrom::Default)
+  value: 0
 
 -------------------------------------------------------------------------------
 Random seed generation accepts known methods
@@ -10240,6 +11413,9 @@ RandomNumberGeneration.tests.cpp:<line number>
 
 RandomNumberGeneration.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( Catch::generateRandomSeed(method) )
+with 1 generator
+  line:59: GENERATE(GenerateFrom::Time, GenerateFrom::RandomDevice, GenerateFrom::Default)
+  value: 1
 
 -------------------------------------------------------------------------------
 Random seed generation accepts known methods
@@ -10249,6 +11425,9 @@ RandomNumberGeneration.tests.cpp:<line number>
 
 RandomNumberGeneration.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( Catch::generateRandomSeed(method) )
+with 1 generator
+  line:59: GENERATE(GenerateFrom::Time, GenerateFrom::RandomDevice, GenerateFrom::Default)
+  value: 2
 
 -------------------------------------------------------------------------------
 Random seed generation reports unknown methods
@@ -17649,6 +18828,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str.size() == data.len )
 with expansion:
   3 == 3
+with 1 generator
+  line:94: GENERATE(values<Data>({ {"one", 3}, {"two", 3}, {"three", 5}, {"four", 4} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 strlen3
@@ -17660,6 +18842,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str.size() == data.len )
 with expansion:
   3 == 3
+with 1 generator
+  line:94: GENERATE(values<Data>({ {"one", 3}, {"two", 3}, {"three", 5}, {"four", 4} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 strlen3
@@ -17671,6 +18856,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str.size() == data.len )
 with expansion:
   5 == 5
+with 1 generator
+  line:94: GENERATE(values<Data>({ {"one", 3}, {"two", 3}, {"three", 5}, {"four", 4} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 strlen3
@@ -17682,6 +18870,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str.size() == data.len )
 with expansion:
   4 == 4
+with 1 generator
+  line:94: GENERATE(values<Data>({ {"one", 3}, {"two", 3}, {"three", 5}, {"four", 4} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 tables
@@ -17693,6 +18884,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( strlen(std::get<0>(data)) == static_cast<size_t>(std::get<1>(data)) )
 with expansion:
   5 == 5
+with 1 generator
+  line:63: GENERATE(table<char const*, int>({ tuple_type{"first", 5}, tuple_type{"second", 6}, tuple_type{"third", 5}, tuple_type{"etc...", 6} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 tables
@@ -17704,6 +18898,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( strlen(std::get<0>(data)) == static_cast<size_t>(std::get<1>(data)) )
 with expansion:
   6 == 6
+with 1 generator
+  line:63: GENERATE(table<char const*, int>({ tuple_type{"first", 5}, tuple_type{"second", 6}, tuple_type{"third", 5}, tuple_type{"etc...", 6} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 tables
@@ -17715,6 +18912,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( strlen(std::get<0>(data)) == static_cast<size_t>(std::get<1>(data)) )
 with expansion:
   5 == 5
+with 1 generator
+  line:63: GENERATE(table<char const*, int>({ tuple_type{"first", 5}, tuple_type{"second", 6}, tuple_type{"third", 5}, tuple_type{"etc...", 6} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 tables
@@ -17726,6 +18926,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( strlen(std::get<0>(data)) == static_cast<size_t>(std::get<1>(data)) )
 with expansion:
   6 == 6
+with 1 generator
+  line:63: GENERATE(table<char const*, int>({ tuple_type{"first", 5}, tuple_type{"second", 6}, tuple_type{"third", 5}, tuple_type{"etc...", 6} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 tags with dots in later positions are not parsed as hidden
@@ -18451,5 +19654,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  394 |  304 passed |  83 failed |  7 failed as expected
-assertions: 2299 | 2129 passed | 143 failed | 27 failed as expected
+assertions: 2302 | 2132 passed | 143 failed | 27 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.multi.approved.txt
@@ -226,6 +226,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( counter < 7 )
 with expansion:
   3 < 7
+with 1 generator
+  line:267: GENERATE(1, 2)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1913 - GENERATE inside a for loop should not keep recreating the generator
@@ -237,6 +240,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( counter < 7 )
 with expansion:
   6 < 7
+with 1 generator
+  line:267: GENERATE(1, 2)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1913 - GENERATEs can share a line
@@ -248,6 +254,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i != j )
 with expansion:
   1 != 3
+with 2 generators
+  line:276: GENERATE(1, 2)
+  value: 1
+  line:276: GENERATE(3, 4)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1913 - GENERATEs can share a line
@@ -259,6 +270,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i != j )
 with expansion:
   1 != 4
+with 2 generators
+  line:276: GENERATE(1, 2)
+  value: 1
+  line:276: GENERATE(3, 4)
+  value: 4
 
 -------------------------------------------------------------------------------
 #1913 - GENERATEs can share a line
@@ -270,6 +286,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i != j )
 with expansion:
   2 != 3
+with 2 generators
+  line:276: GENERATE(1, 2)
+  value: 2
+  line:276: GENERATE(3, 4)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1913 - GENERATEs can share a line
@@ -281,6 +302,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i != j )
 with expansion:
   2 != 4
+with 2 generators
+  line:276: GENERATE(1, 2)
+  value: 2
+  line:276: GENERATE(3, 4)
+  value: 4
 
 -------------------------------------------------------------------------------
 #1938 - GENERATE after a section
@@ -304,6 +330,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   1
+with 1 generator
+  line:216: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - GENERATE after a section
@@ -316,6 +345,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 1 generator
+  line:216: GENERATE(1, 2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - GENERATE after a section
@@ -328,6 +360,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 1 generator
+  line:216: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - Section followed by flat generate
@@ -349,6 +384,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 1 generator
+  line:252: GENERATE(2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - Section followed by flat generate
@@ -360,6 +398,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 1 generator
+  line:252: GENERATE(2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - flat generate
@@ -371,6 +412,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   1
+with 1 generator
+  line:223: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - flat generate
@@ -382,6 +426,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 1 generator
+  line:223: GENERATE(1, 2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - flat generate
@@ -393,6 +440,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 1 generator
+  line:223: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - mixed sections and generates
@@ -402,6 +452,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:235: GENERATE(1, 2)
+  value: 1
 with message:
   A
 
@@ -412,6 +465,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:239: GENERATE(3, 4)
+  value: 3
+  line:243: GENERATE(5, 6)
+  value: 5
 with messages:
   i := 1
   j := 3
@@ -425,6 +483,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:235: GENERATE(1, 2)
+  value: 1
+  line:239: GENERATE(3, 4)
+  value: 3
 with message:
   B
 
@@ -435,6 +498,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:243: GENERATE(5, 6)
+  value: 6
 with messages:
   i := 1
   j := 3
@@ -448,6 +514,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:235: GENERATE(1, 2)
+  value: 1
+  line:239: GENERATE(3, 4)
+  value: 4
 with message:
   B
 
@@ -458,6 +529,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:243: GENERATE(5, 6)
+  value: 5
 with messages:
   i := 1
   j := 4
@@ -470,6 +544,13 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 3 generators
+  line:235: GENERATE(1, 2)
+  value: 1
+  line:239: GENERATE(3, 4)
+  value: 4
+  line:243: GENERATE(5, 6)
+  value: 6
 with messages:
   i := 1
   j := 4
@@ -483,6 +564,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:235: GENERATE(1, 2)
+  value: 2
 with message:
   A
 
@@ -493,6 +577,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:239: GENERATE(3, 4)
+  value: 3
+  line:243: GENERATE(5, 6)
+  value: 5
 with messages:
   i := 2
   j := 3
@@ -506,6 +595,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:235: GENERATE(1, 2)
+  value: 2
+  line:239: GENERATE(3, 4)
+  value: 3
 with message:
   B
 
@@ -516,6 +610,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:243: GENERATE(5, 6)
+  value: 6
 with messages:
   i := 2
   j := 3
@@ -529,6 +626,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:235: GENERATE(1, 2)
+  value: 2
+  line:239: GENERATE(3, 4)
+  value: 4
 with message:
   B
 
@@ -539,6 +641,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:243: GENERATE(5, 6)
+  value: 5
 with messages:
   i := 2
   j := 4
@@ -551,6 +656,13 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 3 generators
+  line:235: GENERATE(1, 2)
+  value: 2
+  line:239: GENERATE(3, 4)
+  value: 4
+  line:243: GENERATE(5, 6)
+  value: 6
 with messages:
   i := 2
   j := 4
@@ -566,27 +678,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   1
-
--------------------------------------------------------------------------------
-#1938 - nested generate
--------------------------------------------------------------------------------
-PartTracker.tests.cpp:<line number>
-...............................................................................
-
-PartTracker.tests.cpp:<line number>: PASSED:
-  REQUIRE( m )
-with expansion:
-  1
-
-PartTracker.tests.cpp:<line number>: PASSED:
-  REQUIRE( n )
-with expansion:
-  2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -598,11 +704,47 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 2
+
+PartTracker.tests.cpp:<line number>: PASSED:
+  REQUIRE( n )
+with expansion:
+  2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 2
+
+-------------------------------------------------------------------------------
+#1938 - nested generate
+-------------------------------------------------------------------------------
+PartTracker.tests.cpp:<line number>
+...............................................................................
+
+PartTracker.tests.cpp:<line number>: PASSED:
+  REQUIRE( m )
+with expansion:
+  1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -614,11 +756,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -630,11 +782,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 2
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -646,11 +808,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -662,11 +834,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -678,11 +860,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 2
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -694,11 +886,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1954 - 7 arg template test case sig compiles - 1, 1, 1, 1, 1, 0, 0
@@ -1091,16 +1293,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1112,16 +1335,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1133,16 +1377,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1154,16 +1419,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1175,16 +1461,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1196,16 +1503,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1217,16 +1545,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1238,16 +1587,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1259,16 +1629,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   1 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   1 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 1
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1280,16 +1671,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1301,16 +1713,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1322,16 +1755,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1343,16 +1797,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1364,16 +1839,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1385,16 +1881,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1406,16 +1923,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1427,16 +1965,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1448,16 +2007,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   2 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   2 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 2
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1469,16 +2049,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1490,16 +2091,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1511,16 +2133,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 4
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   4 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 4
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1532,16 +2175,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1553,16 +2217,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1574,16 +2259,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 5
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   5 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 5
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1595,16 +2301,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 7
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 7
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1616,16 +2343,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 8
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 8
 
 -------------------------------------------------------------------------------
 3x3x3 ints
@@ -1637,16 +2385,37 @@ Generators.tests.cpp:<line number>: PASSED:
   CHECK( x < y )
 with expansion:
   3 < 6
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   CHECK( y < z )
 with expansion:
   6 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( x < z )
 with expansion:
   3 < 9
+with 3 generators
+  line:35: GENERATE(1, 2, 3)
+  value: 3
+  line:36: GENERATE(4, 5, 6)
+  value: 6
+  line:37: GENERATE(7, 8, 9)
+  value: 9
 
 -------------------------------------------------------------------------------
 A METHOD_AS_TEST_CASE based test run that fails
@@ -3712,6 +4481,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:250: GENERATE(from_range(data.begin(), data.end()))
+  value: 1
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3724,6 +4496,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:250: GENERATE(from_range(data.begin(), data.end()))
+  value: 3
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3736,6 +4511,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:250: GENERATE(from_range(data.begin(), data.end()))
+  value: 5
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3748,6 +4526,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:250: GENERATE(from_range(data.begin(), data.end()))
+  value: 7
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3760,6 +4541,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:250: GENERATE(from_range(data.begin(), data.end()))
+  value: 9
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3772,6 +4556,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:250: GENERATE(from_range(data.begin(), data.end()))
+  value: 11
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3784,6 +4571,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:254: GENERATE(from_range(make_data_counted()))
+  value: 1
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3796,6 +4586,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:254: GENERATE(from_range(make_data_counted()))
+  value: 3
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3808,6 +4601,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:254: GENERATE(from_range(make_data_counted()))
+  value: 5
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3820,6 +4616,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:254: GENERATE(from_range(make_data_counted()))
+  value: 7
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3832,6 +4631,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:254: GENERATE(from_range(make_data_counted()))
+  value: 9
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -3844,6 +4646,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( elem % 2 == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:254: GENERATE(from_range(make_data_counted()))
+  value: 11
 
 -------------------------------------------------------------------------------
 Copy and then generate a range
@@ -4829,6 +5634,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i % 2 == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:133: GENERATE(filter([] (int val) { return val % 2 == 0; }, values({ 1, 2, 3, 4, 5, 6 })))
+  value: 2
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4842,6 +5650,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i % 2 == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:133: GENERATE(filter([] (int val) { return val % 2 == 0; }, values({ 1, 2, 3, 4, 5, 6 })))
+  value: 4
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4855,6 +5666,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i % 2 == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:133: GENERATE(filter([] (int val) { return val % 2 == 0; }, values({ 1, 2, 3, 4, 5, 6 })))
+  value: 6
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4878,6 +5692,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 4 )
 with expansion:
   1 < 4
+with 1 generator
+  line:143: GENERATE(take(3, values({ 1, 2, 3, 4, 5, 6 })))
+  value: 1
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4890,6 +5707,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 4 )
 with expansion:
   2 < 4
+with 1 generator
+  line:143: GENERATE(take(3, values({ 1, 2, 3, 4, 5, 6 })))
+  value: 2
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4902,6 +5722,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i < 4 )
 with expansion:
   3 < 4
+with 1 generator
+  line:143: GENERATE(take(3, values({ 1, 2, 3, 4, 5, 6 })))
+  value: 3
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4915,6 +5738,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i % 2 == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:149: GENERATE(map([] (int val) { return val * 2; }, values({ 1, 2, 3 })))
+  value: 2
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4928,6 +5754,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i % 2 == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:149: GENERATE(map([] (int val) { return val * 2; }, values({ 1, 2, 3 })))
+  value: 4
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4941,6 +5770,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i % 2 == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:149: GENERATE(map([] (int val) { return val * 2; }, values({ 1, 2, 3 })))
+  value: 6
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4954,6 +5786,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i.size() == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:154: GENERATE(map<std::string>([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })))
+  value: "1"
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4967,6 +5802,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i.size() == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:154: GENERATE(map<std::string>([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })))
+  value: "2"
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4980,6 +5818,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i.size() == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:154: GENERATE(map<std::string>([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })))
+  value: "3"
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -4993,6 +5834,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i.size() == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:159: GENERATE(map([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })))
+  value: "1"
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5006,6 +5850,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i.size() == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:159: GENERATE(map([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })))
+  value: "2"
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5019,6 +5866,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i.size() == 1 )
 with expansion:
   1 == 1
+with 1 generator
+  line:159: GENERATE(map([] (int val) { return std::to_string(val); }, values({ 1, 2, 3 })))
+  value: "3"
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5031,6 +5881,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j > 0 )
 with expansion:
   1 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 1
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5043,6 +5896,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j > 0 )
 with expansion:
   2 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 2
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5055,6 +5911,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j > 0 )
 with expansion:
   3 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 3
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5067,6 +5926,24 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j > 0 )
 with expansion:
   1 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 1
+
+-------------------------------------------------------------------------------
+Generators -- adapters
+  Repeating a generator
+-------------------------------------------------------------------------------
+Generators.tests.cpp:<line number>
+...............................................................................
+
+Generators.tests.cpp:<line number>: PASSED:
+  REQUIRE( j > 0 )
+with expansion:
+  1 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 1
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5079,6 +5956,24 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j > 0 )
 with expansion:
   2 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 2
+
+-------------------------------------------------------------------------------
+Generators -- adapters
+  Repeating a generator
+-------------------------------------------------------------------------------
+Generators.tests.cpp:<line number>
+...............................................................................
+
+Generators.tests.cpp:<line number>: PASSED:
+  REQUIRE( j > 0 )
+with expansion:
+  2 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 2
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5091,6 +5986,24 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j > 0 )
 with expansion:
   3 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 3
+
+-------------------------------------------------------------------------------
+Generators -- adapters
+  Repeating a generator
+-------------------------------------------------------------------------------
+Generators.tests.cpp:<line number>
+...............................................................................
+
+Generators.tests.cpp:<line number>: PASSED:
+  REQUIRE( j > 0 )
+with expansion:
+  3 > 0
+with 1 generator
+  line:165: GENERATE(repeat(2, values({ 1, 2, 3 })))
+  value: 3
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5104,11 +6017,17 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 2 )
 with expansion:
   2 == 2
+with 1 generator
+  line:170: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3, 3 })))
+  value: { 1, 1 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() == chunk2.back() )
 with expansion:
   1 == 1
+with 1 generator
+  line:170: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3, 3 })))
+  value: { 1, 1 }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5122,11 +6041,17 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 2 )
 with expansion:
   2 == 2
+with 1 generator
+  line:170: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3, 3 })))
+  value: { 2, 2 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() == chunk2.back() )
 with expansion:
   2 == 2
+with 1 generator
+  line:170: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3, 3 })))
+  value: { 2, 2 }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5140,11 +6065,17 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 2 )
 with expansion:
   2 == 2
+with 1 generator
+  line:170: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3, 3 })))
+  value: { 3, 3 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() == chunk2.back() )
 with expansion:
   3 == 3
+with 1 generator
+  line:170: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3, 3 })))
+  value: { 3, 3 }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5158,16 +6089,25 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 2 )
 with expansion:
   2 == 2
+with 1 generator
+  line:175: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3 })))
+  value: { 1, 1 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() == chunk2.back() )
 with expansion:
   1 == 1
+with 1 generator
+  line:175: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3 })))
+  value: { 1, 1 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() < 3 )
 with expansion:
   1 < 3
+with 1 generator
+  line:175: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3 })))
+  value: { 1, 1 }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5181,16 +6121,25 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 2 )
 with expansion:
   2 == 2
+with 1 generator
+  line:175: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3 })))
+  value: { 2, 2 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() == chunk2.back() )
 with expansion:
   2 == 2
+with 1 generator
+  line:175: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3 })))
+  value: { 2, 2 }
 
 Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.front() < 3 )
 with expansion:
   2 < 3
+with 1 generator
+  line:175: GENERATE(chunk(2, values({ 1, 1, 2, 2, 3 })))
+  value: { 2, 2 }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5204,6 +6153,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:181: GENERATE(take(3, chunk(0, value(1))))
+  value: {  }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5217,6 +6169,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:181: GENERATE(take(3, chunk(0, value(1))))
+  value: {  }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5230,6 +6185,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( chunk2.size() == 0 )
 with expansion:
   0 == 0
+with 1 generator
+  line:181: GENERATE(take(3, chunk(0, value(1))))
+  value: {  }
 
 -------------------------------------------------------------------------------
 Generators -- adapters
@@ -5253,6 +6211,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -3 < 1
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 1
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -3
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5265,6 +6228,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -2 < 1
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 1
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -2
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5277,6 +6245,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -1 < 1
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 1
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -1
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5289,6 +6262,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   4 > 1
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 1
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "a"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5301,6 +6279,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   4 > 2
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 1
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "bb"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5313,6 +6296,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   4 > 3
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 1
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "ccc"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5325,6 +6313,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -3 < 2
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 2
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -3
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5337,6 +6330,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -2 < 2
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 2
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -2
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5349,6 +6347,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -1 < 2
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 2
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -1
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5361,6 +6364,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   8 > 1
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 2
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "a"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5373,6 +6381,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   8 > 2
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 2
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "bb"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5385,6 +6398,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   8 > 3
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 2
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "ccc"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5397,6 +6415,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -3 < 3
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 3
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -3
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5409,6 +6432,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -2 < 3
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 3
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -2
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5421,6 +6449,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( j < i )
 with expansion:
   -1 < 3
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 3
+  line:22: GENERATE(values({ -3, -2, -1 }))
+  value: -1
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5433,6 +6466,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   12 > 1
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 3
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "a"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5445,6 +6483,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   12 > 2
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 3
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "bb"
 
 -------------------------------------------------------------------------------
 Generators -- simple
@@ -5457,6 +6500,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( 4u * i > str.size() )
 with expansion:
   12 > 3
+with 2 generators
+  line:20: GENERATE(1, 2, 3)
+  value: 3
+  line:28: GENERATE(as<std::string>{}, "a", "bb", "ccc")
+  value: "ccc"
 
 -------------------------------------------------------------------------------
 Generators internals
@@ -7471,6 +8519,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   3 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 3
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7482,6 +8535,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   4 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 4
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7493,6 +8551,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   5 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 5
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7504,6 +8567,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   6 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 6
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7515,6 +8583,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   -5 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: -5
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7526,6 +8599,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   -4 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: -4
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7537,6 +8615,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   90 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 90
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7548,6 +8631,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   91 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 91
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7559,6 +8647,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   92 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 92
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7570,6 +8663,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   93 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 93
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7581,6 +8679,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   94 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 94
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7592,6 +8695,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   95 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 95
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7603,6 +8711,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   96 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 96
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7614,6 +8727,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   97 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 97
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7625,6 +8743,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   98 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 98
 
 -------------------------------------------------------------------------------
 Nested generators and captured variables
@@ -7636,6 +8759,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( values > -6 )
 with expansion:
   99 > -6
+with 2 generators
+  line:217: GENERATE(table<int, int>({ record{3, 7}, record{-5, -3}, record{90, 100} }))
+  value: {?}
+  line:222: GENERATE(range(from, to))
+  value: 99
 
 -------------------------------------------------------------------------------
 Nice descriptive name
@@ -9189,6 +10317,9 @@ TestSpecParser.tests.cpp:<line number>: PASSED:
   REQUIRE( spec.hasFilters() )
 with expansion:
   true
+with 1 generator
+  line:36: GENERATE(as<std::string>{}, "[tag with spaces]", "[I said \"good day\" sir!]")
+  value: "[tag with spaces]"
 with message:
   tagString := "[tag with spaces]"
 
@@ -9196,6 +10327,9 @@ TestSpecParser.tests.cpp:<line number>: PASSED:
   REQUIRE( spec.getInvalidSpecs().empty() )
 with expansion:
   true
+with 1 generator
+  line:36: GENERATE(as<std::string>{}, "[tag with spaces]", "[I said \"good day\" sir!]")
+  value: "[tag with spaces]"
 with message:
   tagString := "[tag with spaces]"
 
@@ -9203,6 +10337,9 @@ TestSpecParser.tests.cpp:<line number>: PASSED:
   REQUIRE( spec.matches( testCase ) )
 with expansion:
   true
+with 1 generator
+  line:36: GENERATE(as<std::string>{}, "[tag with spaces]", "[I said \"good day\" sir!]")
+  value: "[tag with spaces]"
 with message:
   tagString := "[tag with spaces]"
 
@@ -9216,6 +10353,9 @@ TestSpecParser.tests.cpp:<line number>: PASSED:
   REQUIRE( spec.hasFilters() )
 with expansion:
   true
+with 1 generator
+  line:36: GENERATE(as<std::string>{}, "[tag with spaces]", "[I said \"good day\" sir!]")
+  value: "[I said "good day" sir!]"
 with message:
   tagString := "[I said "good day" sir!]"
 
@@ -9223,6 +10363,9 @@ TestSpecParser.tests.cpp:<line number>: PASSED:
   REQUIRE( spec.getInvalidSpecs().empty() )
 with expansion:
   true
+with 1 generator
+  line:36: GENERATE(as<std::string>{}, "[tag with spaces]", "[I said \"good day\" sir!]")
+  value: "[I said "good day" sir!]"
 with message:
   tagString := "[I said "good day" sir!]"
 
@@ -9230,6 +10373,9 @@ TestSpecParser.tests.cpp:<line number>: PASSED:
   REQUIRE( spec.matches( testCase ) )
 with expansion:
   true
+with 1 generator
+  line:36: GENERATE(as<std::string>{}, "[tag with spaces]", "[I said \"good day\" sir!]")
+  value: "[I said "good day" sir!]"
 with message:
   tagString := "[I said "good day" sir!]"
 
@@ -9824,11 +10970,17 @@ CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) )
 with expansion:
   {?}
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.waitForKeypress == std::get<1>(input) )
 with expansion:
   0 == 0
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 Process can be configured on command line
@@ -9843,11 +10995,17 @@ CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) )
 with expansion:
   {?}
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.waitForKeypress == std::get<1>(input) )
 with expansion:
   1 == 1
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 Process can be configured on command line
@@ -9862,11 +11020,17 @@ CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) )
 with expansion:
   {?}
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.waitForKeypress == std::get<1>(input) )
 with expansion:
   2 == 2
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 Process can be configured on command line
@@ -9881,11 +11045,17 @@ CmdLine.tests.cpp:<line number>: PASSED:
   CHECK( cli.parse({"test", "--wait-for-keypress", std::get<0>(input)}) )
 with expansion:
   {?}
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 CmdLine.tests.cpp:<line number>: PASSED:
   REQUIRE( config.waitForKeypress == std::get<1>(input) )
 with expansion:
   3 == 3
+with 1 generator
+  line:514: GENERATE(table<char const*, Catch::WaitForKeypress::When>({ tuple_type{"never", Catch::WaitForKeypress::Never}, tuple_type{"start", Catch::WaitForKeypress::BeforeStart}, tuple_type{"exit", Catch::WaitForKeypress::BeforeExit}, tuple_type{"both", Catch::WaitForKeypress::BeforeStartAndExit}, }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 Process can be configured on command line
@@ -10229,6 +11399,9 @@ RandomNumberGeneration.tests.cpp:<line number>
 
 RandomNumberGeneration.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( Catch::generateRandomSeed(method) )
+with 1 generator
+  line:59: GENERATE(GenerateFrom::Time, GenerateFrom::RandomDevice, GenerateFrom::Default)
+  value: 0
 
 -------------------------------------------------------------------------------
 Random seed generation accepts known methods
@@ -10238,6 +11411,9 @@ RandomNumberGeneration.tests.cpp:<line number>
 
 RandomNumberGeneration.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( Catch::generateRandomSeed(method) )
+with 1 generator
+  line:59: GENERATE(GenerateFrom::Time, GenerateFrom::RandomDevice, GenerateFrom::Default)
+  value: 1
 
 -------------------------------------------------------------------------------
 Random seed generation accepts known methods
@@ -10247,6 +11423,9 @@ RandomNumberGeneration.tests.cpp:<line number>
 
 RandomNumberGeneration.tests.cpp:<line number>: PASSED:
   REQUIRE_NOTHROW( Catch::generateRandomSeed(method) )
+with 1 generator
+  line:59: GENERATE(GenerateFrom::Time, GenerateFrom::RandomDevice, GenerateFrom::Default)
+  value: 2
 
 -------------------------------------------------------------------------------
 Random seed generation reports unknown methods
@@ -17641,6 +18820,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str.size() == data.len )
 with expansion:
   3 == 3
+with 1 generator
+  line:94: GENERATE(values<Data>({ {"one", 3}, {"two", 3}, {"three", 5}, {"four", 4} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 strlen3
@@ -17652,6 +18834,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str.size() == data.len )
 with expansion:
   3 == 3
+with 1 generator
+  line:94: GENERATE(values<Data>({ {"one", 3}, {"two", 3}, {"three", 5}, {"four", 4} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 strlen3
@@ -17663,6 +18848,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str.size() == data.len )
 with expansion:
   5 == 5
+with 1 generator
+  line:94: GENERATE(values<Data>({ {"one", 3}, {"two", 3}, {"three", 5}, {"four", 4} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 strlen3
@@ -17674,6 +18862,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( data.str.size() == data.len )
 with expansion:
   4 == 4
+with 1 generator
+  line:94: GENERATE(values<Data>({ {"one", 3}, {"two", 3}, {"three", 5}, {"four", 4} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 tables
@@ -17685,6 +18876,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( strlen(std::get<0>(data)) == static_cast<size_t>(std::get<1>(data)) )
 with expansion:
   5 == 5
+with 1 generator
+  line:63: GENERATE(table<char const*, int>({ tuple_type{"first", 5}, tuple_type{"second", 6}, tuple_type{"third", 5}, tuple_type{"etc...", 6} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 tables
@@ -17696,6 +18890,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( strlen(std::get<0>(data)) == static_cast<size_t>(std::get<1>(data)) )
 with expansion:
   6 == 6
+with 1 generator
+  line:63: GENERATE(table<char const*, int>({ tuple_type{"first", 5}, tuple_type{"second", 6}, tuple_type{"third", 5}, tuple_type{"etc...", 6} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 tables
@@ -17707,6 +18904,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( strlen(std::get<0>(data)) == static_cast<size_t>(std::get<1>(data)) )
 with expansion:
   5 == 5
+with 1 generator
+  line:63: GENERATE(table<char const*, int>({ tuple_type{"first", 5}, tuple_type{"second", 6}, tuple_type{"third", 5}, tuple_type{"etc...", 6} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 tables
@@ -17718,6 +18918,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( strlen(std::get<0>(data)) == static_cast<size_t>(std::get<1>(data)) )
 with expansion:
   6 == 6
+with 1 generator
+  line:63: GENERATE(table<char const*, int>({ tuple_type{"first", 5}, tuple_type{"second", 6}, tuple_type{"third", 5}, tuple_type{"etc...", 6} }))
+  value: {?}
 
 -------------------------------------------------------------------------------
 tags with dots in later positions are not parsed as hidden
@@ -18443,5 +19646,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  394 |  304 passed |  83 failed |  7 failed as expected
-assertions: 2299 | 2129 passed | 143 failed | 27 failed as expected
+assertions: 2302 | 2132 passed | 143 failed | 27 failed as expected
 

--- a/tests/SelfTest/Baselines/console.swa4.approved.txt
+++ b/tests/SelfTest/Baselines/console.swa4.approved.txt
@@ -228,6 +228,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( counter < 7 )
 with expansion:
   3 < 7
+with 1 generator
+  line:267: GENERATE(1, 2)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1913 - GENERATE inside a for loop should not keep recreating the generator
@@ -239,6 +242,9 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( counter < 7 )
 with expansion:
   6 < 7
+with 1 generator
+  line:267: GENERATE(1, 2)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1913 - GENERATEs can share a line
@@ -250,6 +256,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i != j )
 with expansion:
   1 != 3
+with 2 generators
+  line:276: GENERATE(1, 2)
+  value: 1
+  line:276: GENERATE(3, 4)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1913 - GENERATEs can share a line
@@ -261,6 +272,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i != j )
 with expansion:
   1 != 4
+with 2 generators
+  line:276: GENERATE(1, 2)
+  value: 1
+  line:276: GENERATE(3, 4)
+  value: 4
 
 -------------------------------------------------------------------------------
 #1913 - GENERATEs can share a line
@@ -272,6 +288,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i != j )
 with expansion:
   2 != 3
+with 2 generators
+  line:276: GENERATE(1, 2)
+  value: 2
+  line:276: GENERATE(3, 4)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1913 - GENERATEs can share a line
@@ -283,6 +304,11 @@ Generators.tests.cpp:<line number>: PASSED:
   REQUIRE( i != j )
 with expansion:
   2 != 4
+with 2 generators
+  line:276: GENERATE(1, 2)
+  value: 2
+  line:276: GENERATE(3, 4)
+  value: 4
 
 -------------------------------------------------------------------------------
 #1938 - GENERATE after a section
@@ -306,6 +332,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   1
+with 1 generator
+  line:216: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - GENERATE after a section
@@ -318,6 +347,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 1 generator
+  line:216: GENERATE(1, 2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - GENERATE after a section
@@ -330,6 +362,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 1 generator
+  line:216: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - Section followed by flat generate
@@ -351,6 +386,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 1 generator
+  line:252: GENERATE(2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - Section followed by flat generate
@@ -362,6 +400,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 1 generator
+  line:252: GENERATE(2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - flat generate
@@ -373,6 +414,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   1
+with 1 generator
+  line:223: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - flat generate
@@ -384,6 +428,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 1 generator
+  line:223: GENERATE(1, 2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - flat generate
@@ -395,6 +442,9 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 1 generator
+  line:223: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - mixed sections and generates
@@ -404,6 +454,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:235: GENERATE(1, 2)
+  value: 1
 with message:
   A
 
@@ -414,6 +467,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:239: GENERATE(3, 4)
+  value: 3
+  line:243: GENERATE(5, 6)
+  value: 5
 with messages:
   i := 1
   j := 3
@@ -427,6 +485,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:235: GENERATE(1, 2)
+  value: 1
+  line:239: GENERATE(3, 4)
+  value: 3
 with message:
   B
 
@@ -437,6 +500,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:243: GENERATE(5, 6)
+  value: 6
 with messages:
   i := 1
   j := 3
@@ -450,6 +516,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:235: GENERATE(1, 2)
+  value: 1
+  line:239: GENERATE(3, 4)
+  value: 4
 with message:
   B
 
@@ -460,6 +531,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:243: GENERATE(5, 6)
+  value: 5
 with messages:
   i := 1
   j := 4
@@ -472,6 +546,13 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 3 generators
+  line:235: GENERATE(1, 2)
+  value: 1
+  line:239: GENERATE(3, 4)
+  value: 4
+  line:243: GENERATE(5, 6)
+  value: 6
 with messages:
   i := 1
   j := 4
@@ -485,6 +566,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:235: GENERATE(1, 2)
+  value: 2
 with message:
   A
 
@@ -495,6 +579,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:239: GENERATE(3, 4)
+  value: 3
+  line:243: GENERATE(5, 6)
+  value: 5
 with messages:
   i := 2
   j := 3
@@ -508,6 +597,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:235: GENERATE(1, 2)
+  value: 2
+  line:239: GENERATE(3, 4)
+  value: 3
 with message:
   B
 
@@ -518,6 +612,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:243: GENERATE(5, 6)
+  value: 6
 with messages:
   i := 2
   j := 3
@@ -531,6 +628,11 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 2 generators
+  line:235: GENERATE(1, 2)
+  value: 2
+  line:239: GENERATE(3, 4)
+  value: 4
 with message:
   B
 
@@ -541,6 +643,9 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 1 generator
+  line:243: GENERATE(5, 6)
+  value: 5
 with messages:
   i := 2
   j := 4
@@ -553,6 +658,13 @@ PartTracker.tests.cpp:<line number>
 ...............................................................................
 
 PartTracker.tests.cpp:<line number>: PASSED:
+with 3 generators
+  line:235: GENERATE(1, 2)
+  value: 2
+  line:239: GENERATE(3, 4)
+  value: 4
+  line:243: GENERATE(5, 6)
+  value: 6
 with messages:
   i := 2
   j := 4
@@ -568,27 +680,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   1
-
--------------------------------------------------------------------------------
-#1938 - nested generate
--------------------------------------------------------------------------------
-PartTracker.tests.cpp:<line number>
-...............................................................................
-
-PartTracker.tests.cpp:<line number>: PASSED:
-  REQUIRE( m )
-with expansion:
-  1
-
-PartTracker.tests.cpp:<line number>: PASSED:
-  REQUIRE( n )
-with expansion:
-  2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -600,11 +706,47 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 2
+
+PartTracker.tests.cpp:<line number>: PASSED:
+  REQUIRE( n )
+with expansion:
+  2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 2
+
+-------------------------------------------------------------------------------
+#1938 - nested generate
+-------------------------------------------------------------------------------
+PartTracker.tests.cpp:<line number>
+...............................................................................
+
+PartTracker.tests.cpp:<line number>: PASSED:
+  REQUIRE( m )
+with expansion:
+  1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 1
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -616,11 +758,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -632,11 +784,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 2
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -648,11 +810,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 2
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -664,11 +836,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   1
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 1
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -680,11 +862,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 2
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   2
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 2
 
 -------------------------------------------------------------------------------
 #1938 - nested generate
@@ -696,11 +888,21 @@ PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( m )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 PartTracker.tests.cpp:<line number>: PASSED:
   REQUIRE( n )
 with expansion:
   3
+with 2 generators
+  line:228: GENERATE(1, 2, 3)
+  value: 3
+  line:229: GENERATE(1, 2, 3)
+  value: 3
 
 -------------------------------------------------------------------------------
 #1954 - 7 arg template test case sig compiles - 1, 1, 1, 1, 1, 0, 0


### PR DESCRIPTION
## Description

As a user of catch I often came across the situation that I wanted to know what the generator values were when a test failed. I'm aware of the CAPTURE API, but I always wanted something automatic.

I'm not entirely certain what kind of format would be preferred, so I'm happy to change and implement it for other reporters too. Currently, I've only implemented this for the console reporter.

Some approval tests don't pass even though I haven't touched these reporters. Any help is appreciated.

## GitHub Issues

#2366