### PR TITLE
FileStream: enable automatic flushing

### DIFF
--- a/src/catch2/internal/catch_istream.cpp
+++ b/src/catch2/internal/catch_istream.cpp
@@ -78,6 +78,7 @@ namespace Detail {
             FileStream( std::string const& filename ) {
                 m_ofs.open( filename.c_str() );
                 CATCH_ENFORCE( !m_ofs.fail(), "Unable to open file: '" << filename << '\'' );
+                m_ofs << std::unitbuf;
             }
             ~FileStream() override = default;
         public: // IStream


### PR DESCRIPTION
## Description

when a test executable is killed by a signal (e.g. when executed by ctest with timeout), the reporter files are not flushed. this can lead to incomplete (or empty) report files.
to avoid this we enable automatic flushing via `std::unitbuf`

compare #663
