### PR TITLE
Handle linking to liblog when [cross] building for Android using meson.

### DIFF
--- a/src/catch2/meson.build
+++ b/src/catch2/meson.build
@@ -18,6 +18,8 @@ configure_file(
   configuration: conf_data,
 )
 
+fs = import('fs')
+
 benchmark_headers = [
   'benchmark/catch_benchmark.hpp',
   'benchmark/catch_benchmark_all.hpp',
@@ -341,7 +343,10 @@ foreach file : headers
 endforeach
 
 catch2_dependencies = []
-if (host_machine.system() == 'android')
+# Check if this is an Android NDK build.
+if ((host_machine.system() == 'android') or
+  # Check if this is an Android Termux build.
+  (host_machine.system() == 'linux' and fs.is_dir('/data/data/com.termux')))
   log_dep = meson.get_compiler('cpp').find_library('log')
   catch2_dependencies += log_dep
 endif

--- a/src/catch2/meson.build
+++ b/src/catch2/meson.build
@@ -340,9 +340,16 @@ foreach file : headers
   install_headers(file, subdir: join_paths(include_subdir, folder))
 endforeach
 
+catch2_dependencies = []
+if (host_machine.system() == 'android')
+  log_dep = meson.get_compiler('cpp').find_library('log')
+  catch2_dependencies += log_dep
+endif
+
 catch2 = static_library(
   'Catch2',
   sources,
+  dependencies: catch2_dependencies,
   include_directories: '..',
   install: true,
 )


### PR DESCRIPTION
## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
When cross building with meson for the Android NDK, and additional link to liblog is required but was missing from the meson build directives. This adds checking in the meson build directives for if the system is android. Without linking the build will give the following error:
```
ld.lld: error: undefined symbol: __android_log_write
>>> referenced by catch_debug_console.cpp:24 (../src/catch2/internal/catch_debug_console.cpp:24)
>>>               internal_catch_debug_console.cpp.o:(Catch::writeToDebugConsole(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)) in archive src/catch2/libCatch2.a
clang-17: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

While testing I also tried a build on Termux and found that it too needed to have liblog linked, but in meson on Termux the system is reported as 'linux' instead of 'android', so I added a big of a hack to detect Termux by checking for its system data folder.

Test for both builds ran successfully on my Android device under Termux, but I had to copy over some .so libraries for the NDK build as the test doesn't statically link them - it doesn't seem particularly necessary for me but if this is an issue please comment and I'll try to add detection for NDK and impose a static build on the self test.

Also note I added the 'fs' module include toward the top of the meson.build file because that feels more "correct" to me.