### PR TITLE
ObjectStorage: fix UB (strict aliasing violation)

### DIFF
--- a/include/internal/benchmark/catch_constructor.hpp
+++ b/include/internal/benchmark/catch_constructor.hpp
@@ -54,11 +54,11 @@ namespace Catch {
                 void destruct_on_exit(typename std::enable_if<!Destruct, U>::type* = 0) { }
 
                 T& stored_object() {
-                    return *static_cast<T*>(static_cast<void*>(&data));
+                    return *CATCH_LAUNDER(static_cast<T*>(static_cast<void*>(&data)));
                 }
 
                 T const& stored_object() const {
-                    return *static_cast<T*>(static_cast<void*>(&data));
+                    return *CATCH_LAUNDER(static_cast<T*>(static_cast<void*>(&data)));
                 }
 
 

--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -37,6 +37,14 @@
 #    define CATCH_CPP17_OR_GREATER
 #  endif
 
+#  include <new> // for __cpp_lib_launder
+
+#  ifdef __cpp_lib_launder
+#    define CATCH_LAUNDER(p) std::launder(p)
+#  else
+#    define CATCH_LAUNDER(p) (p)
+#  endif
+
 #endif
 
 // Only GCC compiler should be used in this block, so other compilers trying to


### PR DESCRIPTION
ObjectStorage is acting like a std::optional, manually managing the lifetime of an object placed into a char array buffer. C++17 changes the lifetime rules around such patterns, with the effect that this code now exhibits undefined behaviour, because &data is a pointer to a struct containing a char array, not a pointer to T, and it remains that way even after the static_cast.

The fix is to use std::launder(), which, for C++14 compilers, we hide behind a macro.

The similar Option type is not affected, since it has an additional T* member that stores the result of placement new, and therefore doesn't alias anything.

Fixes #2638.

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
