### PR TITLE
Fix reporter detection in catch_discover_tests

### DIFF
--- a/extras/Catch.cmake
+++ b/extras/Catch.cmake
@@ -35,7 +35,7 @@ same as the Catch name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
                          [TEST_LIST var]
                          [REPORTER reporter]
                          [OUTPUT_DIR dir]
-                         [OUTPUT_PREFIX prefix}
+                         [OUTPUT_PREFIX prefix]
                          [OUTPUT_SUFFIX suffix]
     )
 

--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -66,30 +66,30 @@ endif()
 
 string(REPLACE "\n" ";" output "${output}")
 
-# Run test executable to get list of available reporters
-execute_process(
-  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-reporters
-  OUTPUT_VARIABLE reporters_output
-  RESULT_VARIABLE reporters_result
-  WORKING_DIRECTORY "${TEST_WORKING_DIR}"
-)
-if(NOT ${reporters_result} EQUAL 0)
-  message(FATAL_ERROR
-    "Error running test executable '${TEST_EXECUTABLE}':\n"
-    "  Result: ${reporters_result}\n"
-    "  Output: ${reporters_output}\n"
-  )
-endif()
-string(FIND "${reporters_output}" "${reporter}" reporter_is_valid)
-if(reporter AND ${reporter_is_valid} EQUAL -1)
-  message(FATAL_ERROR
-    "\"${reporter}\" is not a valid reporter!\n"
-  )
-endif()
-
 # Prepare reporter
 if(reporter)
   set(reporter_arg "--reporter ${reporter}")
+
+  # Run test executable to check whether reporter is available
+  # note that the use of --list-reporters is not the important part,
+  # we only want to check whether the execution succeeds with ${reporter_arg}
+  execute_process(
+    COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} ${reporter_arg} --list-reporters
+    OUTPUT_VARIABLE reporter_check_output
+    RESULT_VARIABLE reporter_check_result
+    WORKING_DIRECTORY "${TEST_WORKING_DIR}"
+  )
+  if(${reporter_check_result} EQUAL 255)
+    message(FATAL_ERROR
+      "\"${reporter}\" is not a valid reporter!\n"
+    )
+  elseif(NOT ${reporter_check_result} EQUAL 0)
+    message(FATAL_ERROR
+      "Error running test executable '${TEST_EXECUTABLE}':\n"
+      "  Result: ${reporter_check_result}\n"
+      "  Output: ${reporter_check_output}\n"
+    )
+  endif()
 endif()
 
 # Prepare output dir


### PR DESCRIPTION
Closes #2668
Instead of grepping for the reporter, use it in the process and check for the error code

## Description
Inside the `catch_discover_tests` CMake script, instead of searching for the supposed reporter in the verbose (!) output of --list-reporters, actually use it as the actual reporter and check for failures when doing so. This will avoid failures when a correct reporter is not spelled in the correct case (reporters are case insensitive), and it avoids success when the supposed reporter is only a fill word in one of the reporter descriptions.

## GitHub Issues
- #2668 fixed
