### PR TITLE
WIP: Fix handling of semicolon and backslash characters in CMake test discovery

### DIFF
--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -74,6 +74,10 @@ function(catch_discover_tests_impl)
     )
   endif()
 
+  # Make sure to escape ; (semicolons) in test names first, because
+  # that'd break the foreach loop for "Parse output" later and create
+  # wrongly splitted and thus failing test cases (false positives)
+  string(REPLACE ";" "\;" output "${output}")
   string(REPLACE "\n" ";" output "${output}")
 
   # Prepare reporter
@@ -119,15 +123,16 @@ function(catch_discover_tests_impl)
 
   # Parse output
   foreach(line ${output})
-    set(test ${line})
+    set(test "${line}")
     # Escape characters in test case names that would be parsed by Catch2
-    set(test_name ${test})
-    foreach(char , [ ])
-      string(REPLACE ${char} "\\${char}" test_name ${test_name})
+    # Note that the \ escaping must happen FIRST! Do not change the order.
+    set(test_name "${test}")
+    foreach(char \\ , [ ])
+      string(REPLACE ${char} "\\${char}" test_name "${test_name}")
     endforeach(char)
     # ...add output dir
     if(output_dir)
-      string(REGEX REPLACE "[^A-Za-z0-9_]" "_" test_name_clean ${test_name})
+      string(REGEX REPLACE "[^A-Za-z0-9_]" "_" test_name_clean "${test_name}")
       set(output_dir_arg "--out ${output_dir}/${output_prefix}${test_name_clean}${output_suffix}")
     endif()
 

--- a/tests/TestScripts/DiscoverTests/register-tests.cpp
+++ b/tests/TestScripts/DiscoverTests/register-tests.cpp
@@ -8,4 +8,5 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+TEST_CASE("@Script[C:\\EPM1A]=x;\"SCALA_ZERO:\"", "[script regressions]"){}
 TEST_CASE("Some test") {}


### PR DESCRIPTION
## Description
This PR fixes the handling of semicolon and backslash characters in test names in the CMake test discovery 

## GitHub Issues
https://github.com/catchorg/Catch2/issues/2674

## TODO:
How can we test this? I believe introducing a new "category" of tests that actually makes use of `catch_discover_tests` would be the best way?