### PR TITLE
Add C++ version for bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -78,6 +78,7 @@ cc_library(
     linkstatic = True,
     visibility = ["//visibility:public"],
     deps = [":catch2_generated"],
+    copts = ["-std=c++14"],
 )
 
 # Static library, with main.
@@ -88,4 +89,5 @@ cc_library(
     linkstatic = True,
     visibility = ["//visibility:public"],
     deps = [":catch2"],
+    copts = ["-std=c++14"],
 )


### PR DESCRIPTION
## Description
When adding Catch2 to the bazel workspace, the bazel build of the static libraries will fail if the C++ version of the project is less than C++14 due to use of `std::enable_if_t`. This calls out the C++ version explicitly in the compilation.

## GitHub Issues
Sort of related to #2462 if you're using bazel to manage dependencies instead of a package manager.