### PR TITLE
Add cstdint to relevant headers

### DIFF
--- a/src/catch2/catch_test_case_info.hpp
+++ b/src/catch2/catch_test_case_info.hpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/src/catch2/internal/catch_string_manip.hpp
+++ b/src/catch2/internal/catch_string_manip.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <iosfwd>
 #include <vector>
+#include <cstdint>
 
 namespace Catch {
 

--- a/src/catch2/internal/catch_xmlwriter.cpp
+++ b/src/catch2/internal/catch_xmlwriter.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <iomanip>
 #include <type_traits>
+#include <cstdint>
 
 namespace Catch {
 


### PR DESCRIPTION
## Description
Simple fix to get catch2 to compile on GCC 13.1. GCC 13 [requires explicit inclusion](https://gcc.gnu.org/gcc-13/porting_to.html) of some headers, such as `<cstdint>`