### PR TITLE
implement stringify for std::nullopt_t

### DIFF
--- a/src/catch2/catch_tostring.hpp
+++ b/src/catch2/catch_tostring.hpp
@@ -398,6 +398,12 @@ namespace Catch {
             }
         }
     };
+    template <>
+    struct StringMaker<std::nullopt_t> {
+        static std::string convert(const std::nullopt_t&) {
+            return "{ }";
+        }
+    };
 }
 #endif // CATCH_CONFIG_ENABLE_OPTIONAL_STRINGMAKER
 

--- a/tests/SelfTest/UsageTests/ToStringOptional.tests.cpp
+++ b/tests/SelfTest/UsageTests/ToStringOptional.tests.cpp
@@ -28,4 +28,8 @@ TEST_CASE( "std::vector<std::optional<int> > -> toString", "[toString][optional]
     REQUIRE( "{ 0, { }, 2 }" == ::Catch::Detail::stringify( type{ 0, {}, 2 } ) );
 }
 
+TEST_CASE( "std::nullopt -> toString", "[toString][optional][approvals]" ) {
+    REQUIRE( "{ }" == ::Catch::Detail::stringify( std::nullopt ) );
+}
+
 #endif // CATCH_INTERNAL_CONFIG_CPP17_OPTIONAL


### PR DESCRIPTION
## Description

With `CHECK(some_optional == std::nullopt)`, `nullopt` was stringified differently than `std::optional<T>()` (that is, `{?}` as opposed to `{ }`). That's because `std::nullopt` is not an optional but a special type.

This MR adds stringification for `std::nullopt_t`.