### PR TITLE
Clarify unit of test duration in docs

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -365,14 +365,14 @@ There are currently two warnings implemented:
 ## Reporting timings
 <pre>-d, --durations &lt;yes/no></pre>
 
-When set to ```yes``` Catch will report the duration of each test case, in milliseconds. Note that it does this regardless of whether a test case passes or fails. Note, also, the certain reporters (e.g. Junit) always report test case durations regardless of this option being set or not.
+When set to ```yes``` Catch will report the duration of each test case, in seconds with millisecond precision. Note that it does this regardless of whether a test case passes or fails. Note, also, the certain reporters (e.g. Junit) always report test case durations regardless of this option being set or not.
 
 <pre>-D, --min-duration &lt;value></pre>
 
 > `--min-duration` was [introduced](https://github.com/catchorg/Catch2/pull/1910) in Catch2 2.13.0
 
 When set, Catch will report the duration of each test case that took more
-than &lt;value> seconds, in milliseconds. This option is overridden by both
+than &lt;value> seconds, in seconds with millisecond precision. This option is overridden by both
 `-d yes` and `-d no`, so that either all durations are reported, or none
 are.
 


### PR DESCRIPTION
## Description

Test duration with `-d yes` or with `-D` is shown in seconds with millisecond precision, not in milliseconds.
