### PR TITLE
Bump up actions/checkout version to v4

### DIFF
--- a/.github/workflows/linux-bazel-builds.yml
+++ b/.github/workflows/linux-bazel-builds.yml
@@ -11,7 +11,7 @@ jobs:
         compilation_mode: [fastbuild, dbg, opt]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Mount bazel cache
       uses: actions/cache@v3

--- a/.github/workflows/linux-meson-builds.yml
+++ b/.github/workflows/linux-meson-builds.yml
@@ -18,7 +18,7 @@ jobs:
             other_pkgs: clang-11
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Prepare environment
       run: sudo apt-get install -y meson ninja-build ${{matrix.other_pkgs}}

--- a/.github/workflows/linux-other-builds.yml
+++ b/.github/workflows/linux-other-builds.yml
@@ -70,7 +70,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Prepare environment
       run: sudo apt-get install -y ninja-build ${{matrix.other_pkgs}}

--- a/.github/workflows/linux-simple-builds.yml
+++ b/.github/workflows/linux-simple-builds.yml
@@ -83,7 +83,7 @@ jobs:
             other_pkgs: g++-10
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Add repositories for older GCC
       run: |

--- a/.github/workflows/mac-builds.yml
+++ b/.github/workflows/mac-builds.yml
@@ -22,7 +22,7 @@ jobs:
             extra_tests: ON
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Configure build
       working-directory: ${{runner.workspace}}

--- a/.github/workflows/validate-header-guards.yml
+++ b/.github/workflows/validate-header-guards.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
 
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Dependencies
         uses: actions/setup-python@v2

--- a/.github/workflows/windows-simple-builds.yml
+++ b/.github/workflows/windows-simple-builds.yml
@@ -13,7 +13,7 @@ jobs:
         build_type: [Debug, Release]
         std: [14, 17]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure build
         working-directory: ${{runner.workspace}}


### PR DESCRIPTION
This gets rid of the warning displayed in actions run annotation:
`The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2.`

