### PR TITLE
Consider Visual C++ 2015 Update 3 in regard to 'extended constexpr'

### DIFF
--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -37,6 +37,17 @@
 #    define CATCH_CPP17_OR_GREATER
 #  endif
 
+// Visual C++ Update 3 reports itself as being capable of C++14 but is still
+// lacking
+// - Extended constexpr
+// - Aggregates with default member initializers
+#    if ( __cpp_constexpr >= 201304L ) || \
+        ( defined( _MSC_VER ) && _MSC_VER > 1900 )
+#        define CATCH_INTERNAL_RELAXED_CONSTEXPR_FUNCTION constexpr
+#    else
+#        define CATCH_INTERNAL_RELAXED_CONSTEXPR_FUNCTION
+#    endif
+
 #endif
 
 // Only GCC compiler should be used in this block, so other compilers trying to

--- a/src/catch2/internal/catch_stringref.hpp
+++ b/src/catch2/internal/catch_stringref.hpp
@@ -8,6 +8,8 @@
 #ifndef CATCH_STRINGREF_HPP_INCLUDED
 #define CATCH_STRINGREF_HPP_INCLUDED
 
+#include <catch2/internal/catch_compiler_capabilities.hpp>
+
 #include <cstddef>
 #include <string>
 #include <iosfwd>
@@ -54,7 +56,7 @@ namespace Catch {
             return !(*this == other);
         }
 
-        constexpr auto operator[] ( size_type index ) const noexcept -> char {
+        CATCH_INTERNAL_RELAXED_CONSTEXPR_FUNCTION auto operator[] ( size_type index ) const noexcept -> char {
             assert(index < m_size);
             return m_start[index];
         }
@@ -72,7 +74,7 @@ namespace Catch {
         // Returns a substring of [start, start + length).
         // If start + length > size(), then the substring is [start, start + size()).
         // If start > size(), then the substring is empty.
-        constexpr StringRef substr(size_type start, size_type length) const noexcept {
+        CATCH_INTERNAL_RELAXED_CONSTEXPR_FUNCTION StringRef substr(size_type start, size_type length) const noexcept {
             if (start < m_size) {
                 const auto shortened_size = m_size - start;
                 return StringRef(m_start + start, (shortened_size < length) ? shortened_size : length);


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
What: Consider Visual C++ 2015 Update 3 in regard to 'extended constexpr'
Why: Visual C++ Update 3 reports itself as being capable of C++14 but is still lacking
- Extended constexpr
- Aggregates with default member initializers

It would be great to keep VC++ 2015 Update 3 for a while longer, as long as Microsoft still supports it (extended support until the end of 2025) and/or vcpkg lists it as a minimum requirement.
This would ensure compatibility for other libraries/projects being dependent on Catch2.


## GitHub Issues
#2624 