### PR TITLE
Raise the minimum CMake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,23 +30,21 @@ if (CMAKE_BINARY_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     message(FATAL_ERROR "Building in-source is not supported! Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
 endif()
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.9)
+if(CMAKE_VERSION VERSION_GREATER 3.8)
   # Enable IPO for CMake versions that support it
   cmake_policy(SET CMP0069 NEW)
-  project(Catch2
-    VERSION 3.1.0 # CML version placeholder, don't delete
-    LANGUAGES CXX
-    # HOMEPAGE_URL is not supported until CMake version 3.12, which
-    # we do not target yet.
-    # HOMEPAGE_URL "https://github.com/catchorg/Catch2"
-    DESCRIPTION "A modern, C++-native, unit test framework."
-  )
-else()
-  project(Catch2
-    VERSION 3.1.0 # CML version placeholder, don't delete
-    LANGUAGES CXX
-  )
 endif()
+
+
+project(Catch2
+  VERSION 3.1.0 # CML version placeholder, don't delete
+  LANGUAGES CXX
+  # HOMEPAGE_URL is not supported until CMake version 3.12, which
+  # we do not target yet.
+  # HOMEPAGE_URL "https://github.com/catchorg/Catch2"
+  DESCRIPTION "A modern, C++-native, unit test framework."
+)
+
 
 # Provide path for scripts. We first add path to the scripts we don't use,
 # but projects including us might, and set the path up to parent scope.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 # detect if Catch is being bundled,
 # disable testsuite in that case
@@ -29,12 +29,6 @@ cmake_dependent_option(CATCH_ENABLE_CONFIGURE_TESTS "Enable CMake configuration 
 if (CMAKE_BINARY_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     message(FATAL_ERROR "Building in-source is not supported! Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
 endif()
-
-if(CMAKE_VERSION VERSION_GREATER 3.8)
-  # Enable IPO for CMake versions that support it
-  cmake_policy(SET CMP0069 NEW)
-endif()
-
 
 project(Catch2
   VERSION 3.1.0 # CML version placeholder, don't delete

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 3.10 )
 
 project( Catch2Examples LANGUAGES CXX )
 

--- a/tests/ExtraTests/CMakeLists.txt
+++ b/tests/ExtraTests/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Build extra tests.
 #
 
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 3.10 )
 
 project( Catch2ExtraTests LANGUAGES CXX )
 


### PR DESCRIPTION
The CMake file states 3.5 as minimal version, but 3.8 was actually minimal, see patch https://github.com/catchorg/Catch2/commit/47d56f28a9801911c048d011b375e5631dbb658f. Before that patch 3.9 was needed. This patch really fixes compatibility with 3.5.