### PR TITLE
🛠💚 Add <exception> header where strictly necessary

### DIFF
--- a/src/catch2/benchmark/catch_benchmark.hpp
+++ b/src/catch2/benchmark/catch_benchmark.hpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <exception>
 #include <functional>
 #include <string>
 #include <vector>

--- a/src/catch2/catch_registry_hub.cpp
+++ b/src/catch2/catch_registry_hub.cpp
@@ -22,6 +22,8 @@
 #include <catch2/internal/catch_move_and_forward.hpp>
 #include <catch2/internal/catch_reporter_registry.hpp>
 
+#include <exception>
+
 namespace Catch {
 
     namespace {

--- a/src/catch2/catch_session.cpp
+++ b/src/catch2/catch_session.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <exception>
 #include <iomanip>
 #include <set>
 

--- a/src/catch2/internal/catch_exception_translator_registry.cpp
+++ b/src/catch2/internal/catch_exception_translator_registry.cpp
@@ -11,6 +11,8 @@
 #include <catch2/internal/catch_test_failure_exception.hpp>
 #include <catch2/internal/catch_move_and_forward.hpp>
 
+#include <exception>
+
 namespace Catch {
 
     namespace {


### PR DESCRIPTION
Prevents failures on later versions of Clang and libc++ where the inclusion of standard library headers becomes more strict, specifically build failures in the LLVM 14/15 distributions related to `#include <exception>`.