### PR TITLE
add versioning to shared libs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -304,7 +304,7 @@ endif()
 set_target_properties(Catch2 PROPERTIES 
                           DEBUG_POSTFIX "d"
                                 VERSION ${PROJECT_VERSION}
-                              SOVERSION ${PROJECT_VERSION_MAJOR})
+                              SOVERSION ${PROJECT_VERSION})
 
 # depend on bunch of C++11 and C++14 features to have C++14 enabled by default
 target_compile_features(Catch2
@@ -354,7 +354,7 @@ set_target_properties(Catch2WithMain
   PROPERTIES
     OUTPUT_NAME "Catch2Main"
         VERSION ${PROJECT_VERSION}
-      SOVERSION ${PROJECT_VERSION_MAJOR}
+      SOVERSION ${PROJECT_VERSION}
 )
 set_target_properties(Catch2WithMain PROPERTIES DEBUG_POSTFIX "d")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -301,7 +301,10 @@ if (ANDROID)
     target_link_libraries(Catch2 INTERFACE log)
 endif()
 
-set_target_properties(Catch2 PROPERTIES DEBUG_POSTFIX "d")
+set_target_properties(Catch2 PROPERTIES 
+                          DEBUG_POSTFIX "d"
+                                VERSION ${PROJECT_VERSION}
+                              SOVERSION ${PROJECT_VERSION_MAJOR})
 
 # depend on bunch of C++11 and C++14 features to have C++14 enabled by default
 target_compile_features(Catch2
@@ -350,6 +353,8 @@ target_link_libraries(Catch2WithMain PUBLIC Catch2)
 set_target_properties(Catch2WithMain
   PROPERTIES
     OUTPUT_NAME "Catch2Main"
+        VERSION ${PROJECT_VERSION}
+      SOVERSION ${PROJECT_VERSION_MAJOR}
 )
 set_target_properties(Catch2WithMain PROPERTIES DEBUG_POSTFIX "d")
 


### PR DESCRIPTION
I'm not sure what you have planned for ABI/API compatibility so versioning it to major.minor might be more appropriate than just major.