### PR TITLE
Mark `CATCH_CONFIG_` options as advanced

### DIFF
--- a/CMake/CatchConfigOptions.cmake
+++ b/CMake/CatchConfigOptions.cmake
@@ -18,10 +18,12 @@
 macro(AddOverridableConfigOption OptionBaseName)
   option(CATCH_CONFIG_${OptionBaseName} "Read docs/configuration.md for details" OFF)
   option(CATCH_CONFIG_NO_${OptionBaseName} "Read docs/configuration.md for details" OFF)
+  mark_as_advanced(CATCH_CONFIG_${OptionBaseName} CATCH_CONFIG_NO_${OptionBaseName})
 endmacro()
 
 macro(AddConfigOption OptionBaseName)
   option(CATCH_CONFIG_${OptionBaseName} "Read docs/configuration.md for details" OFF)
+  mark_as_advanced(CATCH_CONFIG_${OptionBaseName})
 endmacro()
 
 set(_OverridableOptions
@@ -78,6 +80,8 @@ endif()
 
 set(CATCH_CONFIG_DEFAULT_REPORTER "console" CACHE STRING "Read docs/configuration.md for details. The name of the reporter should be without quotes.")
 set(CATCH_CONFIG_CONSOLE_WIDTH "80" CACHE STRING "Read docs/configuration.md for details. Must form a valid integer literal.")
+
+mark_as_advanced(CATCH_CONFIG_SHARED_LIBRARY CATCH_CONFIG_DEFAULT_REPORTER CATCH_CONFIG_CONSOLE_WIDTH)
 
 # There is no good way to both turn this into a CMake cache variable,
 # and keep reasonable default semantics inside the project. Thus we do


### PR DESCRIPTION
## Description
These options are rather low-level and don't need to be seen in the CMake cache unless you opt into seeing all other advanced options.

This removes a lot of cache entries from the screen when using a GUI or TUI to view the cache thus making it easier for developers of Catch2 and users of it using FetchContent to focus on the cache variables they're most likely to change.

Before:
<img width="278" alt="Screenshot 2023-10-31 at 10 20 16 AM" src="https://github.com/catchorg/Catch2/assets/39244355/e7dbe771-427c-48e4-a2cc-65e80f6464c7">

After:
<img width="278" alt="Screenshot 2023-10-31 at 10 18 58 AM" src="https://github.com/catchorg/Catch2/assets/39244355/8bca997d-5a63-4371-a1a3-363b1dcb6b35">

