### PR TITLE
lifted suggested version in documentation from 3.0.1 to 3.4.0 to avoid compilation issues

### DIFF
--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -51,7 +51,7 @@ Include(FetchContent)
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v3.0.1 # or a later release
+  GIT_TAG        v3.4.0 # or a later release
 )
 
 FetchContent_MakeAvailable(Catch2)


### PR DESCRIPTION
Did this, because with 3.0.1, the files
- catch_xmlwriter.cpp
- catch_string_manip.hpp
- catch_test_case_info.hpp

were missing

This led to some obvious and some obscure compile errors when compiling with g++ 13.2.0 (std c++17 or c++20)
One of these errors being "Elaborated-type-specifier for a scoped enum must not use the ‘class’ keyword"

Since this is a rather bad experience and debugging it is time-consuming, I suggest to simply boost the recommended version in the snippet which is likely copied by new Catch2 users

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
