### PR TITLE
Fix clang-tidy `bugprone-chained-comparison` warnings

### DIFF
--- a/src/catch2/internal/catch_test_macro_impl.hpp
+++ b/src/catch2/internal/catch_test_macro_impl.hpp
@@ -49,7 +49,7 @@
         INTERNAL_CATCH_TRY { \
             CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
             CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
-            catchAssertionHandler.handleExpr( Catch::Decomposer() <= __VA_ARGS__ ); \
+            catchAssertionHandler.handleExpr( Catch::Decomposer() <= __VA_ARGS__ ); /* NOLINT(bugprone-chained-comparison) */ \
             CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
         } INTERNAL_CATCH_CATCH( catchAssertionHandler ) \
         INTERNAL_CATCH_REACT( catchAssertionHandler ) \


### PR DESCRIPTION
## Description
This triggers when running clang-tidy's bugprone-* family of checks in code which uses Catch2 even if Catch2 headers are marked as SYSTEM headers due to how code expanded from macros is treated as first party even if the macro comes from a 3rd party library. The fix is luckily pretty straightforward.

This check is added in clang-tidy-18 due for release later this year.

https://github.com/llvm/llvm-project/pull/76365