### PR TITLE
catch_debugger.hpp: restore PPC support

### DIFF
--- a/src/catch2/internal/catch_debugger.hpp
+++ b/src/catch2/internal/catch_debugger.hpp
@@ -19,7 +19,10 @@ namespace Catch {
     #if defined(__i386__) || defined(__x86_64__)
         #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
     #elif defined(__aarch64__)
-        #define CATCH_TRAP()  __asm__(".inst 0xd43e0000")
+        #define CATCH_TRAP() __asm__(".inst 0xd43e0000")
+    #elif defined(__POWERPC__)
+        #define CATCH_TRAP() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
+        : : : "memory","r0","r3","r4" ) /* NOLINT */
     #endif
 
 #elif defined(CATCH_PLATFORM_IPHONE)


### PR DESCRIPTION
This restores PPC support in `catch_debugger.hpp`.

Code from:
https://github.com/osmcode/libosmium/blob/b293e96dbe2e3a9afe400768a990e107f8af3f02/test/catch/catch.hpp#L2128
https://gitlab.labos.polytechnique.fr/massot-team/mutationpp/-/blob/fd5188804fadbce5029d3a83c89320d201181a61/thirdparty/catch/include/internal/catch_debugger.h#L26
It obviously was there, but got lost on the way.