### PR TITLE
Update CatchConfigOptions.cmake

### DIFF
--- a/CMake/CatchConfigOptions.cmake
+++ b/CMake/CatchConfigOptions.cmake
@@ -68,7 +68,11 @@ set(_OtherConfigOptions
 foreach(OptionName ${_OtherConfigOptions})
   AddConfigOption(${OptionName})
 endforeach()
-set(CATCH_CONFIG_SHARED_LIBRARY ${BUILD_SHARED_LIBS})
+if(DEFINED BUILD_SHARED_LIBS)
+    set(CATCH_CONFIG_SHARED_LIBRARY ${BUILD_SHARED_LIBS})
+else()
+    set(CATCH_CONFIG_SHARED_LIBRARY "")
+endif()
 
 set(CATCH_CONFIG_DEFAULT_REPORTER "console" CACHE STRING "Read docs/configuration.md for details. The name of the reporter should be without quotes.")
 set(CATCH_CONFIG_CONSOLE_WIDTH "80" CACHE STRING "Read docs/configuration.md for details. Must form a valid integer literal.")


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
Fix CMake warning

```
CMake Warning (dev) at catch2-src/CMake/CatchConfigOptions.cmake:71 (set):
  uninitialized variable 'BUILD_SHARED_LIBS'
```

CMake's --warn-uninitialized is very useful feature to prevent some silly problems like hard to detect typos in cmake variables. Unfortunately cmake doesn't have any way to locally disable this warning for 3rd-party code, so only way to deal with it - ignore or actually fix it.

