### PR TITLE
Fixed extras installation and shard impl script detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,8 @@ if (NOT_SUBPROJECT)
             "extras/ParseAndAddCatchTests.cmake"
             "extras/Catch.cmake"
             "extras/CatchAddTests.cmake"
+            "extras/CatchShardTests.cmake"
+            "extras/CatchShardTestsImpl.cmake"
           DESTINATION
             ${CATCH_CMAKE_CONFIG_DESTINATION}
         )

--- a/extras/CatchShardTests.cmake
+++ b/extras/CatchShardTests.cmake
@@ -46,7 +46,7 @@ function(catch_add_sharded_tests TARGET)
     APPEND PROPERTY TEST_INCLUDE_FILES "${ctest_include_file}"
   )
 
-  set(shard_impl_script_file "${CMAKE_CURRENT_LIST_DIR}/CatchShardTestsImpl.cmake")
+  set(shard_impl_script_file "${_CATCH_DISCOVER_SHARD_TESTS_IMPL_SCRIPT}")
 
   add_custom_command(
     TARGET ${TARGET} POST_BUILD
@@ -64,3 +64,11 @@ function(catch_add_sharded_tests TARGET)
 
 
 endfunction()
+
+
+###############################################################################
+
+set(_CATCH_DISCOVER_SHARD_TESTS_IMPL_SCRIPT
+    ${CMAKE_CURRENT_LIST_DIR}/CatchShardTestsImpl.cmake
+  CACHE INTERNAL "Catch2 full path to CatchShardTestsImpl.cmake helper file"
+)


### PR DESCRIPTION
## Description
What: Fixed CMake sharding installation and associated test script location calculation

Why: I need sharding support to work from a clean catch build for my CI.

## GitHub Issues
https://github.com/catchorg/Catch2/issues/2656