### PR TITLE
Add Bazel instructions to integration docs

### DIFF
--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -413,7 +413,7 @@ If the version is out of date, please [create an issue or pull request](https://
 Catch2 is now a supported module in the Bazel Central Registry. You only need to add one line to your MODULE.bazel file;
 please see https://registry.bazel.build/modules/catch2 for the latest supported version.
 
-You can then add
+You can then add `catch2_main` to each of your C++ test build rules as follows:
 
 ```
 cc_test(

--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -408,6 +408,24 @@ cd vcpkg
 The catch2 port in vcpkg is kept up to date by microsoft team members and community contributors.
 If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
+## Installing Catch2 from Bazel
+
+Catch2 is now a supported module in the Bazel Central Registry. You only need to add one line to your MODULE.bazel file;
+please see https://registry.bazel.build/modules/catch2 for the latest supported version.
+
+You can then add
+
+```
+cc_test(
+    name = "example_test",
+    srcs = ["example_test.cpp"],
+    deps = [
+        ":example",
+        "@catch2//:catch2_main",
+    ],
+)
+```
+
 ---
 
 [Home](Readme.md#top)


### PR DESCRIPTION
## Description

Catch2 support was added to the Bazel Central Registry (BCR) last month:
https://registry.bazel.build/modules/catch2

This greatly simplifies incorporating Catch2 tests in Bazel and is in line with modern (https://bazel.build/external/migration) practices for specifying external third-party deps in projects using the Bazel build system.

