### PR TITLE
Make MatcherGenericBase copy constructor take const parameter.

### DIFF
--- a/src/catch2/matchers/catch_matchers_templated.hpp
+++ b/src/catch2/matchers/catch_matchers_templated.hpp
@@ -24,7 +24,7 @@ namespace Matchers {
         MatcherGenericBase() = default;
         ~MatcherGenericBase() override; // = default;
 
-        MatcherGenericBase(MatcherGenericBase&) = default;
+        MatcherGenericBase(MatcherGenericBase const&) = default;
         MatcherGenericBase(MatcherGenericBase&&) = default;
 
         MatcherGenericBase& operator=(MatcherGenericBase const&) = delete;


### PR DESCRIPTION
## Description
Fix the copy constructor signature of `MatcherGenericBase` to take a `const` parameter. While C++ allows copy constructors taking non-const parameters, this is very atypical and blocks making copies of const objects.

## GitHub Issues
