### PR TITLE
cmake: Add new DISCOVERY_MODE option to catch_discover_tests

### DIFF
--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -126,6 +126,7 @@ catch_discover_tests(target
                      [OUTPUT_DIR dir]
                      [OUTPUT_PREFIX prefix]
                      [OUTPUT_SUFFIX suffix]
+                     [DISCOVERY_MODE <POST_BUILD|PRE_TEST>]
 )
 ```
 
@@ -198,6 +199,16 @@ If specified, `suffix` is added to each output file name, like so
 `--out dir/<test_name>suffix`. This can be used to add a file extension to
 the output file name e.g. ".xml".
 
+* `DISCOVERY_MODE mode`
+
+If specified allows control over when test discovery is performed.
+For a value of `POST_BUILD` (default) test discovery is performed at build time.
+For a a value of `PRE_TEST` test discovery is delayed until just prior to test
+execution (useful e.g. in cross-compilation environments).
+``DISCOVERY_MODE`` defaults to the value of the
+``CMAKE_CATCH_DISCOVER_TESTS_DISCOVERY_MODE`` variable if it is not passed when
+calling ``catch_discover_tests``. This provides a mechanism for globally
+selecting a preferred test discovery behavior.
 
 ### `ParseAndAddCatchTests.cmake`
 

--- a/extras/Catch.cmake
+++ b/extras/Catch.cmake
@@ -37,6 +37,7 @@ same as the Catch name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
                          [OUTPUT_DIR dir]
                          [OUTPUT_PREFIX prefix]
                          [OUTPUT_SUFFIX suffix]
+                         [DISCOVERY_MODE <POST_BUILD|PRE_TEST>]
     )
 
   ``catch_discover_tests`` sets up a post-build command on the test executable
@@ -123,14 +124,28 @@ same as the Catch name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
     test executable and when the tests are executed themselves. This requires
     cmake/ctest >= 3.22.
 
+  `DISCOVERY_MODE mode``
+    Provides control over when ``catch_discover_tests`` performs test discovery.
+    By default, ``POST_BUILD`` sets up a post-build command to perform test discovery
+    at build time. In certain scenarios, like cross-compiling, this ``POST_BUILD``
+    behavior is not desirable. By contrast, ``PRE_TEST`` delays test discovery until
+    just prior to test execution. This way test discovery occurs in the target environment
+    where the test has a better chance at finding appropriate runtime dependencies.
+
+    ``DISCOVERY_MODE`` defaults to the value of the
+    ``CMAKE_CATCH_DISCOVER_TESTS_DISCOVERY_MODE`` variable if it is not passed when
+    calling ``catch_discover_tests``. This provides a mechanism for globally selecting
+    a preferred test discovery behavior without having to modify each call site.
+
 #]=======================================================================]
 
 #------------------------------------------------------------------------------
 function(catch_discover_tests TARGET)
+
   cmake_parse_arguments(
     ""
     ""
-    "TEST_PREFIX;TEST_SUFFIX;WORKING_DIRECTORY;TEST_LIST;REPORTER;OUTPUT_DIR;OUTPUT_PREFIX;OUTPUT_SUFFIX"
+    "TEST_PREFIX;TEST_SUFFIX;WORKING_DIRECTORY;TEST_LIST;REPORTER;OUTPUT_DIR;OUTPUT_PREFIX;OUTPUT_SUFFIX;DISCOVERY_MODE"
     "TEST_SPEC;EXTRA_ARGS;PROPERTIES;DL_PATHS"
     ${ARGN}
   )
@@ -141,11 +156,19 @@ function(catch_discover_tests TARGET)
   if(NOT _TEST_LIST)
     set(_TEST_LIST ${TARGET}_TESTS)
   endif()
-
   if (_DL_PATHS)
     if(${CMAKE_VERSION} VERSION_LESS "3.22.0")
         message(FATAL_ERROR "The DL_PATHS option requires at least cmake 3.22")
     endif()
+  endif()
+  if(NOT _DISCOVERY_MODE)
+    if(NOT CMAKE_CATCH_DISCOVER_TESTS_DISCOVERY_MODE)
+      set(CMAKE_CATCH_DISCOVER_TESTS_DISCOVERY_MODE "POST_BUILD")
+    endif()
+    set(_DISCOVERY_MODE ${CMAKE_CATCH_DISCOVER_TESTS_DISCOVERY_MODE})
+  endif()
+  if (NOT _DISCOVERY_MODE MATCHES "^(POST_BUILD|PRE_TEST)$")
+    message(FATAL_ERROR "Unknown DISCOVERY_MODE: ${_DISCOVERY_MODE}")
   endif()
 
   ## Generate a unique name based on the extra arguments
@@ -159,39 +182,77 @@ function(catch_discover_tests TARGET)
     TARGET ${TARGET}
     PROPERTY CROSSCOMPILING_EMULATOR
   )
-  add_custom_command(
-    TARGET ${TARGET} POST_BUILD
-    BYPRODUCTS "${ctest_tests_file}"
-    COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_TARGET=${TARGET}"
-            -D "TEST_EXECUTABLE=$<TARGET_FILE:${TARGET}>"
-            -D "TEST_EXECUTOR=${crosscompiling_emulator}"
-            -D "TEST_WORKING_DIR=${_WORKING_DIRECTORY}"
-            -D "TEST_SPEC=${_TEST_SPEC}"
-            -D "TEST_EXTRA_ARGS=${_EXTRA_ARGS}"
-            -D "TEST_PROPERTIES=${_PROPERTIES}"
-            -D "TEST_PREFIX=${_TEST_PREFIX}"
-            -D "TEST_SUFFIX=${_TEST_SUFFIX}"
-            -D "TEST_LIST=${_TEST_LIST}"
-            -D "TEST_REPORTER=${_REPORTER}"
-            -D "TEST_OUTPUT_DIR=${_OUTPUT_DIR}"
-            -D "TEST_OUTPUT_PREFIX=${_OUTPUT_PREFIX}"
-            -D "TEST_OUTPUT_SUFFIX=${_OUTPUT_SUFFIX}"
-            -D "TEST_DL_PATHS=${_DL_PATHS}"
-            -D "CTEST_FILE=${ctest_tests_file}"
-            -P "${_CATCH_DISCOVER_TESTS_SCRIPT}"
-    VERBATIM
-  )
 
-  file(WRITE "${ctest_include_file}"
-    "if(EXISTS \"${ctest_tests_file}\")\n"
-    "  include(\"${ctest_tests_file}\")\n"
-    "else()\n"
-    "  add_test(${TARGET}_NOT_BUILT-${args_hash} ${TARGET}_NOT_BUILT-${args_hash})\n"
-    "endif()\n"
-  )
+  if(_DISCOVERY_MODE STREQUAL "POST_BUILD")
+    add_custom_command(
+      TARGET ${TARGET} POST_BUILD
+      BYPRODUCTS "${ctest_tests_file}"
+      COMMAND "${CMAKE_COMMAND}"
+              -D "TEST_TARGET=${TARGET}"
+              -D "TEST_EXECUTABLE=$<TARGET_FILE:${TARGET}>"
+              -D "TEST_EXECUTOR=${crosscompiling_emulator}"
+              -D "TEST_WORKING_DIR=${_WORKING_DIRECTORY}"
+              -D "TEST_SPEC=${_TEST_SPEC}"
+              -D "TEST_EXTRA_ARGS=${_EXTRA_ARGS}"
+              -D "TEST_PROPERTIES=${_PROPERTIES}"
+              -D "TEST_PREFIX=${_TEST_PREFIX}"
+              -D "TEST_SUFFIX=${_TEST_SUFFIX}"
+              -D "TEST_LIST=${_TEST_LIST}"
+              -D "TEST_REPORTER=${_REPORTER}"
+              -D "TEST_OUTPUT_DIR=${_OUTPUT_DIR}"
+              -D "TEST_OUTPUT_PREFIX=${_OUTPUT_PREFIX}"
+              -D "TEST_OUTPUT_SUFFIX=${_OUTPUT_SUFFIX}"
+              -D "TEST_DL_PATHS=${_DL_PATHS}"
+              -D "CTEST_FILE=${ctest_tests_file}"
+              -P "${_CATCH_DISCOVER_TESTS_SCRIPT}"
+      VERBATIM
+    )
 
-  if(NOT ${CMAKE_VERSION} VERSION_LESS "3.10.0") 
+    file(WRITE "${ctest_include_file}"
+      "if(EXISTS \"${ctest_tests_file}\")\n"
+      "  include(\"${ctest_tests_file}\")\n"
+      "else()\n"
+      "  add_test(${TARGET}_NOT_BUILT-${args_hash} ${TARGET}_NOT_BUILT-${args_hash})\n"
+      "endif()\n"
+    )
+
+  elseif(_DISCOVERY_MODE STREQUAL "PRE_TEST")
+
+    string(CONCAT ctest_include_content
+      "if(EXISTS \"$<TARGET_FILE:${TARGET}>\")"                                    "\n"
+      "  if(NOT EXISTS \"${ctest_tests_file}\" OR"                                 "\n"
+      "     NOT \"${ctest_tests_file}\" IS_NEWER_THAN \"$<TARGET_FILE:${TARGET}>\" OR\n"
+      "     NOT \"${ctest_tests_file}\" IS_NEWER_THAN \"\${CMAKE_CURRENT_LIST_FILE}\")\n"
+      "    include(\"${_CATCH_DISCOVER_TESTS_SCRIPT}\")"                           "\n"
+      "    catch_discover_tests_impl("                                             "\n"
+      "      TEST_EXECUTABLE"        " [==[" "$<TARGET_FILE:${TARGET}>"   "]==]"   "\n"
+      "      TEST_EXECUTOR"          " [==[" "${crosscompiling_emulator}" "]==]"   "\n"
+      "      TEST_WORKING_DIR"       " [==[" "${_WORKING_DIRECTORY}"      "]==]"   "\n"
+      "      TEST_SPEC"              " [==[" "${_TEST_SPEC}"              "]==]"   "\n"
+      "      TEST_EXTRA_ARGS"        " [==[" "${_EXTRA_ARGS}"             "]==]"   "\n"
+      "      TEST_PROPERTIES"        " [==[" "${_PROPERTIES}"             "]==]"   "\n"
+      "      TEST_PREFIX"            " [==[" "${_TEST_PREFIX}"            "]==]"   "\n"
+      "      TEST_SUFFIX"            " [==[" "${_TEST_SUFFIX}"            "]==]"   "\n"
+      "      TEST_LIST"              " [==[" "${_TEST_LIST}"              "]==]"   "\n"
+      "      TEST_REPORTER"          " [==[" "${_REPORTER}"               "]==]"   "\n"
+      "      TEST_OUTPUT_DIR"        " [==[" "${_OUTPUT_DIR}"             "]==]"   "\n"
+      "      TEST_OUTPUT_PREFIX"     " [==[" "${_OUTPUT_PREFIX}"          "]==]"   "\n"
+      "      TEST_OUTPUT_SUFFIX"     " [==[" "${_OUTPUT_SUFFIX}"          "]==]"   "\n"
+      "      CTEST_FILE"             " [==[" "${ctest_tests_file}"        "]==]"   "\n"
+      "      TEST_DL_PATHS"          " [==[" "${_DL_PATHS}"               "]==]"   "\n"
+      "      CTEST_FILE"             " [==[" "${CTEST_FILE}"              "]==]"   "\n"
+      "    )"                                                                      "\n"
+      "  endif()"                                                                  "\n"
+      "  include(\"${ctest_tests_file}\")"                                         "\n"
+      "else()"                                                                     "\n"
+      "  add_test(${TARGET}_NOT_BUILT ${TARGET}_NOT_BUILT)"                        "\n"
+      "endif()"                                                                    "\n"
+    )
+
+    file(GENERATE OUTPUT "${ctest_include_file}" CONTENT "${ctest_include_content}")
+  endif()
+
+  if(NOT ${CMAKE_VERSION} VERSION_LESS "3.10.0")
     # Add discovered tests to directory TEST_INCLUDE_FILES
     set_property(DIRECTORY
       APPEND PROPERTY TEST_INCLUDE_FILES "${ctest_include_file}"
@@ -204,9 +265,7 @@ function(catch_discover_tests TARGET)
         PROPERTY TEST_INCLUDE_FILE "${ctest_include_file}"
       )
     else()
-      message(FATAL_ERROR
-        "Cannot set more than one TEST_INCLUDE_FILE"
-      )
+      message(FATAL_ERROR "Cannot set more than one TEST_INCLUDE_FILE")
     endif()
   endif()
 

--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -1,28 +1,6 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 
-set(prefix "${TEST_PREFIX}")
-set(suffix "${TEST_SUFFIX}")
-set(spec ${TEST_SPEC})
-set(extra_args ${TEST_EXTRA_ARGS})
-set(properties ${TEST_PROPERTIES})
-set(reporter ${TEST_REPORTER})
-set(output_dir ${TEST_OUTPUT_DIR})
-set(output_prefix ${TEST_OUTPUT_PREFIX})
-set(output_suffix ${TEST_OUTPUT_SUFFIX})
-set(dl_paths ${TEST_DL_PATHS})
-set(script)
-set(suite)
-set(tests)
-
-if(WIN32)
-  set(dl_paths_variable_name PATH)
-elseif(APPLE)
-  set(dl_paths_variable_name DYLD_LIBRARY_PATH)
-else()
-  set(dl_paths_variable_name LD_LIBRARY_PATH)
-endif()
-
 function(add_command NAME)
   set(_args "")
   # use ARGV* instead of ARGN, because ARGN splits arrays into multiple arguments
@@ -38,119 +16,172 @@ function(add_command NAME)
   set(script "${script}${NAME}(${_args})\n" PARENT_SCOPE)
 endfunction()
 
-# Run test executable to get list of available tests
-if(NOT EXISTS "${TEST_EXECUTABLE}")
-  message(FATAL_ERROR
-    "Specified test executable '${TEST_EXECUTABLE}' does not exist"
+function(catch_discover_tests_impl)
+
+  cmake_parse_arguments(
+    ""
+    ""
+    "TEST_EXECUTABLE;TEST_WORKING_DIR;TEST_DL_PATHS;TEST_OUTPUT_DIR;TEST_OUTPUT_PREFIX;TEST_OUTPUT_SUFFIX;TEST_PREFIX;TEST_REPORTER;TEST_SPEC;TEST_SUFFIX;TEST_LIST;CTEST_FILE"
+    "TEST_EXTRA_ARGS;TEST_PROPERTIES;TEST_EXECUTOR"
+    ${ARGN}
   )
-endif()
 
-if(dl_paths)
-  cmake_path(CONVERT "${dl_paths}" TO_NATIVE_PATH_LIST paths)
-  set(ENV{${dl_paths_variable_name}} "${paths}")
-endif()
+  set(prefix "${_TEST_PREFIX}")
+  set(suffix "${_TEST_SUFFIX}")
+  set(spec ${_TEST_SPEC})
+  set(extra_args ${_TEST_EXTRA_ARGS})
+  set(properties ${_TEST_PROPERTIES})
+  set(reporter ${_TEST_REPORTER})
+  set(output_dir ${_TEST_OUTPUT_DIR})
+  set(output_prefix ${_TEST_OUTPUT_PREFIX})
+  set(output_suffix ${_TEST_OUTPUT_SUFFIX})
+  set(dl_paths ${_TEST_DL_PATHS})
+  set(script)
+  set(suite)
+  set(tests)
 
-execute_process(
-  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-tests --verbosity quiet
-  OUTPUT_VARIABLE output
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY "${TEST_WORKING_DIR}"
-)
-if(NOT ${result} EQUAL 0)
-  message(FATAL_ERROR
-    "Error running test executable '${TEST_EXECUTABLE}':\n"
-    "  Result: ${result}\n"
-    "  Output: ${output}\n"
-  )
-endif()
+  if(WIN32)
+    set(dl_paths_variable_name PATH)
+  elseif(APPLE)
+    set(dl_paths_variable_name DYLD_LIBRARY_PATH)
+  else()
+    set(dl_paths_variable_name LD_LIBRARY_PATH)
+  endif()
 
-string(REPLACE "\n" ";" output "${output}")
+  # Run test executable to get list of available tests
+  if(NOT EXISTS "${_TEST_EXECUTABLE}")
+    message(FATAL_ERROR
+      "Specified test executable '${_TEST_EXECUTABLE}' does not exist"
+    )
+  endif()
 
-# Prepare reporter
-if(reporter)
-  set(reporter_arg "--reporter ${reporter}")
+  if(dl_paths)
+    cmake_path(CONVERT "${dl_paths}" TO_NATIVE_PATH_LIST paths)
+    set(ENV{${dl_paths_variable_name}} "${paths}")
+  endif()
 
-  # Run test executable to check whether reporter is available
-  # note that the use of --list-reporters is not the important part,
-  # we only want to check whether the execution succeeds with ${reporter_arg}
   execute_process(
-    COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} ${reporter_arg} --list-reporters
-    OUTPUT_VARIABLE reporter_check_output
-    RESULT_VARIABLE reporter_check_result
-    WORKING_DIRECTORY "${TEST_WORKING_DIR}"
+    COMMAND ${_TEST_EXECUTOR} "${_TEST_EXECUTABLE}" ${spec} --list-tests --verbosity quiet
+    OUTPUT_VARIABLE output
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY "${_TEST_WORKING_DIR}"
   )
-  if(${reporter_check_result} EQUAL 255)
+  if(NOT ${result} EQUAL 0)
     message(FATAL_ERROR
-      "\"${reporter}\" is not a valid reporter!\n"
-    )
-  elseif(NOT ${reporter_check_result} EQUAL 0)
-    message(FATAL_ERROR
-      "Error running test executable '${TEST_EXECUTABLE}':\n"
-      "  Result: ${reporter_check_result}\n"
-      "  Output: ${reporter_check_output}\n"
+      "Error running test executable '${_TEST_EXECUTABLE}':\n"
+      "  Result: ${result}\n"
+      "  Output: ${output}\n"
     )
   endif()
-endif()
 
-# Prepare output dir
-if(output_dir AND NOT IS_ABSOLUTE ${output_dir})
-  set(output_dir "${TEST_WORKING_DIR}/${output_dir}")
-  if(NOT EXISTS ${output_dir})
-    file(MAKE_DIRECTORY ${output_dir})
+  string(REPLACE "\n" ";" output "${output}")
+
+  # Prepare reporter
+  if(reporter)
+    set(reporter_arg "--reporter ${reporter}")
+
+    # Run test executable to check whether reporter is available
+    # note that the use of --list-reporters is not the important part,
+    # we only want to check whether the execution succeeds with ${reporter_arg}
+    execute_process(
+      COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} ${reporter_arg} --list-reporters
+      OUTPUT_VARIABLE reporter_check_output
+      RESULT_VARIABLE reporter_check_result
+      WORKING_DIRECTORY "${TEST_WORKING_DIR}"
+    )
+    if(${reporter_check_result} EQUAL 255)
+      message(FATAL_ERROR
+        "\"${reporter}\" is not a valid reporter!\n"
+      )
+    elseif(NOT ${reporter_check_result} EQUAL 0)
+      message(FATAL_ERROR
+        "Error running test executable '${TEST_EXECUTABLE}':\n"
+        "  Result: ${reporter_check_result}\n"
+        "  Output: ${reporter_check_output}\n"
+      )
+    endif()
   endif()
-endif()
 
-if(dl_paths)
-  foreach(path ${dl_paths})
-    cmake_path(NATIVE_PATH path native_path)
-    list(APPEND environment_modifications "${dl_paths_variable_name}=path_list_prepend:${native_path}")
+  # Prepare output dir
+  if(output_dir AND NOT IS_ABSOLUTE ${output_dir})
+    set(output_dir "${_TEST_WORKING_DIR}/${output_dir}")
+    if(NOT EXISTS ${output_dir})
+      file(MAKE_DIRECTORY ${output_dir})
+    endif()
+  endif()
+
+  if(dl_paths)
+    foreach(path ${dl_paths})
+      cmake_path(NATIVE_PATH path native_path)
+      list(APPEND environment_modifications "${dl_paths_variable_name}=path_list_prepend:${native_path}")
+    endforeach()
+  endif()
+
+  # Parse output
+  foreach(line ${output})
+    set(test ${line})
+    # Escape characters in test case names that would be parsed by Catch2
+    set(test_name ${test})
+    foreach(char , [ ])
+      string(REPLACE ${char} "\\${char}" test_name ${test_name})
+    endforeach(char)
+    # ...add output dir
+    if(output_dir)
+      string(REGEX REPLACE "[^A-Za-z0-9_]" "_" test_name_clean ${test_name})
+      set(output_dir_arg "--out ${output_dir}/${output_prefix}${test_name_clean}${output_suffix}")
+    endif()
+
+    # ...and add to script
+    add_command(add_test
+      "${prefix}${test}${suffix}"
+      ${_TEST_EXECUTOR}
+      "${_TEST_EXECUTABLE}"
+      "${test_name}"
+      ${extra_args}
+      "${reporter_arg}"
+      "${output_dir_arg}"
+    )
+    add_command(set_tests_properties
+      "${prefix}${test}${suffix}"
+      PROPERTIES
+      WORKING_DIRECTORY "${_TEST_WORKING_DIR}"
+      ${properties}
+    )
+
+    if(environment_modifications)
+      add_command(set_tests_properties
+        "${prefix}${test}${suffix}"
+        PROPERTIES
+        ENVIRONMENT_MODIFICATION "${environment_modifications}")
+    endif()
+
+    list(APPEND tests "${prefix}${test}${suffix}")
   endforeach()
+
+  # Create a list of all discovered tests, which users may use to e.g. set
+  # properties on the tests
+  add_command(set ${_TEST_LIST} ${tests})
+
+  # Write CTest script
+  file(WRITE "${_CTEST_FILE}" "${script}")
+endfunction()
+
+if(CMAKE_SCRIPT_MODE_FILE)
+  catch_discover_tests_impl(
+    TEST_EXECUTABLE ${TEST_EXECUTABLE}
+    TEST_EXECUTOR ${TEST_EXECUTOR}
+    TEST_WORKING_DIR ${TEST_WORKING_DIR}
+    TEST_SPEC ${TEST_SPEC}
+    TEST_EXTRA_ARGS ${TEST_EXTRA_ARGS}
+    TEST_PROPERTIES ${TEST_PROPERTIES}
+    TEST_PREFIX ${TEST_PREFIX}
+    TEST_SUFFIX ${TEST_SUFFIX}
+    TEST_LIST ${TEST_LIST}
+    TEST_REPORTER ${TEST_REPORTER}
+    TEST_OUTPUT_DIR ${TEST_OUTPUT_DIR}
+    TEST_OUTPUT_PREFIX ${TEST_OUTPUT_PREFIX}
+    TEST_OUTPUT_SUFFIX ${TEST_OUTPUT_SUFFIX}
+    TEST_DL_PATHS ${TEST_DL_PATHS}
+    CTEST_FILE ${CTEST_FILE}
+  )
 endif()
-
-# Parse output
-foreach(line ${output})
-  set(test ${line})
-  # Escape characters in test case names that would be parsed by Catch2
-  set(test_name ${test})
-  foreach(char , [ ])
-    string(REPLACE ${char} "\\${char}" test_name ${test_name})
-  endforeach(char)
-  # ...add output dir
-  if(output_dir)
-    string(REGEX REPLACE "[^A-Za-z0-9_]" "_" test_name_clean ${test_name})
-    set(output_dir_arg "--out ${output_dir}/${output_prefix}${test_name_clean}${output_suffix}")
-  endif()
-  
-  # ...and add to script
-  add_command(add_test
-    "${prefix}${test}${suffix}"
-    ${TEST_EXECUTOR}
-    "${TEST_EXECUTABLE}"
-    "${test_name}"
-    ${extra_args}
-    "${reporter_arg}"
-    "${output_dir_arg}"
-  )
-  add_command(set_tests_properties
-    "${prefix}${test}${suffix}"
-    PROPERTIES
-    WORKING_DIRECTORY "${TEST_WORKING_DIR}"
-    ${properties}
-  )
-
-   if(environment_modifications)
-     add_command(set_tests_properties
-       "${prefix}${test}${suffix}"
-       PROPERTIES
-       ENVIRONMENT_MODIFICATION "${environment_modifications}")
-   endif()
-
-  list(APPEND tests "${prefix}${test}${suffix}")
-endforeach()
-
-# Create a list of all discovered tests, which users may use to e.g. set
-# properties on the tests
-add_command(set ${TEST_LIST} ${tests})
-
-# Write CTest script
-file(WRITE "${CTEST_FILE}" "${script}")


### PR DESCRIPTION
## Description

Provide `DISCOVERY_MODE` option to `catch_discover_tests` to allow for `PRE_TEST` discovery mode.

Cf. details in commit msg-es.

This change follows closely the corresponding functionality / changes in the GoogleTest counterpart to maintain the convenient similarity to `gtest_discover_tests()` and friends.

## GitHub Issues

Closes #2493