### PR TITLE
Fix clang warning about redundant link libraries

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -53,7 +53,7 @@ set(ALL_EXAMPLE_TARGETS
 )
 
 foreach( name ${ALL_EXAMPLE_TARGETS} )
-    target_link_libraries( ${name} Catch2 Catch2WithMain )
+    target_link_libraries( ${name} Catch2WithMain )
 endforeach()
 
 


### PR DESCRIPTION
## Description
Fixes the following warnings when building the library.

```
[1/12] Linking CXX executable examples/210-Evt-EventListeners
ld: warning: ignoring duplicate libraries: 'src/libCatch2d.a'
[2/12] Linking CXX executable examples/020-MultiFile
ld: warning: ignoring duplicate libraries: 'src/libCatch2d.a'
[3/12] Linking CXX executable examples/300-Gen-OwnGenerator
ld: warning: ignoring duplicate libraries: 'src/libCatch2d.a'
[4/12] Linking CXX executable examples/310-Gen-VariablesInGenerators
ld: warning: ignoring duplicate libraries: 'src/libCatch2d.a'
[5/12] Linking CXX executable examples/010-TestCase
ld: warning: ignoring duplicate libraries: 'src/libCatch2d.a'
[6/12] Linking CXX executable examples/120-Bdd-ScenarioGivenWhenThen
ld: warning: ignoring duplicate libraries: 'src/libCatch2d.a'
[7/12] Linking CXX executable examples/100-Fix-Section
ld: warning: ignoring duplicate libraries: 'src/libCatch2d.a'
[8/12] Linking CXX executable examples/302-Gen-Table
ld: warning: ignoring duplicate libraries: 'src/libCatch2d.a'
[9/12] Linking CXX executable examples/110-Fix-ClassFixture
ld: warning: ignoring duplicate libraries: 'src/libCatch2d.a'
[10/12] Linking CXX executable examples/030-Asn-Require-Check
ld: warning: ignoring duplicate libraries: 'src/libCatch2d.a'
[11/12] Linking CXX executable examples/311-Gen-CustomCapture
ld: warning: ignoring duplicate libraries: 'src/libCatch2d.a'
[12/12] Linking CXX executable examples/301-Gen-MapTypeConversion
ld: warning: ignoring duplicate libraries: 'src/libCatch2d.a'
```