### PR TITLE
Avoid usage of master when possible

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1319,7 +1319,7 @@ CHM_FILE               =
 HHC_LOCATION           =
 
 # The GENERATE_CHI flag controls if a separate .chi index file is generated
-# (YES) or that it should be included in the master .chm file (NO).
+# (YES) or that it should be included in the main .chm file (NO).
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -155,7 +155,7 @@ with expansion:
 
 
 ### Clang/G++ -- skipping leaf sections after an exception
-Some versions of `libc++` and `libstdc++` (or their runtimes) have a bug with `std::uncaught_exception()` getting stuck returning `true` after rethrow, even if there are no active exceptions. One such case is this snippet, which skipped the sections "a" and "b", when compiled against `libcxxrt` from master
+Some versions of `libc++` and `libstdc++` (or their runtimes) have a bug with `std::uncaught_exception()` getting stuck returning `true` after rethrow, even if there are no active exceptions. One such case is this snippet, which skipped the sections "a" and "b", when compiled against `libcxxrt` from the master branch
 ```cpp
 #include <catch2/catch_test_macros.hpp>
 


### PR DESCRIPTION
Signed-off-by: Sergio Arroutbi <sarroutb@redhat.com>

## Description
References to "master" should be avoided when possible
