### PR TITLE
Add -Wdouble-promotion to common warnings

### DIFF
--- a/CMake/CatchMiscFunctions.cmake
+++ b/CMake/CatchMiscFunctions.cmake
@@ -53,6 +53,7 @@ function(add_warnings_to_targets targets)
           "-Wdangling"
           "-Wdeprecated"
           "-Wdeprecated-register"
+          "-Wdouble-promotion"
           "-Wexceptions"
           "-Wexit-time-destructors"
           "-Wextra"

--- a/src/catch2/catch_approx.cpp
+++ b/src/catch2/catch_approx.cpp
@@ -25,7 +25,7 @@ bool marginComparison(double lhs, double rhs, double margin) {
 namespace Catch {
 
     Approx::Approx ( double value )
-    :   m_epsilon( std::numeric_limits<float>::epsilon()*100. ),
+    :   m_epsilon( std::numeric_limits<float>::epsilon()*100.f ),
         m_margin( 0.0 ),
         m_scale( 0.0 ),
         m_value( value )

--- a/tests/SelfTest/UsageTests/Condition.tests.cpp
+++ b/tests/SelfTest/UsageTests/Condition.tests.cpp
@@ -136,7 +136,7 @@ TEST_CASE( "Ordering comparison checks that should succeed" )
 
     REQUIRE( data.float_nine_point_one > 9 );
     REQUIRE( data.float_nine_point_one < 10 );
-    REQUIRE( data.float_nine_point_one < 9.2 );
+    REQUIRE( data.float_nine_point_one < 9.2f );
 
     REQUIRE( data.str_hello <= "hello" );
     REQUIRE( data.str_hello >= "hello" );
@@ -163,7 +163,7 @@ TEST_CASE( "Ordering comparison checks that should fail", "[.][failing]" )
 
     CHECK( data.float_nine_point_one < 9 );
     CHECK( data.float_nine_point_one > 10 );
-    CHECK( data.float_nine_point_one > 9.2 );
+    CHECK( data.float_nine_point_one > 9.2f );
 
     CHECK( data.str_hello > "hello" );
     CHECK( data.str_hello < "hello" );


### PR DESCRIPTION
This has not huge benefits in Catch2 codebase, but it is still easy to take in use and it will benefit those which build catch2 with project default compiler options.

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
