### PR TITLE
Add sections support to TeamCity reporter

### DIFF
--- a/src/catch2/reporters/catch_reporter_teamcity.hpp
+++ b/src/catch2/reporters/catch_reporter_teamcity.hpp
@@ -12,6 +12,7 @@
 #include <catch2/catch_timer.hpp>
 
 #include <cstring>
+#include <string>
 
 #ifdef __clang__
 #   pragma clang diagnostic push
@@ -22,11 +23,7 @@ namespace Catch {
 
     class TeamCityReporter final : public StreamingReporterBase {
     public:
-        TeamCityReporter( ReporterConfig&& _config )
-        :   StreamingReporterBase( CATCH_MOVE(_config) )
-        {
-            m_preferences.shouldRedirectStdOut = true;
-        }
+        TeamCityReporter( ReporterConfig&& _config );
 
         ~TeamCityReporter() override;
 
@@ -38,23 +35,25 @@ namespace Catch {
         void testRunStarting( TestRunInfo const& groupInfo ) override;
         void testRunEnded( TestRunStats const& testGroupStats ) override;
 
-
         void assertionEnded(AssertionStats const& assertionStats) override;
 
-        void sectionStarting(SectionInfo const& sectionInfo) override {
-            m_headerPrintedForThisSection = false;
-            StreamingReporterBase::sectionStarting( sectionInfo );
-        }
+        void sectionStarting( SectionInfo const& sectionInfo ) override;
+        void sectionEnded( SectionStats const& sectionStats ) override;
 
         void testCaseStarting(TestCaseInfo const& testInfo) override;
 
         void testCaseEnded(TestCaseStats const& testCaseStats) override;
 
     private:
-        void printSectionHeader(std::ostream& os);
+        std::string printSectionName();
+        std::string createTestCaseHeader( std::string name );
+        std::string createTestCaseFooter( std::string name, double duration );
+        void parseCustomOptions();
 
-        bool m_headerPrintedForThisSection = false;
-        Timer m_testTimer;
+        Timer m_testCaseTimer;
+        bool m_headerPrintedForThisSection{ false };
+        bool m_printSections{ false };
+        std::string m_sectionSeparator{ "." };
     };
 
 } // end namespace Catch


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
This MR allows for printing SECTIONs when using TeamCity reporter.

Two new TeamCity reporter options were added: 
`Xsections=true/false` - enable printing sections
`Xseparator=` - optional, override the default separator(".") when composing unique test cases from sections

As TeamCity only operates on ordinary test cases(no extra sections tags as far as I know), it is required to flatten the section tree. 
Test case names are built as follows:`name='<TEST_CASE>.<SECTION>.*']`
Additionally, any spaces within test/section name are replaced with underscores.

An example of entry:
`##teamcity[testStarted name='basic_test.check_if_x.should_do_y']`

TBH, I would get rid of section option in favour of supporting it permanently. Such change will make code much simpler and more readable, but the decision is up to you.

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
Mentioned here: https://github.com/catchorg/Catch2/issues/1879
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
