### PR TITLE
Export symbols for all compilers on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -487,12 +487,10 @@ set(CATCH_WARNING_TARGETS ${CATCH_WARNING_TARGETS} PARENT_SCOPE)
 # so we want to check & warn users if they do this. However, we won't abort
 # the configuration step so that we don't have to also provide an override.
 if (BUILD_SHARED_LIBS)
-    if (MSVC)
-        set_target_properties(Catch2 Catch2WithMain
-          PROPERTIES
-            WINDOWS_EXPORT_ALL_SYMBOLS ON
-        )
-    endif()
+    set_target_properties(Catch2 Catch2WithMain
+      PROPERTIES
+        WINDOWS_EXPORT_ALL_SYMBOLS ON
+    )
 
     get_target_property(_VisPreset Catch2 CXX_VISIBILITY_PRESET)
     if (NOT MSVC AND _VisPreset STREQUAL "hidden")


### PR DESCRIPTION
## Description
Linking Catch2 v3.2.1 as a shared library when using Clang on Windows fails because symbols only get exported for MSVC (and MSVC-like compilers) but not for Clang. Removing this conditional means that Clang on Windows now gets this too. This should have no effect on compilers on non-Windows platforms. I believe we could move this out of the `if(BUILD_SHARED_LIBS)` block as well since it will just do nothing if you're building static libraries.

Here are two CI pipeline runs from SFML illustrating before and after applying this patch.

Before:
https://github.com/ChrisThrasher/SFML/actions/runs/3946193148

After
https://github.com/ChrisThrasher/SFML/actions/runs/3972002714