### PR TITLE
Improve tutorial.md with link to two-file setup instructions.

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -16,7 +16,7 @@ Ideally you should be using Catch2 through its [CMake integration](cmake-integra
 Catch2 also provides pkg-config files and two file (header + cpp)
 distribution, but this documentation will assume you are using CMake. If
 you are using the two file distribution instead, remember to replace
-the included header with `catch_amalgamated.hpp`.
+the included header with `catch_amalgamated.hpp` ([step by step instructions](migrate-v2-to-v3.md#how-to-migrate-projects-from-v2-to-v3)).
 
 
 ## Writing tests


### PR DESCRIPTION
## Description
Add link in tutorial because otherwise it is not clear how to follow those steps (for example, it is not mentioned where those two files can be found) and it requires more effort to start.