### PR TITLE
.clang-format: `SortIncludes: True` is incorrect

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@ Standard: c++14
 
 # Note that we cannot use IncludeIsMainRegex functionality, because it
 # does not support includes in angle brackets (<>)
-SortIncludes: True
+SortIncludes: CaseInsensitive
 IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '<catch2/.*\.hpp>'
@@ -21,24 +21,24 @@ AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLambdasOnASingleLine: Inline
 
-AccessModifierOffset: '-4'
+AccessModifierOffset: -4
 AlignEscapedNewlines: Left
-AllowAllConstructorInitializersOnNextLine: 'true'
-BinPackArguments: 'false'
-BinPackParameters: 'false'
+AllowAllConstructorInitializersOnNextLine: true
+BinPackArguments: false
+BinPackParameters: false
 BreakConstructorInitializers: AfterColon
-ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
-DerivePointerAlignment: 'false'
-FixNamespaceComments: 'true'
-IndentCaseLabels: 'false'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerAlignment: false
+FixNamespaceComments: true
+IndentCaseLabels: false
 IndentPPDirectives: AfterHash
-IndentWidth: '4'
+IndentWidth: 4
 NamespaceIndentation: All
 PointerAlignment: Left
-SpaceBeforeCtorInitializerColon: 'false'
-SpaceInEmptyParentheses: 'false'
-SpacesInParentheses: 'true'
-TabWidth: '4'
+SpaceBeforeCtorInitializerColon: false
+SpaceInEmptyParentheses: false
+SpacesInParentheses: true
+TabWidth: 4
 UseTab: Never
 
 ...


### PR DESCRIPTION
Also `'false'` instead of `false` gives warnings like "Required: boolean. Actual: string. "
