### PR TITLE
reporters: silence -Wsubobject-linkage

### DIFF
--- a/src/catch2/reporters/catch_reporter_console.cpp
+++ b/src/catch2/reporters/catch_reporter_console.cpp
@@ -209,13 +209,6 @@ findMax( std::size_t& i, std::size_t& j, std::size_t& k, std::size_t& l ) {
         return l;
 }
 
-enum class Justification { Left, Right };
-
-struct ColumnInfo {
-    std::string name;
-    std::size_t width;
-    Justification justification;
-};
 struct ColumnBreak {};
 struct RowBreak {};
 struct OutputFlush {};
@@ -292,6 +285,14 @@ public:
     }
 };
 } // end anon namespace
+
+enum class Justification { Left, Right };
+
+struct ColumnInfo {
+    std::string name;
+    std::size_t width;
+    Justification justification;
+};
 
 class TablePrinter {
     std::ostream& m_os;


### PR DESCRIPTION
gcc emits `Wsubobject-linkage`, because the the publicly visible `TablePrinter` contains `ColumnInfo`, which is part of an anonymous namespace

## Description
```
path/to/src/catch2/reporters/catch_reporter_console.cpp:296:7: warning: ‘Catch::TablePrinter’ has a field ‘Catch::TablePrinter::m_columnInfos’ whose type uses the anonymous namespace [-Wsubobject-linkage]
  296 | class TablePrinter {
      |       ^~~~~~~~~~~~
```