### PR TITLE
Add missing cstdint includes to avoid compiler errors because of unknown symbols uint32_t

### DIFF
--- a/src/catch2/catch_test_case_info.hpp
+++ b/src/catch2/catch_test_case_info.hpp
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/src/catch2/internal/catch_string_manip.hpp
+++ b/src/catch2/internal/catch_string_manip.hpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <iosfwd>
 #include <vector>
+#include <cstdint>
 
 namespace Catch {
 

--- a/src/catch2/internal/catch_xmlwriter.cpp
+++ b/src/catch2/internal/catch_xmlwriter.cpp
@@ -13,6 +13,7 @@
 
 #include <iomanip>
 #include <type_traits>
+#include <cstdint>
 
 namespace Catch {
 


### PR DESCRIPTION
I get a lot of compiler errors with a Catch2 project as uintXX_t is used everywhere but the required source file is not included. I fixed the few files that came up during my compilation process (under archlinux).

I guess in older versions of gcc and dependencies there was cstdint included somewhere else and only because of that Catch2 compiled so far.

One of my failed compilation processes looked like this:
```
FAILED: components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_enum_values_registry.cpp.o 
/usr/lib/ccache/bin/g++  -I<build-folder>/components/catch2-src/src/catch2/.. -I<build-folder>/generated-includes -DQT_QML_DEBUG -g -std=gnu++23 -ffile-prefix-map=<build-folder>/components/catch2-src=. -MD -MT components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_enum_values_registry.cpp.o -MF components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_enum_values_registry.cpp.o.d -o components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_enum_values_registry.cpp.o -c <build-folder>/components/catch2-src/src/catch2/internal/catch_enum_values_registry.cpp
In file included from <build-folder>/components/catch2-src/src/catch2/internal/catch_enum_values_registry.cpp:9:
<build-folder>/components/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:47:14: error: ‘uint64_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   47 |         std::uint64_t m_count;
      |              ^~~~~~~~
      |              wint_t
<build-folder>/components/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:51:42: error: expected ‘)’ before ‘count’
   51 |         constexpr pluralise(std::uint64_t count, StringRef label):
      |                            ~             ^~~~~~
      |                                          )
[49/132 18.6/sec] Building CXX object components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_debug_console.cpp.o
[50/132 18.9/sec] Building CXX object components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_case_insensitive_comparisons.cpp.o
FAILED: components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_case_insensitive_comparisons.cpp.o 
/usr/lib/ccache/bin/g++  -I<build-folder>/components/catch2-src/src/catch2/.. -I<build-folder>/generated-includes -DQT_QML_DEBUG -g -std=gnu++23 -ffile-prefix-map=<build-folder>/components/catch2-src=. -MD -MT components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_case_insensitive_comparisons.cpp.o -MF components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_case_insensitive_comparisons.cpp.o.d -o components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_case_insensitive_comparisons.cpp.o -c <build-folder>/components/catch2-src/src/catch2/internal/catch_case_insensitive_comparisons.cpp
In file included from <build-folder>/components/catch2-src/src/catch2/internal/catch_case_insensitive_comparisons.cpp:10:
<build-folder>/components/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:47:14: error: ‘uint64_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   47 |         std::uint64_t m_count;
      |              ^~~~~~~~
      |              wint_t
<build-folder>/components/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:51:42: error: expected ‘)’ before ‘count’
   51 |         constexpr pluralise(std::uint64_t count, StringRef label):
      |                            ~             ^~~~~~
      |                                          )
[51/132 18.5/sec] Building CXX object components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_exception_translator_registry.cpp.o
[52/132 18.8/sec] Building CXX object components/cpputils-build/CMakeFiles/cpputils.dir/src/color_utils.cpp.o
[53/132 19.2/sec] Building CXX object components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_enforce.cpp.o
[54/132 17.8/sec] Building CXX object components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_istream.cpp.o
[55/132 14.9/sec] Building CXX object components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o
FAILED: components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o 
/usr/lib/ccache/bin/g++  -I<build-folder>/components/catch2-src/src/catch2/.. -I<build-folder>/generated-includes -DQT_QML_DEBUG -g -std=gnu++23 -ffile-prefix-map=<build-folder>/components/catch2-src=. -MD -MT components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o -MF components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o.d -o components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o -c <build-folder>/components/catch2-src/src/catch2/internal/catch_clara.cpp
In file included from <build-folder>/components/catch2-src/src/catch2/internal/catch_clara.cpp:12:
<build-folder>/components/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:47:14: error: ‘uint64_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   47 |         std::uint64_t m_count;
      |              ^~~~~~~~
      |              wint_t
<build-folder>/components/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:51:42: error: expected ‘)’ before ‘count’
   51 |         constexpr pluralise(std::uint64_t count, StringRef label):
      |                            ~             ^~~~~~
      |                                          )
[56/132 10.8/sec] Building CXX object components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_fatal_condition_handler.cpp.o
[57/132 10.5/sec] Building CXX object components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/interfaces/catch_interfaces_reporter.cpp.o
[58/132 9.3/sec] Building CXX object components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/matchers/catch_matchers_quantifiers.cpp.o
[59/132 8.9/sec] Building CXX object components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_list.cpp.o
[60/132 8.9/sec] Building CXX object components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/matchers/catch_matchers_floating_point.cpp.o
[61/132 5.6/sec] Building CXX object components/catch2-build/src/CMakeFiles/Catch2.dir/catch2/matchers/catch_matchers_string.cpp.o
```

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
