### PR TITLE
Suppress declared_but_not_referenced warning for NVHPC

### DIFF
--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -41,7 +41,7 @@
 
 // Only GCC compiler should be used in this block, so other compilers trying to
 // mask themselves as GCC should be ignored.
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC) && !defined(__CUDACC__) && !defined(__LCC__)
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC) && !defined(__CUDACC__) && !defined(__LCC__) && !defined(__NVCOMPILER)
 #    define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION _Pragma( "GCC diagnostic push" )
 #    define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  _Pragma( "GCC diagnostic pop" )
 
@@ -58,6 +58,12 @@
 
 #    define CATCH_INTERNAL_IGNORE_BUT_WARN(...) (void)__builtin_constant_p(__VA_ARGS__)
 
+#endif
+
+#if defined(__NVCOMPILER)
+#    define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION _Pragma( "diag push" )
+#    define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  _Pragma( "diag pop" )
+#    define CATCH_INTERNAL_SUPPRESS_UNUSED_VARIABLE_WARNINGS _Pragma( "diag_suppress declared_but_not_referenced" )
 #endif
 
 #if defined(__CUDACC__) && !defined(__clang__)


### PR DESCRIPTION
## Description

Catch2 suppresses unusued variable and equivalent warnings in a couple of places, but most importantly, in the declaration of autoRegistrar [here](https://github.com/catchorg/Catch2/blob/cefa8fcf329c950493f80dcbf7e2870a20213e0f/src/catch2/internal/catch_test_registry.hpp#L81). This warning gets triggered by `NVHPC` compiler. The current patch adds three macros, namely:

1. `CATCH_INTERNAL_START_WARNINGS_SUPPRESSION`
2. `CATCH_INTERNAL_SUPPRESS_UNUSED_VARIABLE_WARNINGS`
3.  `CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION`

for the NVHPC Compiler which in particular prevents that warning from occurring.  The compiler is detected completely separately from the other  compilers in this patch, because from what I found out, `NVHPC` defines `__GNUC__` as well for some reason. (I suspect because it advertises itself as GNU compatible. 

In any case, I can try to find out a more optimal way of adding this combination if you want. 