### PR TITLE
Fix building as shared library with MSVC.

### DIFF
--- a/CMake/CatchConfigOptions.cmake
+++ b/CMake/CatchConfigOptions.cmake
@@ -67,6 +67,7 @@ set(_OtherConfigOptions
 foreach(OptionName ${_OtherConfigOptions})
   AddConfigOption(${OptionName})
 endforeach()
+set(CATCH_CONFIG_SHARED_LIBRARY ${BUILD_SHARED_LIBS})
 
 set(CATCH_CONFIG_DEFAULT_REPORTER "console" CACHE STRING "Read docs/configuration.md for details. The name of the reporter should be without quotes.")
 set(CATCH_CONFIG_CONSOLE_WIDTH "80" CACHE STRING "Read docs/configuration.md for details. Must form a valid integer literal.")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -409,6 +409,10 @@ if (CATCH_BUILD_EXAMPLES OR CATCH_BUILD_EXTRA_TESTS)
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/generated-includes>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
+    target_compile_definitions(Catch2_buildall_interface
+      INTERFACE
+        CATCH_CONFIG_STATIC
+    )
     target_compile_features(Catch2_buildall_interface
       INTERFACE
         cxx_alignas

--- a/src/catch2/catch_tostring.hpp
+++ b/src/catch2/catch_tostring.hpp
@@ -296,13 +296,13 @@ namespace Catch {
     template<>
     struct StringMaker<float> {
         static std::string convert(float value);
-        static int precision;
+        CATCH_EXPORT static int precision;
     };
 
     template<>
     struct StringMaker<double> {
         static std::string convert(double value);
-        static int precision;
+        CATCH_EXPORT static int precision;
     };
 
     template <typename T>

--- a/src/catch2/catch_user_config.hpp.in
+++ b/src/catch2/catch_user_config.hpp.in
@@ -181,6 +181,8 @@
 #cmakedefine CATCH_CONFIG_PREFIX_ALL
 #cmakedefine CATCH_CONFIG_WINDOWS_CRTDBG
 
+#cmakedefine CATCH_CONFIG_SHARED_LIBRARY
+
 
 // ------
 // "Variable" defines, these have actual values

--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -376,5 +376,15 @@
 #    define CATCH_CONFIG_COLOUR_WIN32
 #endif
 
+#if defined( CATCH_CONFIG_SHARED_LIBRARY ) && defined( _MSC_VER ) && \
+    !defined( CATCH_CONFIG_STATIC )
+#    ifdef Catch2_EXPORTS
+#        define CATCH_EXPORT //__declspec( dllexport ) // not needed
+#    else
+#        define CATCH_EXPORT __declspec( dllimport )
+#    endif
+#else
+#    define CATCH_EXPORT
+#endif
 
 #endif // CATCH_COMPILER_CAPABILITIES_HPP_INCLUDED

--- a/src/catch2/internal/catch_context.hpp
+++ b/src/catch2/internal/catch_context.hpp
@@ -8,6 +8,8 @@
 #ifndef CATCH_CONTEXT_HPP_INCLUDED
 #define CATCH_CONTEXT_HPP_INCLUDED
 
+#include <catch2/internal/catch_compiler_capabilities.hpp>
+
 namespace Catch {
 
     class IResultCapture;
@@ -28,7 +30,7 @@ namespace Catch {
         virtual void setConfig( IConfig const* config ) = 0;
 
     private:
-        static IMutableContext *currentContext;
+        CATCH_EXPORT static IMutableContext* currentContext;
         friend IMutableContext& getCurrentMutableContext();
         friend void cleanUpContext();
         static void createContext();


### PR DESCRIPTION
Fixes #2482.

For some more info see https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html.

> For global data symbols, __declspec(dllimport) must still be used when compiling against the code in the .dll.

See also this https://cmake.org/cmake/help/latest/prop_tgt/DEFINE_SYMBOL.html . That is where the define `Catch2_EXPORTS` comes from.