### PR TITLE
Improve unreachable-code warnings

### DIFF
--- a/CMake/CatchMiscFunctions.cmake
+++ b/CMake/CatchMiscFunctions.cmake
@@ -83,7 +83,7 @@ function(add_warnings_to_targets targets)
           "-Wundef"
           "-Wuninitialized"
           "-Wunneeded-internal-declaration"
-          "-Wunreachable-code"
+          "-Wunreachable-code-aggressive"
           "-Wunused"
           "-Wunused-function"
           "-Wunused-parameter"

--- a/src/catch2/internal/catch_reporter_registry.cpp
+++ b/src/catch2/internal/catch_reporter_registry.cpp
@@ -57,8 +57,6 @@ namespace Catch {
         auto it = m_impl->factories.find( name );
         if ( it == m_impl->factories.end() ) return nullptr;
         return it->second->create( CATCH_MOVE( config ) );
-
-        return IEventListenerPtr();
     }
 
     void ReporterRegistry::registerReporter( std::string const& name,

--- a/tests/SelfTest/UsageTests/Exception.tests.cpp
+++ b/tests/SelfTest/UsageTests/Exception.tests.cpp
@@ -20,7 +20,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wweak-vtables"
 #pragma clang diagnostic ignored "-Wmissing-noreturn"
-#pragma clang diagnostic ignored "-Wunreachable-code"
+#pragma clang diagnostic ignored "-Wunreachable-code-return"
 #endif
 
 namespace {


### PR DESCRIPTION
## Description

Enable CI to report -Wunreachable-code-aggressive warnings in clang builds which covers all,  -Wunreachable-code, -code-break, -code-return.

Adapt tests.
Fix one instance of unreachable-code-return, regression from d0f70fdfd.

## GitHub Issues
