### PR TITLE
Edited amalgamated file generator, to block REUSE from getting confused

### DIFF
--- a/tools/scripts/generateAmalgamatedFiles.py
+++ b/tools/scripts/generateAmalgamatedFiles.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+#              Copyright Catch2 Authors
+# Distributed under the Boost Software License, Version 1.0.
+#   (See accompanying file LICENSE.txt or copy at
+#        https://www.boost.org/LICENSE_1_0.txt)
+# SPDX-License-Identifier: BSL-1.0
 
 import os
 import re
@@ -11,6 +16,8 @@ root_path = os.path.join(catchPath, 'src')
 starting_header = os.path.join(root_path, 'catch2', 'catch_all.hpp')
 output_header = os.path.join(catchPath, 'extras', 'catch_amalgamated.hpp')
 output_cpp = os.path.join(catchPath, 'extras', 'catch_amalgamated.cpp')
+
+# REUSE-IgnoreStart
 
 # These are the copyright comments in each file, we want to ignore them
 copyright_lines = [
@@ -38,6 +45,8 @@ file_header = '''\
 //  You probably shouldn't edit it directly.
 //  ----------------------------------------------------------
 '''
+
+# REUSE-IgnoreEnd
 
 # Returns file header with proper version string and generation time
 def formatted_file_header(version):


### PR DESCRIPTION
## Description
I use the [REUSE tool](https://reuse.software) to generate a software bill-of-materials
for projects I work on. Some of them include a copy of Catch2. However, the REUSE
tool gets confused by code or docs that include things that look like copyright/license statements.

(Without this patch, the following error happens:

```
reuse._util - ERROR - Could not parse 'BSL-1.0\n','
reuse.project - ERROR - 'src/external/catch2/tools/scripts/generateAmalgamatedFiles.py' holds an SPDX expression that cannot be parsed, skipping the file
```
)

They do support comments to disable recognition, so I have added those in the script in question


(It would be really cool if all of Catch2 passed REUSE, but at least not breaking the tool is a start.)
