### PR TITLE
Increase build parallelism on macOS

### DIFF
--- a/.github/workflows/mac-builds.yml
+++ b/.github/workflows/mac-builds.yml
@@ -42,11 +42,10 @@ jobs:
 
     - name: Build tests + lib
       working-directory: ${{runner.workspace}}/build
-      run: make -j 3
+      run: make -j `sysctl -n hw.ncpu`
 
     - name: Run tests
       env:
           CTEST_OUTPUT_ON_FAILURE: 1
       working-directory: ${{runner.workspace}}/build
-      # Hardcode 3 cores we know are there
-      run: ctest -C ${{matrix.build_type}} -j 3
+      run: ctest -C ${{matrix.build_type}} -j `sysctl -n hw.ncpu`

--- a/.github/workflows/mac-builds.yml
+++ b/.github/workflows/mac-builds.yml
@@ -42,11 +42,11 @@ jobs:
 
     - name: Build tests + lib
       working-directory: ${{runner.workspace}}/build
-      run: make -j 2
+      run: make -j 3
 
     - name: Run tests
       env:
           CTEST_OUTPUT_ON_FAILURE: 1
       working-directory: ${{runner.workspace}}/build
-      # Hardcode 2 cores we know are there
-      run: ctest -C ${{matrix.build_type}} -j 2
+      # Hardcode 3 cores we know are there
+      run: ctest -C ${{matrix.build_type}} -j 3


### PR DESCRIPTION
According to [this information](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), all the macOS runners have at least 3 cores, so it makes sense to increase the build parallelism to this number.
