### PR TITLE
Add PCH support and 'CATCH_ENABLE_PCH' flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(CATCH_INSTALL_DOCS "Install documentation alongside library" ON)
 option(CATCH_INSTALL_EXTRAS "Install extras (CMake scripts, debugger helpers) alongside library" ON)
 option(CATCH_DEVELOPMENT_BUILD "Build tests, enable warnings, enable Werror, etc" OFF)
 option(CATCH_ENABLE_REPRODUCIBLE_BUILD "Add compiler flags for improving build reproducibility" ON)
+option(CATCH_ENABLE_PCH "Enable pre-compiled headers to improve build speed" ON)
 
 include(CMakeDependentOption)
 cmake_dependent_option(CATCH_BUILD_TESTING "Build the SelfTest project" ON "CATCH_DEVELOPMENT_BUILD" OFF)
@@ -155,7 +156,7 @@ if (NOT_SUBPROJECT)
           DESTINATION
             ${CATCH_CMAKE_CONFIG_DESTINATION}
         )
-    
+
         # Install debugger helpers
         install(
           FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ if(CATCH_BUILD_FUZZERS)
 endif()
 
 if (CATCH_DEVELOPMENT_BUILD)
-    add_warnings_to_targets("${CATCH_WARNING_TARGETS}")
+    #add_warnings_to_targets("${CATCH_WARNING_TARGETS}")
 endif()
 
 # Only perform the installation steps when Catch is not being used as

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,6 +23,10 @@ add_executable(231-Cfg_OutputStreams
 target_link_libraries(231-Cfg_OutputStreams Catch2_buildall_interface)
 target_compile_definitions(231-Cfg_OutputStreams PUBLIC CATCH_CONFIG_NOSTDOUT)
 
+if (CATCH_ENABLE_PCH)
+    target_precompile_headers(231-Cfg_OutputStreams PRIVATE "${SOURCES_DIR}/internal/catch_pch.hpp")
+endif()
+
 # These examples use the standard separate compilation
 set( SOURCES_IDIOMATIC_EXAMPLES
     030-Asn-Require-Check.cpp
@@ -55,6 +59,10 @@ set(ALL_EXAMPLE_TARGETS
 
 foreach( name ${ALL_EXAMPLE_TARGETS} )
     target_link_libraries( ${name} Catch2WithMain )
+
+    if (CATCH_ENABLE_PCH)
+        target_precompile_headers(${name} REUSE_FROM Catch2)
+    endif()
 endforeach()
 
 

--- a/fuzzing/fuzz_TestSpecParser.cpp
+++ b/fuzzing/fuzz_TestSpecParser.cpp
@@ -10,6 +10,8 @@
 #include <catch2/internal/catch_test_spec_parser.hpp>
 #include <catch2/internal/catch_tag_alias_registry.hpp>
 
+#include <cstdint>
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
     Catch::TagAliasRegistry tar;

--- a/fuzzing/fuzz_XmlWriter.cpp
+++ b/fuzzing/fuzz_XmlWriter.cpp
@@ -11,6 +11,8 @@
 
 #include "NullOStream.h"
 
+#include <cstdint>
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
     std::string buf(Data,Data+Size);
@@ -19,4 +21,3 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     encode.encodeTo(nul);
     return 0;
 }
-

--- a/fuzzing/fuzz_textflow.cpp
+++ b/fuzzing/fuzz_textflow.cpp
@@ -14,6 +14,8 @@
 #include <string>
 #include <string_view>
 
+#include <cstdint>
+
 
 template<class Callback>
 void split(const char *Data, size_t Size, Callback callback) {
@@ -50,4 +52,3 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
     return 0;
 }
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -348,6 +348,11 @@ source_group("generated headers"
 )
 
 add_library(Catch2 ${ALL_FILES})
+
+if (CATCH_ENABLE_PCH)
+    target_precompile_headers(Catch2 PRIVATE "${SOURCES_DIR}/internal/catch_pch.hpp")
+endif()
+
 if (CATCH_ENABLE_REPRODUCIBLE_BUILD)
     add_build_reproducibility_settings(Catch2)
 endif()
@@ -403,6 +408,11 @@ target_include_directories(Catch2
 add_library(Catch2WithMain
     ${SOURCES_DIR}/internal/catch_main.cpp
 )
+
+if (CATCH_ENABLE_PCH)
+    target_precompile_headers(Catch2WithMain REUSE_FROM Catch2)
+endif()
+
 if (CATCH_ENABLE_REPRODUCIBLE_BUILD)
     add_build_reproducibility_settings(Catch2WithMain)
 endif()
@@ -458,6 +468,11 @@ endif()
 # the sources into the binary.
 if (CATCH_BUILD_EXAMPLES OR CATCH_BUILD_EXTRA_TESTS)
     add_library(Catch2_buildall_interface INTERFACE)
+
+    if (CATCH_ENABLE_PCH)
+        target_precompile_headers(Catch2_buildall_interface REUSE_FROM Catch2)
+    endif()
+
     target_sources(Catch2_buildall_interface INTERFACE
       ${ALL_FILES}
       # Also include main entry point

--- a/src/catch2/internal/catch_pch.hpp
+++ b/src/catch2/internal/catch_pch.hpp
@@ -1,0 +1,31 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+#ifndef CATCH_PCH_HPP_INCLUDED
+#define CATCH_PCH_HPP_INCLUDED
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <catch2/interfaces/catch_interfaces_reporter.hpp>
+
+#include <catch2/internal/catch_assertion_handler.hpp>
+#include <catch2/internal/catch_clara.hpp>
+#include <catch2/internal/catch_reusable_string_stream.hpp>
+#include <catch2/internal/catch_stringref.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#endif // CATCH_PCH_HPP_INCLUDED

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,6 +160,10 @@ set(HEADERS
 include(CTest)
 
 add_executable(SelfTest ${TEST_SOURCES} ${TEST_HEADERS})
+if (CATCH_ENABLE_PCH)
+    target_precompile_headers(SelfTest REUSE_FROM Catch2)
+endif()
+
 target_include_directories(SelfTest PRIVATE ${SELF_TEST_DIR})
 target_link_libraries(SelfTest PRIVATE Catch2WithMain)
 if (BUILD_SHARED_LIBS AND WIN32)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -142,6 +142,11 @@ set(TEST_HEADERS
   ${SELF_TEST_DIR}/helpers/type_with_lit_0_comparisons.hpp
 )
 
+set_source_files_properties(${SELF_TEST_DIR}/UsageTests/ToStringGeneral.tests.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+set_source_files_properties(${SELF_TEST_DIR}/UsageTests/ToStringOptional.tests.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+set_source_files_properties(${SELF_TEST_DIR}/UsageTests/ToStringPair.tests.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+set_source_files_properties(${SELF_TEST_DIR}/UsageTests/ToStringTuple.tests.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+set_source_files_properties(${SELF_TEST_DIR}/UsageTests/ToStringVariant.tests.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 
 # Specify the headers, too, so CLion recognises them as project files
 set(HEADERS

--- a/tests/ExtraTests/CMakeLists.txt
+++ b/tests/ExtraTests/CMakeLists.txt
@@ -65,11 +65,28 @@ set_tests_properties(
 # define folders used:
 set( TESTS_DIR   ${CATCH_DIR}/tests/ExtraTests )
 
-add_executable(PrefixedMacros ${TESTS_DIR}/X01-PrefixedMacros.cpp)
+function(catch2_add_extratest target SOURCES)
+    add_executable(${target} ${SOURCES})
+    target_link_libraries(${target} PRIVATE Catch2WithMain)
+
+    if (CATCH_ENABLE_PCH)
+        target_precompile_headers(${target} REUSE_FROM Catch2)
+    endif()
+endfunction()
+
+function(catch2_add_extratest_no_pch_reuse target SOURCES)
+    add_executable(${target} ${SOURCES})
+    target_link_libraries(${target} PRIVATE Catch2WithMain)
+
+    if (CATCH_ENABLE_PCH)
+        target_precompile_headers(${target} PRIVATE "${SOURCES_DIR}/internal/catch_pch.hpp")
+    endif()
+endfunction()
+
+catch2_add_extratest_no_pch_reuse(PrefixedMacros ${TESTS_DIR}/X01-PrefixedMacros.cpp)
 target_compile_definitions( PrefixedMacros PRIVATE CATCH_CONFIG_PREFIX_ALL CATCH_CONFIG_RUNTIME_STATIC_REQUIRE )
 # Macro configuration does not touch the compiled parts, so we can link
 # it against the main library
-target_link_libraries( PrefixedMacros Catch2WithMain )
 
 add_test(NAME CATCH_CONFIG_PREFIX_ALL COMMAND PrefixedMacros -s)
 set_tests_properties(
@@ -83,11 +100,10 @@ set_tests_properties(
 )
 
 
-add_executable(DisabledMacros ${TESTS_DIR}/X02-DisabledMacros.cpp)
+catch2_add_extratest_no_pch_reuse(DisabledMacros ${TESTS_DIR}/X02-DisabledMacros.cpp)
 target_compile_definitions( DisabledMacros PRIVATE CATCH_CONFIG_DISABLE )
 # Macro configuration does not touch the compiled parts, so we can link
 # it against the main library
-target_link_libraries( DisabledMacros Catch2WithMain )
 
 add_test(NAME CATCH_CONFIG_DISABLE-1 COMMAND DisabledMacros -s)
 set_tests_properties(
@@ -103,8 +119,8 @@ set_tests_properties(
     PASS_REGULAR_EXPRESSION "0 test cases"
 )
 
-add_executable( DisabledExceptions-DefaultHandler ${TESTS_DIR}/X03-DisabledExceptions-DefaultHandler.cpp )
-add_executable( DisabledExceptions-CustomHandler ${TESTS_DIR}/X04-DisabledExceptions-CustomHandler.cpp )
+catch2_add_extratest_no_pch_reuse( DisabledExceptions-DefaultHandler ${TESTS_DIR}/X03-DisabledExceptions-DefaultHandler.cpp )
+catch2_add_extratest_no_pch_reuse( DisabledExceptions-CustomHandler ${TESTS_DIR}/X04-DisabledExceptions-CustomHandler.cpp )
 
 foreach(target DisabledExceptions-DefaultHandler DisabledExceptions-CustomHandler)
   target_compile_options( ${target}
@@ -112,7 +128,7 @@ foreach(target DisabledExceptions-DefaultHandler DisabledExceptions-CustomHandle
       $<$<CXX_COMPILER_ID:MSVC>:/EHs-c-;/D_HAS_EXCEPTIONS=0>
       $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:AppleClang>>:-fno-exceptions>
   )
-  target_link_libraries(${target} Catch2_buildall_interface)
+  target_link_libraries(${target} PRIVATE Catch2_buildall_interface)
 endforeach()
 target_compile_definitions( DisabledExceptions-CustomHandler PUBLIC CATCH_CONFIG_DISABLE_EXCEPTIONS_CUSTOM_HANDLER )
 
@@ -125,9 +141,9 @@ set_tests_properties(
     FAIL_REGULAR_EXPRESSION "abort;terminate;fatal"
 )
 
-add_executable( BazelReporter ${TESTS_DIR}/X30-BazelReporter.cpp )
+catch2_add_extratest_no_pch_reuse( BazelReporter ${TESTS_DIR}/X30-BazelReporter.cpp )
 target_compile_definitions( BazelReporter PRIVATE CATCH_CONFIG_BAZEL_SUPPORT )
-target_link_libraries(BazelReporter Catch2_buildall_interface)
+target_link_libraries(BazelReporter PRIVATE Catch2_buildall_interface)
 add_test(NAME CATCH_CONFIG_BAZEL_REPORTER-1
   COMMAND
   "${PYTHON_EXECUTABLE}" "${CATCH_DIR}/tests/TestScripts/testBazelReporter.py" $<TARGET_FILE:BazelReporter> "${CMAKE_CURRENT_BINARY_DIR}"
@@ -138,8 +154,7 @@ set_tests_properties(CATCH_CONFIG_BAZEL_REPORTER-1
 )
 
 # We must now test this works without the build flag.
-add_executable( BazelReporterNoCatchConfig ${TESTS_DIR}/X30-BazelReporter.cpp )
-target_link_libraries(BazelReporterNoCatchConfig Catch2WithMain)
+catch2_add_extratest( BazelReporterNoCatchConfig ${TESTS_DIR}/X30-BazelReporter.cpp )
 add_test(NAME NO_CATCH_CONFIG_BAZEL_REPORTER-1
   COMMAND
   "${PYTHON_EXECUTABLE}" "${CATCH_DIR}/tests/TestScripts/testBazelReporter.py" $<TARGET_FILE:BazelReporterNoCatchConfig> "${CMAKE_CURRENT_BINARY_DIR}"
@@ -202,8 +217,7 @@ set_tests_properties(
 )
 
 
-add_executable(DeferredStaticChecks ${TESTS_DIR}/X05-DeferredStaticChecks.cpp)
-target_link_libraries(DeferredStaticChecks PRIVATE Catch2WithMain)
+catch2_add_extratest_no_pch_reuse(DeferredStaticChecks ${TESTS_DIR}/X05-DeferredStaticChecks.cpp)
 target_compile_definitions(DeferredStaticChecks PRIVATE "CATCH_CONFIG_RUNTIME_STATIC_REQUIRE")
 
 add_test(NAME DeferredStaticChecks COMMAND DeferredStaticChecks -r compact)
@@ -214,9 +228,8 @@ set_tests_properties(
 )
 
 
-add_executable(FallbackStringifier ${TESTS_DIR}/X10-FallbackStringifier.cpp)
+catch2_add_extratest_no_pch_reuse(FallbackStringifier ${TESTS_DIR}/X10-FallbackStringifier.cpp)
 target_compile_definitions( FallbackStringifier PRIVATE CATCH_CONFIG_FALLBACK_STRINGIFIER=fallbackStringifier )
-target_link_libraries( FallbackStringifier Catch2WithMain )
 
 add_test(NAME FallbackStringifier COMMAND FallbackStringifier -r compact -s)
 set_tests_properties(
@@ -226,9 +239,8 @@ set_tests_properties(
 )
 
 
-add_executable(DisableStringification ${TESTS_DIR}/X11-DisableStringification.cpp)
+catch2_add_extratest_no_pch_reuse(DisableStringification ${TESTS_DIR}/X11-DisableStringification.cpp)
 target_compile_definitions( DisableStringification PRIVATE CATCH_CONFIG_DISABLE_STRINGIFICATION )
-target_link_libraries(DisableStringification Catch2WithMain)
 add_test(NAME CATCH_CONFIG_DISABLE_STRINGIFICATION COMMAND DisableStringification -r compact -s)
 set_tests_properties(
     CATCH_CONFIG_DISABLE_STRINGIFICATION
@@ -241,15 +253,13 @@ set_tests_properties(
 # This test touches windows.h, so it should only be compiled under msvc
 if (MSVC)
     # This test fails if it does not compile and succeeds otherwise
-    add_executable(WindowsHeader ${TESTS_DIR}/X90-WindowsHeaderInclusion.cpp)
-    target_link_libraries( WindowsHeader Catch2WithMain )
+    catch2_add_extratest(WindowsHeader ${TESTS_DIR}/X90-WindowsHeaderInclusion.cpp)
     add_test(NAME WindowsHeader COMMAND WindowsHeader -r compact)
     list(APPEND CATCH_WARNING_TARGETS ${EXTRA_TEST_BINARIES} WindowsHeader)
 endif()
 
 
-add_executable(PartialTestCaseEvents ${TESTS_DIR}/X21-PartialTestCaseEvents.cpp)
-target_link_libraries(PartialTestCaseEvents PRIVATE Catch2WithMain)
+catch2_add_extratest(PartialTestCaseEvents ${TESTS_DIR}/X21-PartialTestCaseEvents.cpp)
 add_test(
   NAME PartialTestCaseEvents
   COMMAND ${PYTHON_EXECUTABLE} ${CATCH_DIR}/tests/TestScripts/testPartialTestCaseEvent.py $<TARGET_FILE:PartialTestCaseEvents>
@@ -259,8 +269,7 @@ set_tests_properties(PartialTestCaseEvents
     LABELS "uses-python"
 )
 
-add_executable(BenchmarksInCumulativeReporter ${TESTS_DIR}/X22-BenchmarksInCumulativeReporter.cpp)
-target_link_libraries(BenchmarksInCumulativeReporter PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(BenchmarksInCumulativeReporter ${TESTS_DIR}/X22-BenchmarksInCumulativeReporter.cpp)
 add_test(
   NAME BenchmarksInCumulativeReporter
   COMMAND BenchmarksInCumulativeReporter --reporter testReporter
@@ -273,8 +282,7 @@ set_tests_properties(
 )
 
 
-add_executable(CasingInReporterNames ${TESTS_DIR}/X23-CasingInReporterNames.cpp)
-target_link_libraries(CasingInReporterNames PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(CasingInReporterNames ${TESTS_DIR}/X23-CasingInReporterNames.cpp)
 add_test(
   NAME Reporters::registration-is-case-preserving
   COMMAND CasingInReporterNames --list-reporters
@@ -294,8 +302,7 @@ set_tests_properties(
     PASS_REGULAR_EXPRESSION "TestReporter constructed"
 )
 
-add_executable(CapturedStdoutInTestCaseEvents ${TESTS_DIR}/X27-CapturedStdoutInTestCaseEvents.cpp)
-target_link_libraries(CapturedStdoutInTestCaseEvents PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(CapturedStdoutInTestCaseEvents ${TESTS_DIR}/X27-CapturedStdoutInTestCaseEvents.cpp)
 add_test(
   NAME Reporters::CapturedStdOutInEvents
   COMMAND CapturedStdoutInTestCaseEvents
@@ -315,8 +322,7 @@ else()
   set(_NullFile "/dev/null")
 endif()
 
-add_executable(ListenerStdoutCaptureInMultireporter ${TESTS_DIR}/X24-ListenerStdoutCaptureInMultireporter.cpp)
-target_link_libraries(ListenerStdoutCaptureInMultireporter PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(ListenerStdoutCaptureInMultireporter ${TESTS_DIR}/X24-ListenerStdoutCaptureInMultireporter.cpp)
 
 # This test checks that there is nothing written out from the process,
 # but if CMake is running the tests under Valgrind or similar tool, then
@@ -338,8 +344,7 @@ if (NOT MEMORYCHECK_COMMAND)
 endif()
 
 
-add_executable(ListenerCanAskForCapturedStdout ${TESTS_DIR}/X25-ListenerCanAskForCapturedStdout.cpp)
-target_link_libraries(ListenerCanAskForCapturedStdout PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(ListenerCanAskForCapturedStdout ${TESTS_DIR}/X25-ListenerCanAskForCapturedStdout.cpp)
 add_test(
   NAME MultiReporter::CapturingListenerCausesStdoutCapture
   COMMAND ListenerCanAskForCapturedStdout
@@ -353,8 +358,7 @@ set_tests_properties(
     FAIL_REGULAR_EXPRESSION "X25 - ERROR"
 )
 
-add_executable(ReporterPreferencesForPassingAssertionsIsRespected ${TESTS_DIR}/X26-ReporterPreferencesForPassingAssertionsIsRespected.cpp)
-target_link_libraries(ReporterPreferencesForPassingAssertionsIsRespected PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(ReporterPreferencesForPassingAssertionsIsRespected ${TESTS_DIR}/X26-ReporterPreferencesForPassingAssertionsIsRespected.cpp)
 add_test(
   NAME Reporters::PreferencesForPassingAssertionsIsRespected
   COMMAND ReporterPreferencesForPassingAssertionsIsRespected
@@ -379,8 +383,7 @@ set_tests_properties(
     FAIL_REGULAR_EXPRESSION "X26 - assertionEnded"
 )
 
-add_executable(ListenersGetEventsBeforeReporters ${TESTS_DIR}/X28-ListenersGetEventsBeforeReporters.cpp)
-target_link_libraries(ListenersGetEventsBeforeReporters PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(ListenersGetEventsBeforeReporters ${TESTS_DIR}/X28-ListenersGetEventsBeforeReporters.cpp)
 add_test(
   NAME ListenersGetEventsBeforeReporters
   COMMAND ListenersGetEventsBeforeReporters --reporter test-reporter
@@ -392,8 +395,7 @@ set_tests_properties(
     FAIL_REGULAR_EXPRESSION "X28 - ERROR"
 )
 
-add_executable(CustomArgumentsForReporters ${TESTS_DIR}/X29-CustomArgumentsForReporters.cpp)
-target_link_libraries(CustomArgumentsForReporters PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(CustomArgumentsForReporters ${TESTS_DIR}/X29-CustomArgumentsForReporters.cpp)
 add_test(
   NAME CustomArgumentsForReporters
   COMMAND CustomArgumentsForReporters
@@ -406,8 +408,7 @@ set_tests_properties(
 )
 
 
-add_executable(DuplicatedTestCases-SameNameAndTags ${TESTS_DIR}/X31-DuplicatedTestCases.cpp)
-target_link_libraries(DuplicatedTestCases-SameNameAndTags PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(DuplicatedTestCases-SameNameAndTags ${TESTS_DIR}/X31-DuplicatedTestCases.cpp)
 add_test(
   NAME DuplicatedTestCases::SameNameAndTags
   COMMAND $<TARGET_FILE:DuplicatedTestCases-SameNameAndTags>
@@ -418,8 +419,7 @@ set_tests_properties(
      PASS_REGULAR_EXPRESSION "error: .* already defined\\."
 )
 
-add_executable(DuplicatedTestCases-SameNameDifferentTags ${TESTS_DIR}/X32-DuplicatedTestCasesDifferentTags.cpp)
-target_link_libraries(DuplicatedTestCases-SameNameDifferentTags PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(DuplicatedTestCases-SameNameDifferentTags ${TESTS_DIR}/X32-DuplicatedTestCasesDifferentTags.cpp)
 add_test(
   NAME DuplicatedTestCases::SameNameDifferentTags
   COMMAND $<TARGET_FILE:DuplicatedTestCases-SameNameDifferentTags>
@@ -430,8 +430,7 @@ set_tests_properties(
      FAIL_REGULAR_EXPRESSION "error: .* already defined\\."
 )
 
-add_executable(DuplicatedTestCases-DuplicatedTestCaseMethods ${TESTS_DIR}/X33-DuplicatedTestCaseMethods.cpp)
-target_link_libraries(DuplicatedTestCases-DuplicatedTestCaseMethods PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(DuplicatedTestCases-DuplicatedTestCaseMethods ${TESTS_DIR}/X33-DuplicatedTestCaseMethods.cpp)
 add_test(
   NAME DuplicatedTestCases::DuplicatedTestCaseMethods
   COMMAND $<TARGET_FILE:DuplicatedTestCases-DuplicatedTestCaseMethods>
@@ -442,8 +441,7 @@ set_tests_properties(
      PASS_REGULAR_EXPRESSION "error: .* already defined\\."
 )
 
-add_executable(DuplicatedTestCases-DifferentFixtures ${TESTS_DIR}/X34-DuplicatedTestCaseMethodsDifferentFixtures.cpp)
-target_link_libraries(DuplicatedTestCases-DifferentFixtures PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(DuplicatedTestCases-DifferentFixtures ${TESTS_DIR}/X34-DuplicatedTestCaseMethodsDifferentFixtures.cpp)
 add_test(
   NAME DuplicatedTestCases::DuplicatedTestCaseMethodsDifferentFixtures
   COMMAND $<TARGET_FILE:DuplicatedTestCases-DifferentFixtures>
@@ -455,8 +453,7 @@ set_tests_properties(
 )
 
 
-add_executable(DuplicatedReporters ${TESTS_DIR}/X35-DuplicatedReporterNames.cpp)
-target_link_libraries(DuplicatedReporters PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(DuplicatedReporters ${TESTS_DIR}/X35-DuplicatedReporterNames.cpp)
 add_test(
   NAME Reporters::RegistrationErrorsAreCaught
   COMMAND $<TARGET_FILE:DuplicatedReporters>
@@ -468,18 +465,15 @@ set_tests_properties(
 )
 
 
-add_executable(AssertionStartingEventGoesBeforeAssertionIsEvaluated
-  X20-AssertionStartingEventGoesBeforeAssertionIsEvaluated.cpp
-)
-target_link_libraries(AssertionStartingEventGoesBeforeAssertionIsEvaluated
-  PRIVATE Catch2::Catch2WithMain
+catch2_add_extratest(AssertionStartingEventGoesBeforeAssertionIsEvaluated
+  ${TESTS_DIR}/X20-AssertionStartingEventGoesBeforeAssertionIsEvaluated.cpp
 )
 add_test(
   NAME ReporterEvents::AssertionStartingHappensBeforeAssertionIsEvaluated
   COMMAND $<TARGET_FILE:AssertionStartingEventGoesBeforeAssertionIsEvaluated>
 )
 
-#add_executable(DebugBreakMacros ${TESTS_DIR}/X12-CustomDebugBreakMacro.cpp)
+#catch2_add_extratest(DebugBreakMacros ${TESTS_DIR}/X12-CustomDebugBreakMacro.cpp)
 #target_link_libraries(DebugBreakMacros Catch2)
 #add_test(NAME DebugBreakMacros COMMAND DebugBreakMacros --break)
 #set_tests_properties(
@@ -488,8 +482,7 @@ add_test(
 #    PASS_REGULAR_EXPRESSION "Pretty please, break into debugger"
 #)
 
-add_executable(NoTests ${TESTS_DIR}/X92-NoTests.cpp)
-target_link_libraries(NoTests PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(NoTests ${TESTS_DIR}/X92-NoTests.cpp)
 
 add_test(
   NAME TestSpecs::EmptySpecWithNoTestsFails
@@ -511,8 +504,7 @@ add_test(
 )
 
 
-add_executable(AllSkipped ${TESTS_DIR}/X93-AllSkipped.cpp)
-target_link_libraries(AllSkipped PRIVATE Catch2::Catch2WithMain)
+catch2_add_extratest(AllSkipped ${TESTS_DIR}/X93-AllSkipped.cpp)
 
 add_test(
   NAME TestSpecs::SkippingAllTestsFails
@@ -556,6 +548,10 @@ add_executable(AmalgamatedTestCompilation
   ${CATCH_DIR}/extras/catch_amalgamated.cpp
 )
 target_include_directories(AmalgamatedTestCompilation PRIVATE ${CATCH_DIR}/extras)
+
+if (CATCH_ENABLE_PCH)
+    target_precompile_headers(AmalgamatedTestCompilation REUSE_FROM Catch2)
+endif()
 
 add_test(NAME AmalgamatedFileTest COMMAND AmalgamatedTestCompilation)
 set_tests_properties(

--- a/tests/SelfTest/UsageTests/Compilation.tests.cpp
+++ b/tests/SelfTest/UsageTests/Compilation.tests.cpp
@@ -25,6 +25,16 @@ namespace bar {
     struct TypeList {};
 }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#endif
+#ifdef __GNUC__
+// Note that because -~GCC~-, this warning cannot be silenced temporarily, by pushing diagnostic stack...
+// Luckily it is firing in test files and thus can be silenced for the whole file, without losing much.
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wmissing-declarations"
 #endif
@@ -76,16 +86,6 @@ static std::ostream &operator<<(std::ostream &o, const A &) { return o << 0; }
 struct B : private A {
     bool operator==(int) const { return true; }
 };
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#endif
-#ifdef __GNUC__
-// Note that because -~GCC~-, this warning cannot be silenced temporarily, by pushing diagnostic stack...
-// Luckily it is firing in test files and thus can be silenced for the whole file, without losing much.
-#pragma GCC diagnostic ignored "-Wunused-function"
-#endif
 
 B f();
 

--- a/tests/SelfTest/UsageTests/ToStringOptional.tests.cpp
+++ b/tests/SelfTest/UsageTests/ToStringOptional.tests.cpp
@@ -11,6 +11,8 @@
 
 #if defined(CATCH_CONFIG_CPP17_OPTIONAL)
 
+#include <optional>
+
 TEST_CASE( "std::optional<int> -> toString", "[toString][optional][approvals]" ) {
     using type = std::optional<int>;
     REQUIRE( "{ }" == ::Catch::Detail::stringify( type{} ) );

--- a/tests/TestScripts/DiscoverTests/CMakeLists.txt
+++ b/tests/TestScripts/DiscoverTests/CMakeLists.txt
@@ -11,6 +11,10 @@ add_executable(tests
 add_subdirectory(${CATCH2_PATH} catch2-build)
 target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)
 
+if (CATCH_ENABLE_PCH)
+    target_precompile_headers(tests REUSE_FROM Catch2)
+endif()
+
 include(CTest)
 include(Catch)
 catch_discover_tests(tests)


### PR DESCRIPTION
This PR enables precompiled headers via the `CATCH_ENABLE_PCH` CMake option, aiming to significantly speed up compilation times.

## Description

These are some benchmark results on my machine with the following specs:

- Intel Core i9-13900K
- 32GB DDR5-6400 RAM
- EVO Plus 900 NVMe SSD

```
#
#
# given this CMake command...
cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja 
         -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_CXX_COMPILER=clang++ 
         -DCMAKE_CXX_FLAGS="-ftime-trace -Wall -Wextra -Wpedantic -Wno-ignored-attributes" 
         -DCATCH_DEVELOPMENT_BUILD=1 -DCATCH_BUILD_EXAMPLES=1 -DCATCH_BUILD_EXTRA_TESTS=1 -DCATCH_BUILD_FUZZERS=0

#
#
# ...with PCH disabled:
hyperfine "ninja clean && ninja" -n5 --warmup 1

Benchmark 1: 5
  Time (mean ± σ):     14.559 s ±  0.220 s    [User: 245.178 s, System: 33.759 s]
  Range (min … max):   14.362 s … 15.001 s    10 runs

#
#
# ...with PCH enabled:
hyperfine "ninja clean && ninja" -n5 --warmup 1

Benchmark 1: 5
  Time (mean ± σ):      9.718 s ±  0.165 s    [User: 104.442 s, System: 30.406 s]
  Range (min … max):    9.584 s … 10.152 s    10 runs
```

I get a ~5.0s speed-up for a full recompilation of Catch. I expect the speed-up to be more significant for machines with less cores.

Let's see if CI is happy with these changes :)