### PR TITLE
Suppress clang-tidy modernize-avoid-c-arrays for TEMPLATE_TEST_CASE

### DIFF
--- a/src/catch2/internal/catch_template_test_registry.hpp
+++ b/src/catch2/internal/catch_template_test_registry.hpp
@@ -89,8 +89,7 @@
                     (void)expander{(reg_test(Types{}, Catch::NameAndTags{ Name " - " + std::string(tmpl_types[index]), Tags } ), index++)... };/* NOLINT */ \
                 }\
             };\
-            /* NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) */\
-            static int INTERNAL_CATCH_UNIQUE_NAME( globalRegistrar ) = [](){\
+            static const int INTERNAL_CATCH_UNIQUE_NAME( globalRegistrar ) = [](){\
             TestName<INTERNAL_CATCH_MAKE_TYPE_LISTS_FROM_TYPES(__VA_ARGS__)>();\
             return 0;\
         }();\

--- a/src/catch2/internal/catch_template_test_registry.hpp
+++ b/src/catch2/internal/catch_template_test_registry.hpp
@@ -84,11 +84,12 @@
             struct TestName{\
                 TestName(){\
                     size_t index = 0;                                    \
-                    constexpr char const* tmpl_types[] = {CATCH_REC_LIST(INTERNAL_CATCH_STRINGIZE_WITHOUT_PARENS, __VA_ARGS__)};\
-                    using expander = size_t[];\
+                    constexpr char const* tmpl_types[] = {CATCH_REC_LIST(INTERNAL_CATCH_STRINGIZE_WITHOUT_PARENS, __VA_ARGS__)}; /* NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays) */\
+                    using expander = size_t[]; /* NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays) */\
                     (void)expander{(reg_test(Types{}, Catch::NameAndTags{ Name " - " + std::string(tmpl_types[index]), Tags } ), index++)... };/* NOLINT */ \
                 }\
             };\
+            /* NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) */\
             static int INTERNAL_CATCH_UNIQUE_NAME( globalRegistrar ) = [](){\
             TestName<INTERNAL_CATCH_MAKE_TYPE_LISTS_FROM_TYPES(__VA_ARGS__)>();\
             return 0;\

--- a/src/catch2/internal/catch_template_test_registry.hpp
+++ b/src/catch2/internal/catch_template_test_registry.hpp
@@ -84,8 +84,8 @@
             struct TestName{\
                 TestName(){\
                     size_t index = 0;                                    \
-                    constexpr char const* tmpl_types[] = {CATCH_REC_LIST(INTERNAL_CATCH_STRINGIZE_WITHOUT_PARENS, __VA_ARGS__)}; /* NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays) */\
-                    using expander = size_t[]; /* NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays) */\
+                    constexpr char const* tmpl_types[] = {CATCH_REC_LIST(INTERNAL_CATCH_STRINGIZE_WITHOUT_PARENS, __VA_ARGS__)}; /* NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,hicpp-avoid-c-arrays) */\
+                    using expander = size_t[]; /* NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,hicpp-avoid-c-arrays) */\
                     (void)expander{(reg_test(Types{}, Catch::NameAndTags{ Name " - " + std::string(tmpl_types[index]), Tags } ), index++)... };/* NOLINT */ \
                 }\
             };\


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

- Suppress the clang-tidy warnings `cppcoreguidelines-avoid-c-arrays`, `modernize-avoid-c-arrays` for:
https://github.com/catchorg/Catch2/blob/0de60d8e7ead1ddd5ba8c46b901c122eac20bf94/src/catch2/internal/catch_template_test_registry.hpp#L87

- Suppress the clang-tidy warnings `cppcoreguidelines-avoid-c-arrays`, `modernize-avoid-c-arrays` for:
https://github.com/catchorg/Catch2/blob/0de60d8e7ead1ddd5ba8c46b901c122eac20bf94/src/catch2/internal/catch_template_test_registry.hpp#L88

- Suppress `cppcoreguidelines-avoid-non-const-global-variables` for: 
https://github.com/catchorg/Catch2/blob/0de60d8e7ead1ddd5ba8c46b901c122eac20bf94/src/catch2/internal/catch_template_test_registry.hpp#L92

### The why:
I am using catch2 `TEMPLATE_TEST_CASE` for my project. My project is seeing clang-tidy failures as seen by someone else also #2095.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
Closes #2095

