### PR TITLE
Fix failure with MSVC and -std:c++20

### DIFF
--- a/src/catch2/benchmark/catch_benchmark.hpp
+++ b/src/catch2/benchmark/catch_benchmark.hpp
@@ -45,7 +45,7 @@ namespace Catch {
             template <typename Clock>
             ExecutionPlan<FloatDuration<Clock>> prepare(const IConfig &cfg, Environment<FloatDuration<Clock>> env) const {
                 auto min_time = env.clock_resolution.mean * Detail::minimum_ticks;
-                auto run_time = std::max(min_time, std::chrono::duration_cast<decltype(min_time)>(cfg.benchmarkWarmupTime()));
+                auto run_time = (std::max)(min_time, std::chrono::duration_cast<decltype(min_time)>(cfg.benchmarkWarmupTime()));
                 auto&& test = Detail::run_for_at_least<Clock>(std::chrono::duration_cast<ClockDuration<Clock>>(run_time), 1, fun);
                 int new_iters = static_cast<int>(std::ceil(min_time * test.iterations / test.elapsed));
                 return { new_iters, test.elapsed / test.iterations * new_iters * cfg.benchmarkSamples(), fun, std::chrono::duration_cast<FloatDuration<Clock>>(cfg.benchmarkWarmupTime()), Detail::warmup_iterations };


### PR DESCRIPTION
## Description

Add parens around `std::max` to prevent compilation failure with MSVC. This is similar to what was done here:
https://github.com/search?q=repo%3Acatchorg%2FCatch2+%22%28std%3A%3Amin%29%22&type=code

and here:
https://github.com/search?q=repo%3Acatchorg%2FCatch2+%22%28std%3A%3Amax%29%22&type=code

When using Catch2 with MSVC 19.36.32532.0 and **-std:c++20** option enabled, I get the following compilation error:

```output
C:\PROG~5P2\MICR~2ZC\2022\BUIL~31X\VC\Tools\MSVC\14_3~A4R.325\bin\Hostx86\x86\cl.exe  /nologo /TP -DLUA_BUILD_AS_DLL -IY:\orbiter\Orbitersdk\include -IY:\orbiter\Src\Module\LuaScript\LuaInterpreter -IY:\orbiter\Extern\Catch2\src\catch2\.. -IY:\orbiter\out\build\windows-x86-
release\Extern\Catch2\generated-includes /DWIN32 /D_WINDOWS /GR /EHsc /O2 /Ob2 /DNDEBUG -std:c++20 -MD /we4311 /showIncludes /FoTests\CMakeFiles\Lua.Interpreter.dir\Lua.Interpreter.cp
p.obj /FdTests\CMakeFiles\Lua.Interpreter.dir\ /FS -c Y:\orbiter\Tests\Lua.Interpreter.cpp
Y:\orbiter\Extern\Catch2\src\catch2\..\catch2/benchmark/catch_benchmark.hpp(48): error C2589: '(': illegal token on right side of '::'
Y:\orbiter\Extern\Catch2\src\catch2\..\catch2/benchmark/catch_benchmark.hpp(46): note: This diagnostic occurred in the compiler generated function 'Catch::Benchmark::ExecutionPlan<std::chrono::duration<double,Clock::period>> Catch::Benchmark::Benchmark::prepare(const Catch::IConfig &,Catch::Benchmark::Environment<std::chrono::duration<double,Clock::period>>) const'
Y:\orbiter\Extern\Catch2\src\catch2\..\catch2/benchmark/catch_benchmark.hpp(48): error C2760: syntax error: ')' was unexpected here; expected ';'
Y:\orbiter\Extern\Catch2\src\catch2\..\catch2/benchmark/catch_benchmark.hpp(46): note: This diagnostic occurred in the compiler generated function 'Catch::Benchmark::ExecutionPlan<std::chrono::duration<double,Clock::period>> Catch::Benchmark::Benchmark::prepare(const Catch::IConfig &,Catch::Benchmark::Environment<std::chrono::duration<double,Clock::period>>) const'
Y:\orbiter\Extern\Catch2\src\catch2\..\catch2/benchmark/catch_benchmark.hpp(48): error C3878: syntax error: unexpected token ')' following 'expression_statement'
Y:\orbiter\Extern\Catch2\src\catch2\..\catch2/benchmark/catch_benchmark.hpp(46): note: This diagnostic occurred in the compiler generated function 'Catch::Benchmark::ExecutionPlan<std::chrono::duration<double,Clock::period>> Catch::Benchmark::Benchmark::prepare(const Catch::IConfig &,Catch::Benchmark::Environment<std::chrono::duration<double,Clock::period>>) const'
Y:\orbiter\Extern\Catch2\src\catch2\..\catch2/benchmark/catch_benchmark.hpp(48): note: error recovery skipped: ')'
Y:\orbiter\Extern\Catch2\src\catch2\..\catch2/benchmark/catch_benchmark.hpp(46): note: This diagnostic occurred in the compiler generated function 'Catch::Benchmark::ExecutionPlan<std::chrono::duration<double,Clock::period>> Catch::Benchmark::Benchmark::prepare(const Catch::IConfig &,Catch::Benchmark::Environment<std::chrono::duration<double,Clock::period>>) const'

```

Adding parens as bove fixes the error.