### PR TITLE
Keep generated headers within project binary directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ set(BENCHMARK_FILES ${BENCHMARK_HEADERS} ${BENCHMARK_SOURCES})
 
 
 set(IMPL_HEADERS
- "${CMAKE_BINARY_DIR}/generated-includes/catch2/catch_user_config.hpp"
+ "${PROJECT_BINARY_DIR}/generated-includes/catch2/catch_user_config.hpp"
   ${SOURCES_DIR}/catch_user_config.hpp.in
   ${SOURCES_DIR}/catch_all.hpp
   ${SOURCES_DIR}/catch_approx.hpp
@@ -321,7 +321,7 @@ set(ALL_FILES
 )
 
 set(FILTERED_FILES ${ALL_FILES})
-list(REMOVE_ITEM FILTERED_FILES "${CMAKE_BINARY_DIR}/generated-includes/catch2/catch_user_config.hpp")
+list(REMOVE_ITEM FILTERED_FILES "${PROJECT_BINARY_DIR}/generated-includes/catch2/catch_user_config.hpp")
 source_group(
   TREE ${SOURCES_DIR}
   PREFIX sources
@@ -329,7 +329,7 @@ source_group(
 )
 source_group("generated headers"
   FILES
-    "${CMAKE_BINARY_DIR}/generated-includes/catch2/catch_user_config.hpp"
+    "${PROJECT_BINARY_DIR}/generated-includes/catch2/catch_user_config.hpp"
 )
 
 add_library(Catch2 ${ALL_FILES})
@@ -372,13 +372,13 @@ target_compile_features(Catch2
 
 configure_file(
   "${SOURCES_DIR}/catch_user_config.hpp.in"
-  "${CMAKE_BINARY_DIR}/generated-includes/catch2/catch_user_config.hpp"
+  "${PROJECT_BINARY_DIR}/generated-includes/catch2/catch_user_config.hpp"
 )
 
 target_include_directories(Catch2
   PUBLIC
     $<BUILD_INTERFACE:${SOURCES_DIR}/..>
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/generated-includes>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/generated-includes>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
@@ -426,7 +426,7 @@ if (NOT_SUBPROJECT)
     install(
       DIRECTORY
         "${SOURCES_DIR}"
-        "${CMAKE_BINARY_DIR}/generated-includes/catch2" # Also install the generated header
+        "${PROJECT_BINARY_DIR}/generated-includes/catch2" # Also install the generated header
       DESTINATION
         "${CMAKE_INSTALL_INCLUDEDIR}"
       FILES_MATCHING
@@ -447,7 +447,7 @@ if (CATCH_BUILD_EXAMPLES OR CATCH_BUILD_EXTRA_TESTS)
     target_include_directories(Catch2_buildall_interface
       INTERFACE
         $<BUILD_INTERFACE:${SOURCES_DIR}/..>
-        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/generated-includes>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/generated-includes>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
     target_compile_definitions(Catch2_buildall_interface


### PR DESCRIPTION
## Description
This stops the `generated-includes/` directory from appearing in the build directories of projects that consume Catch2 via `add_subdirectory`.
