### PR TITLE
Fix number of current reporter

### DIFF
--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -5,7 +5,7 @@ Reporters are a customization point for most of Catch2's output, e.g.
 formatting and writing out [assertions (whether passing or failing),
 sections, test cases, benchmarks, and so on](reporter-events.md#top).
 
-Catch2 comes with a bunch of reporters by default (currently 8), and
+Catch2 comes with a bunch of reporters by default (currently 9), and
 you can also write your own reporter. Because multiple reporters can
 be active at the same time, your own reporters do not even have to handle
 all reporter event, just the ones you are interested in, e.g. benchmarks.


### PR DESCRIPTION
## Description
There are nine reporters in Catch2 3.5.2, Automake, compact, console, JSON, JUnit, SonarQube, TAP, TeamCity and XML.

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->



<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
