### PR TITLE
Mute the sign conversion warning with explicit cast

### DIFF
--- a/src/catch2/catch_tostring.hpp
+++ b/src/catch2/catch_tostring.hpp
@@ -43,7 +43,7 @@ namespace Catch {
         inline std::size_t catch_strnlen(const char *str, std::size_t n) {
             auto ret = std::char_traits<char>::find(str, n, '\0');
             if (ret != nullptr) {
-                return ret - str;
+                return static_cast<std::size_t>(ret - str);
             }
             return n;
         }


### PR DESCRIPTION
## Description

Muted the sign conversion warning caused by implicit cast of returned result of `catch_strnlen()`.
Used `static_cast` to cast the type.

## GitHub Issues

Closes #2545 