### PR TITLE
Add option to disable building unit tests in Meson build file.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,4 +14,6 @@ project(
 )
 
 subdir('src/catch2')
-subdir('tests')
+if get_option('tests')
+  subdir('tests')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('tests', type: 'boolean', value: true, description: 'Build the unit tests')


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
Today, there is an option `BUILD_TESTING` to disable building SelfTest with `cmake`, however that is not available for `meson`. This change adds a [meson option](https://mesonbuild.com/Build-options.html) to disable building unit tests.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
#2666 