### PR TITLE
Don't expose header windows.h in catch_all.hpp

### DIFF
--- a/src/catch2/catch_all.hpp
+++ b/src/catch2/catch_all.hpp
@@ -114,7 +114,6 @@
 #include <catch2/internal/catch_unique_ptr.hpp>
 #include <catch2/internal/catch_void_type.hpp>
 #include <catch2/internal/catch_wildcard_pattern.hpp>
-#include <catch2/internal/catch_windows_h_proxy.hpp>
 #include <catch2/internal/catch_xmlwriter.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
 #include <catch2/reporters/catch_reporters_all.hpp>

--- a/src/catch2/internal/catch_windows_h_proxy.hpp
+++ b/src/catch2/internal/catch_windows_h_proxy.hpp
@@ -21,11 +21,7 @@
 #  define WIN32_LEAN_AND_MEAN
 #endif
 
-#ifdef __AFXDLL
-#include <AfxWin.h>
-#else
 #include <windows.h>
-#endif
 
 #endif // defined(CATCH_PLATFORM_WINDOWS)
 

--- a/tools/scripts/checkConvenienceHeaders.py
+++ b/tools/scripts/checkConvenienceHeaders.py
@@ -120,7 +120,8 @@ def verify_convenience_header(folder):
     # 4) Are all required headers present?
     file_incs_set = set(file_incs)
     for include in target_includes:
-        if include not in file_incs_set:
+        if (include not in file_incs_set and
+            include != 'catch2/internal/catch_windows_h_proxy.hpp'):
             errors_found = True
             print("'{}': missing include '{}'".format(header_name, include))
 

--- a/tools/scripts/generateAmalgamatedFiles.py
+++ b/tools/scripts/generateAmalgamatedFiles.py
@@ -108,6 +108,7 @@ def generate_cpp():
     with open(output_cpp, mode='w', encoding='utf-8') as cpp:
         cpp.write(formatted_file_header(Version()))
         cpp.write('\n#include "catch_amalgamated.hpp"\n')
+        concatenate_file(cpp, os.path.join(root_path, 'catch2/internal/catch_windows_h_proxy.hpp'), False)
         for file in cpp_files:
             concatenate_file(cpp, file, False)
     print('Concatenated {} cpp files'.format(len(cpp_files)))


### PR DESCRIPTION
Fixes #2432.