### PR TITLE
Fix build with GCC 13 (add missing <cstdint> include)

### DIFF
--- a/src/catch2/catch_test_case_info.hpp
+++ b/src/catch2/catch_test_case_info.hpp
@@ -15,6 +15,7 @@
 #include <catch2/internal/catch_unique_ptr.hpp>
 
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/catch2/internal/catch_string_manip.hpp
+++ b/src/catch2/internal/catch_string_manip.hpp
@@ -10,6 +10,7 @@
 
 #include <catch2/internal/catch_stringref.hpp>
 
+#include <cstdint>
 #include <string>
 #include <iosfwd>
 #include <vector>

--- a/src/catch2/internal/catch_xmlwriter.cpp
+++ b/src/catch2/internal/catch_xmlwriter.cpp
@@ -11,6 +11,7 @@
 #include <catch2/internal/catch_enforce.hpp>
 #include <catch2/internal/catch_xmlwriter.hpp>
 
+#include <cstdint>
 #include <iomanip>
 #include <type_traits>
 


### PR DESCRIPTION
## Description
GCC 13 (as usual for new compiler releases) shuffles around some internal includes and so <cstdint> is no longer transitively included.

Explicitly include <cstdint> for uint64_t.

```
FAILED: src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o
/usr/lib/ccache/bin/g++-13  -I/var/tmp/portage/dev-cpp/catch-3.0.1/work/Catch2-3.0.1/src/catch2/.. -I/var/tmp/portage/dev-cpp/catch-3.0.1/work/Catch2-3.0.1_build/generated-includes  -O2 -pipe
-march=native -fdiagnostics-color=always -frecord-gcc-switches -Wreturn-type -D_GLIBCXX_ASSERTIONS  -ggdb3 -fdiagnostics-color=always
-ffile-prefix-map=/var/tmp/portage/dev-cpp/catch-3.0.1/work/Catch2-3.0.1=. -Wall -Wc++20-compat -Wcast-align -Wcatch-value -Wdeprecated -Wexceptions -Wextra -Wextra-semi -Wfloat-equal -Winit-self
-Wmisleading-indentation -Wmismatched-new-delete -Wmismatched-tags -Wmissing-braces -Wmissing-declarations -Wmissing-noreturn -Wnull-dereference -Wold-style-cast -Woverloaded-virtual -Wparentheses
-Wpedantic -Wreorder -Wshadow -Wstrict-aliasing -Wsuggest-override -Wundef -Wuninitialized -Wunreachable-code -Wunused -Wunused-function -Wunused-parameter -Wvla -MD -MT
src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o -MF src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o.d -o src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o -c
/var/tmp/portage/dev-cpp/catch-3.0.1/work/Catch2-3.0.1/src/catch2/internal/catch_clara.cpp
In file included from /var/tmp/portage/dev-cpp/catch-3.0.1/work/Catch2-3.0.1/src/catch2/internal/catch_clara.cpp:12:
/var/tmp/portage/dev-cpp/catch-3.0.1/work/Catch2-3.0.1/src/catch2/../catch2/internal/catch_string_manip.hpp:47:14: error: 'uint64_t' in namespace 'std' does not name a type; did you mean 'wint_t'?
   47 |         std::uint64_t m_count;
      |              ^~~~~~~~
      |              wint_t
/var/tmp/portage/dev-cpp/catch-3.0.1/work/Catch2-3.0.1/src/catch2/../catch2/internal/catch_string_manip.hpp:51:42: error: expected ')' before 'count'
   51 |         constexpr pluralise(std::uint64_t count, StringRef label):
      |                            ~             ^~~~~~
      |                                          )
```