### PR TITLE
adds clang-tidy warning suppressions for `CHECK` and `TEST_CASE`

### DIFF
--- a/src/catch2/catch_test_macros.hpp
+++ b/src/catch2/catch_test_macros.hpp
@@ -137,7 +137,7 @@
   #define CHECK_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( "CHECK_THROWS_AS", exceptionType, Catch::ResultDisposition::ContinueOnFailure, expr )
   #define CHECK_NOTHROW( ... ) INTERNAL_CATCH_NO_THROW( "CHECK_NOTHROW", Catch::ResultDisposition::ContinueOnFailure, __VA_ARGS__ )
 
-  #define TEST_CASE( ... ) INTERNAL_CATCH_TESTCASE( __VA_ARGS__ )
+  #define TEST_CASE( ... ) INTERNAL_CATCH_TESTCASE( __VA_ARGS__ ) /* NOLINT(cppcoreguidelines-avoid-non-const-global-variables) */
   #define TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TEST_CASE_METHOD( className, __VA_ARGS__ )
   #define METHOD_AS_TEST_CASE( method, ... ) INTERNAL_CATCH_METHOD_AS_TEST_CASE( method, __VA_ARGS__ )
   #define REGISTER_TEST_CASE( Function, ... ) INTERNAL_CATCH_REGISTER_TESTCASE( Function, __VA_ARGS__ )

--- a/src/catch2/internal/catch_test_macro_impl.hpp
+++ b/src/catch2/internal/catch_test_macro_impl.hpp
@@ -47,7 +47,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_TEST( macroName, resultDisposition, ... ) \
-    do { /* NOLINT(bugprone-infinite-loop) */ \
+    do { /* NOLINT(bugprone-infinite-loop, cppcoreguidelines-avoid-do-while) */ \
         /* The expression should not be evaluated, but warnings should hopefully be checked */ \
         CATCH_INTERNAL_IGNORE_BUT_WARN(__VA_ARGS__); \
         Catch::AssertionHandler catchAssertionHandler( macroName##_catch_sr, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(__VA_ARGS__), resultDisposition ); \


### PR DESCRIPTION
Both `CHECK` and `TEST_CASE` were giving warnings at the point of use. This commit makes it so that they do not (for now).

Checks disabled:

* `cppcoreguidelines-avoid-do-while` (for `CHECK`)
* `cppcoreguidelines-avoid-non-const-global-variables` (for `TEST_CASE`)
