### PR TITLE
Set target_link_libraries visibility to PRIVATE for linking android log

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -354,7 +354,7 @@ endif()
 add_library(Catch2::Catch2 ALIAS Catch2)
 
 if (ANDROID)
-    target_link_libraries(Catch2 INTERFACE log)
+    target_link_libraries(Catch2 PRIVATE log)
 endif()
 
 set_target_properties(Catch2 PROPERTIES


### PR DESCRIPTION
## Description
Set visibility for `target_link_libraries` to `PRIVATE` when linking in log for Android. 

`INTERFACE` should be used on dependencies from other than our source files. 
`PRIVATE` should be used the include happens in our source files. 

In this case (`src/catch2/internal/catch_debug_console.cpp:20`) the include is from our source file. 

I encountered a issue with this when building Catch2 for Android in combination with `BUILD_SHARED_LIBS`. Changing the visibility to `PRIVATE` fixes the issue. 

Reproduction: 
```
cmake -Bbuild -DANDROID=on -DBUILD_SHARED_LIBS=on -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_ABI=x86_64 && cmake --build build
```
