### PR TITLE
ObjectStorage: fix UB (strict aliasing violation)

### DIFF
--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -37,6 +37,14 @@
 #    define CATCH_CPP17_OR_GREATER
 #  endif
 
+#  include <new> // for __cpp_lib_launder
+
+#  ifdef __cpp_lib_launder
+#    define CATCH_LAUNDER(p) std::launder(p)
+#  else
+#    define CATCH_LAUNDER(p) (p)
+#  endif
+
 #endif
 
 // Only GCC compiler should be used in this block, so other compilers trying to

--- a/src/catch2/internal/catch_optional.hpp
+++ b/src/catch2/internal/catch_optional.hpp
@@ -18,10 +18,10 @@ namespace Catch {
     public:
         Optional() : nullableValue( nullptr ) {}
         Optional( T const& _value )
-        : nullableValue( new( storage ) T( _value ) )
+        : nullableValue( new( &storage ) T( _value ) )
         {}
         Optional( Optional const& _other )
-        : nullableValue( _other ? new( storage ) T( *_other ) : nullptr )
+        : nullableValue( _other ? new( &storage ) T( *_other ) : nullptr )
         {}
 
         ~Optional() {
@@ -32,13 +32,13 @@ namespace Catch {
             if( &_other != this ) {
                 reset();
                 if( _other )
-                    nullableValue = new( storage ) T( *_other );
+                    nullableValue = new( &storage ) T( *_other );
             }
             return *this;
         }
         Optional& operator = ( T const& _value ) {
             reset();
-            nullableValue = new( storage ) T( _value );
+            nullableValue = new( &storage ) T( _value );
             return *this;
         }
 
@@ -92,7 +92,7 @@ namespace Catch {
 
     private:
         T *nullableValue;
-        alignas(alignof(T)) char storage[sizeof(T)];
+        struct { alignas(alignof(T)) char data[sizeof(T)]; } storage;
     };
 
 } // end namespace Catch


### PR DESCRIPTION
ObjectStorage is acting like a std::optional, manually managing the lifetime of an object placed into a char array buffer. C++17 changes the lifetime rules around such patterns, with the effect that this code now exhibits undefined behaviour, because &data is a pointer to a struct containing a char array, not a pointer to T, and it remains that way even after the static_cast.

The fix is to use std::launder(), which, for C++14 compilers, we hide behind a macro.

Incidentally, this should fix the -Wstrict-aliasing we've been suppressing there for real.

As a drive-by, replace the char array with a struct containing a char array (code from Catch2 2.x). This is safer with std::launder(), which is a bit weird with arrays (see reachability discussion in the std::launder() docs).

The similar Optional type is not affected, since it has an additional T* member that stores the result of placement new, and therefore doesn't alias anything, but in the interest of keeping the code similar, replace the char array with a struct containing the char array here, too.

Fixes #2638.

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
