### PR TITLE
Document template macros are in spearate header

### DIFF
--- a/docs/test-cases-and-sections.md
+++ b/docs/test-cases-and-sections.md
@@ -168,7 +168,11 @@ Other than the additional prefixes and the formatting in the console reporter th
 
 In addition to `TEST_CASE`s, Catch2 also supports test cases parametrised
 by types, in the form of `TEMPLATE_TEST_CASE`,
-`TEMPLATE_PRODUCT_TEST_CASE` and `TEMPLATE_LIST_TEST_CASE`.
+`TEMPLATE_PRODUCT_TEST_CASE` and `TEMPLATE_LIST_TEST_CASE`. These macros
+are defined in the `catch_template_test_macros.hpp` header, so compiling
+the code examples below also requires
+`#include <catch2/catch_template_test_macros.hpp>`.
+
 
 * **TEMPLATE_TEST_CASE(** _test name_ , _tags_,  _type1_, _type2_, ..., _typen_ **)**
 
@@ -290,7 +294,9 @@ TEMPLATE_LIST_TEST_CASE("Template test case with test types specified inside std
 In addition to [type parametrised test cases](#type-parametrised-test-cases) Catch2 also supports
 signature base parametrised test cases, in form of `TEMPLATE_TEST_CASE_SIG` and `TEMPLATE_PRODUCT_TEST_CASE_SIG`.
 These test cases have similar syntax like [type parametrised test cases](#type-parametrised-test-cases), with one
-additional positional argument which specifies the signature.
+additional positional argument which specifies the signature. These macros are defined in the
+`catch_template_test_macros.hpp` header, so compiling the code examples below also requires
+`#include <catch2/catch_template_test_macros.hpp>`.
 
 ### Signature
 Signature has some strict rules for these tests cases to work properly:


### PR DESCRIPTION
## Description

Type parametrised and signature parametrised test macros are now in their own header. The documentation should reflect that.