### PR TITLE
meson: require version >=0.54.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
   'cpp',
   version: '3.3.2', # CML version placeholder, don't delete
   license: 'BSL-1.0',
-  meson_version: '>=0.50.0',
+  meson_version: '>=0.54.1',
 )
 
 subdir('src/catch2')


### PR DESCRIPTION
See discussion in https://github.com/mesonbuild/wrapdb/pull/1016.