### PR TITLE
Fix rhel-9 SAST scan issues

### DIFF
--- a/src/catch2/catch_test_case_info.cpp
+++ b/src/catch2/catch_test_case_info.cpp
@@ -88,8 +88,12 @@ namespace Catch {
             --lastDot;
 
             size_t nameStart = lastDot;
-            while (nameStart > 0 && filename[nameStart - 1] != '/' && filename[nameStart - 1] != '\\') {
+            if (nameStart < filename.size()) {
+               while (nameStart > 0 && filename[nameStart - 1] != '/' && filename[nameStart - 1] != '\\') {
                 --nameStart;
+                }
+            } else {
+                nameStart = 0;
             }
 
             return filename.substr(nameStart, lastDot - nameStart);

--- a/src/catch2/internal/catch_random_seed_generation.cpp
+++ b/src/catch2/internal/catch_random_seed_generation.cpp
@@ -16,15 +16,15 @@
 
 namespace Catch {
 
-    std::uint32_t generateRandomSeed( GenerateFrom from ) {
+    std::uint64_t generateRandomSeed( GenerateFrom from ) {
         switch ( from ) {
         case GenerateFrom::Time:
-            return static_cast<std::uint32_t>( std::time( nullptr ) );
+            return static_cast<std::uint64_t>( std::time( nullptr ) );
 
         case GenerateFrom::Default:
         case GenerateFrom::RandomDevice: {
             std::random_device rd;
-            return Detail::fillBitsFrom<std::uint32_t>( rd );
+            return Detail::fillBitsFrom<std::uint64_t>( rd );
         }
 
         default:

--- a/src/catch2/internal/catch_random_seed_generation.hpp
+++ b/src/catch2/internal/catch_random_seed_generation.hpp
@@ -19,7 +19,7 @@ namespace Catch {
         Default
     };
 
-    std::uint32_t generateRandomSeed(GenerateFrom from);
+    std::uint64_t generateRandomSeed(GenerateFrom from);
 
 } // end namespace Catch
 

--- a/src/catch2/reporters/catch_reporter_cumulative_base.cpp
+++ b/src/catch2/reporters/catch_reporter_cumulative_base.cpp
@@ -87,8 +87,8 @@ namespace Catch {
             if ( it == parentNode.childSections.end() ) {
                 auto newNode =
                     Detail::make_unique<SectionNode>( incompleteStats );
-                node = newNode.get();
                 parentNode.childSections.push_back( CATCH_MOVE( newNode ) );
+                node = newNode.get();
             } else {
                 node = it->get();
             }


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
This Patch helps to address the SAST scan issues in Red Hat Enterprise Linux-9
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
Related to https://github.com/catchorg/Catch2/issues/2798
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
