### PR TITLE
Add SFML to the list of open source users

### DIFF
--- a/docs/opensource-users.md
+++ b/docs/opensource-users.md
@@ -95,6 +95,9 @@ A C++ client library for Consul. Consul is a distributed tool for discovering an
 ### [Reactive-Extensions/ RxCpp](https://github.com/Reactive-Extensions/RxCpp)
 A library of algorithms for values-distributed-in-time.
 
+### [SFML](https://github.com/SFML/SFML)
+Simple and Fast Multimedia Library.
+
 ### [SOCI](https://github.com/SOCI/soci)
 The C++ Database Access Library.
 


### PR DESCRIPTION
## Description

I'm a maintainer for SFML and we recently switched from Doctest to Catch2.

https://github.com/SFML/SFML/commit/f6dfc04938032c87c1ebb9e60cb2088abbcf9b7a