### PR TITLE
Evaluate argument of (DYNAMIC_)SECTION, TEST_CASE in static-analysis mode

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,81 @@
+---
+# Note: Alas, `Checks` is a string, not an array.
+#       Comments in the block string are not parsed and are passed in the value.
+#       They must thus be delimited by ',' from either side - then they are
+#       harmless. It's terrible, but it works.
+Checks: >-
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  -clang-analyzer-optin.core.EnumCastOutOfRange,
+
+  bugprone-*,
+  -bugprone-unchecked-optional-access,
+  ,# This is ridiculous, as it triggers on constants,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-easily-swappable-parameters,
+  ,# Is not really useful, has false positives, triggers for no-noexcept move constructors ...,
+  -bugprone-exception-escape,
+  -bugprone-narrowing-conversions,
+  -bugprone-chained-comparison,# RIP decomposers,
+
+  modernize-*,
+  -modernize-avoid-c-arrays,
+  -modernize-use-auto,
+  -modernize-use-emplace,
+  -modernize-use-nullptr,# it went crazy with three-way comparison operators,
+  -modernize-use-trailing-return-type,
+  -modernize-return-braced-init-list,
+  -modernize-concat-nested-namespaces,
+  -modernize-use-nodiscard,
+  -modernize-use-default-member-init,
+  -modernize-type-traits,# we need to support C++14,
+  -modernize-deprecated-headers,
+  ,# There's a lot of these and most of them are probably not useful,
+  -modernize-pass-by-value,
+
+  performance-*,
+  -performance-enum-size,
+
+  portability-*,
+
+  readability-*,
+  -readability-braces-around-statements,
+  -readability-container-size-empty,
+  -readability-convert-member-functions-to-static,
+  -readability-else-after-return,
+  -readability-function-cognitive-complexity,
+  -readability-function-size,
+  -readability-identifier-length,
+  -readability-implicit-bool-conversion,
+  -readability-isolate-declaration,
+  -readability-magic-numbers,
+  -readability-named-parameter,
+  -readability-qualified-auto,
+  -readability-redundant-access-specifiers,
+  -readability-simplify-boolean-expr,
+  -readability-static-definition-in-anonymous-namespace,
+  -readability-uppercase-literal-suffix,
+  -readability-use-anyofallof,
+  -readability-avoid-return-with-void-value,
+
+  ,# time hogs,
+  -bugprone-throw-keyword-missing,
+  -modernize-replace-auto-ptr,
+  -readability-identifier-naming,
+
+  ,# We cannot use this until clang-tidy supports custom unique_ptr,
+  -bugprone-use-after-move,
+  ,# Doesn't recognize unevaluated context in CATCH_MOVE and CATCH_FORWARD,
+  -bugprone-macro-repeated-side-effects,
+WarningsAsErrors: >-
+  clang-analyzer-core.*,
+  clang-analyzer-cplusplus.*,
+  clang-analyzer-security.*,
+  clang-analyzer-unix.*,
+  performance-move-const-arg,
+  performance-unnecessary-value-param,
+  readability-duplicate-include,
+HeaderFilterRegex: '.*\.(c|cxx|cpp)$'
+FormatStyle:     none
+CheckOptions: {}
+...

--- a/.github/workflows/linux-other-builds.yml
+++ b/.github/workflows/linux-other-builds.yml
@@ -103,3 +103,52 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
       working-directory: ${{runner.workspace}}/build
       run: ctest -C ${{matrix.build_type}} -j `nproc` ${{matrix.other_ctest_args}}
+  clang-tidy:
+    name: clang-tidy ${{matrix.version}}, ${{matrix.build_description}}, C++${{matrix.std}} ${{matrix.build_type}}
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - version: "15"
+            build_description: all
+            build_type: Debug
+            std: 17
+            other_pkgs: ''
+            cmake_configurations: -DCATCH_BUILD_EXAMPLES=ON -DCATCH_ENABLE_CMAKE_HELPER_TESTS=ON
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Prepare environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ninja-build clang-${{matrix.version}} clang-tidy-${{matrix.version}} ${{matrix.other_pkgs}}
+
+    - name: Configure build
+      working-directory: ${{runner.workspace}}
+      env:
+        CXX: clang++-${{matrix.version}}
+        CXXFLAGS: ${{matrix.cxxflags}}
+      # Note: $GITHUB_WORKSPACE is distinct from ${{runner.workspace}}.
+      #       This is important
+      run: |
+        clangtidy="clang-tidy-${{matrix.version}};-use-color"
+        # Use a dummy compiler/linker/ar/ranlib to effectively disable the
+        # compilation and only run clang-tidy.
+        cmake -Bbuild -H$GITHUB_WORKSPACE \
+              -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+              -DCMAKE_CXX_STANDARD=${{matrix.std}} \
+              -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+              -DCMAKE_CXX_EXTENSIONS=OFF \
+              -DCATCH_DEVELOPMENT_BUILD=ON \
+              -DCMAKE_CXX_CLANG_TIDY="$clangtidy" \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/true \
+              -DCMAKE_AR=/usr/bin/true \
+              -DCMAKE_CXX_COMPILER_AR=/usr/bin/true \
+              -DCMAKE_RANLIB=/usr/bin/true \
+              -DCMAKE_CXX_LINK_EXECUTABLE=/usr/bin/true \
+              ${{matrix.cmake_configurations}} \
+              -G Ninja
+
+    - name: Run clang-tidy
+      working-directory: ${{runner.workspace}}/build
+      run: ninja

--- a/examples/210-Evt-EventListeners.cpp
+++ b/examples/210-Evt-EventListeners.cpp
@@ -385,8 +385,7 @@ struct MyListener : Catch::EventListenerBase {
 CATCH_REGISTER_LISTENER( MyListener )
 
 // Get rid of Wweak-tables
-MyListener::~MyListener() {}
-
+MyListener::~MyListener() = default;
 
 // -----------------------------------------------------------------------
 // 3. Test cases:

--- a/examples/231-Cfg-OutputStreams.cpp
+++ b/examples/231-Cfg-OutputStreams.cpp
@@ -22,7 +22,7 @@ class out_buff : public std::stringbuf {
     std::FILE* m_stream;
 public:
     out_buff(std::FILE* stream):m_stream(stream) {}
-    ~out_buff();
+    ~out_buff() override;
     int sync() override {
         int ret = 0;
         for (unsigned char c : str()) {

--- a/examples/232-Cfg-CustomMain.cpp
+++ b/examples/232-Cfg-CustomMain.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv) {
       return returnCode;
 
   // if set on the command line then 'height' is now set at this point
-  std::cout << "height: " << height << std::endl;
+  std::cout << "height: " << height << '\n';
 
   return session.run();
 }

--- a/examples/300-Gen-OwnGenerator.cpp
+++ b/examples/300-Gen-OwnGenerator.cpp
@@ -21,7 +21,7 @@
 namespace {
 
 // This class shows how to implement a simple generator for Catch tests
-class RandomIntGenerator : public Catch::Generators::IGenerator<int> {
+class RandomIntGenerator final : public Catch::Generators::IGenerator<int> {
     std::minstd_rand m_rand;
     std::uniform_int_distribution<> m_dist;
     int current_number;

--- a/examples/301-Gen-MapTypeConversion.cpp
+++ b/examples/301-Gen-MapTypeConversion.cpp
@@ -24,12 +24,12 @@ namespace {
 // Returns a line from a stream. You could have it e.g. read lines from
 // a file, but to avoid problems with paths in examples, we will use
 // a fixed stringstream.
-class LineGenerator : public Catch::Generators::IGenerator<std::string> {
+class LineGenerator final : public Catch::Generators::IGenerator<std::string> {
     std::string m_line;
     std::stringstream m_stream;
 public:
-    LineGenerator() {
-        m_stream.str("1\n2\n3\n4\n");
+    explicit LineGenerator( std::string const& lines ) {
+        m_stream.str( lines );
         if (!next()) {
             Catch::Generators::Detail::throw_generator_exception("Couldn't read a single line");
         }
@@ -49,18 +49,19 @@ std::string const& LineGenerator::get() const {
 // This helper function provides a nicer UX when instantiating the generator
 // Notice that it returns an instance of GeneratorWrapper<std::string>, which
 // is a value-wrapper around std::unique_ptr<IGenerator<std::string>>.
-Catch::Generators::GeneratorWrapper<std::string> lines(std::string /* ignored for example */) {
+Catch::Generators::GeneratorWrapper<std::string>
+lines( std::string const& lines ) {
     return Catch::Generators::GeneratorWrapper<std::string>(
-        new LineGenerator()
-    );
+        new LineGenerator( lines ) );
 }
 
 } // end anonymous namespace
 
 
 TEST_CASE("filter can convert types inside the generator expression", "[example][generator]") {
-    auto num = GENERATE(map<int>([](std::string const& line) { return std::stoi(line); },
-                                 lines("fake-file")));
+    auto num = GENERATE(
+        map<int>( []( std::string const& line ) { return std::stoi( line ); },
+                  lines( "1\n2\n3\n4\n" ) ) );
 
     REQUIRE(num > 0);
 }

--- a/src/catch2/catch_message.cpp
+++ b/src/catch2/catch_message.cpp
@@ -91,6 +91,7 @@ namespace Catch {
                     m_messages.back().message += " := ";
                     start = pos;
                 }
+            default:; // noop
             }
         }
         assert(openings.empty() && "Mismatched openings");

--- a/src/catch2/catch_registry_hub.cpp
+++ b/src/catch2/catch_registry_hub.cpp
@@ -20,7 +20,6 @@
 #include <catch2/internal/catch_noncopyable.hpp>
 #include <catch2/interfaces/catch_interfaces_reporter_factory.hpp>
 #include <catch2/internal/catch_move_and_forward.hpp>
-#include <catch2/internal/catch_reporter_registry.hpp>
 
 #include <exception>
 

--- a/src/catch2/catch_test_case_info.hpp
+++ b/src/catch2/catch_test_case_info.hpp
@@ -68,7 +68,7 @@ namespace Catch {
     struct TestCaseInfo : Detail::NonCopyable {
 
         TestCaseInfo(StringRef _className,
-                     NameAndTags const& _tags,
+                     NameAndTags const& _nameAndTags,
                      SourceLineInfo const& _lineInfo);
 
         bool isHidden() const;

--- a/src/catch2/catch_tostring.cpp
+++ b/src/catch2/catch_tostring.cpp
@@ -54,13 +54,13 @@ namespace Detail {
         }
     } // end unnamed namespace
 
-    std::string convertIntoString(StringRef string, bool escape_invisibles) {
+    std::string convertIntoString(StringRef string, bool escapeInvisibles) {
         std::string ret;
         // This is enough for the "don't escape invisibles" case, and a good
         // lower bound on the "escape invisibles" case.
         ret.reserve(string.size() + 2);
 
-        if (!escape_invisibles) {
+        if (!escapeInvisibles) {
             ret += '"';
             ret += string;
             ret += '"';
@@ -138,7 +138,7 @@ std::string StringMaker<char const*>::convert(char const* str) {
         return{ "{null string}" };
     }
 }
-std::string StringMaker<char*>::convert(char* str) {
+std::string StringMaker<char*>::convert(char* str) { // NOLINT(readability-non-const-parameter)
     if (str) {
         return Detail::convertIntoString( str );
     } else {
@@ -235,8 +235,8 @@ std::string StringMaker<signed char>::convert(signed char value) {
 std::string StringMaker<char>::convert(char c) {
     return ::Catch::Detail::stringify(static_cast<signed char>(c));
 }
-std::string StringMaker<unsigned char>::convert(unsigned char c) {
-    return ::Catch::Detail::stringify(static_cast<char>(c));
+std::string StringMaker<unsigned char>::convert(unsigned char value) {
+    return ::Catch::Detail::stringify(static_cast<char>(value));
 }
 
 int StringMaker<float>::precision = 5;

--- a/src/catch2/catch_tostring.hpp
+++ b/src/catch2/catch_tostring.hpp
@@ -279,11 +279,11 @@ namespace Catch {
     };
     template<>
     struct StringMaker<signed char> {
-        static std::string convert(signed char c);
+        static std::string convert(signed char value);
     };
     template<>
     struct StringMaker<unsigned char> {
-        static std::string convert(unsigned char c);
+        static std::string convert(unsigned char value);
     };
 
     template<>

--- a/src/catch2/internal/catch_commandline.cpp
+++ b/src/catch2/internal/catch_commandline.cpp
@@ -47,7 +47,7 @@ namespace Catch {
                     line = trim(line);
                     if( !line.empty() && !startsWith( line, '#' ) ) {
                         if( !startsWith( line, '"' ) )
-                            line = '"' + line + '"';
+                            line = '"' + CATCH_MOVE(line) + '"';
                         config.testsOrTags.push_back( line );
                         config.testsOrTags.emplace_back( "," );
                     }

--- a/src/catch2/internal/catch_console_colour.cpp
+++ b/src/catch2/internal/catch_console_colour.cpp
@@ -230,21 +230,21 @@ namespace {
 
 namespace Catch {
 
-    Detail::unique_ptr<ColourImpl> makeColourImpl( ColourMode implSelection,
+    Detail::unique_ptr<ColourImpl> makeColourImpl( ColourMode colourSelection,
                                                    IStream* stream ) {
 #if defined( CATCH_CONFIG_COLOUR_WIN32 )
-        if ( implSelection == ColourMode::Win32 ) {
+        if ( colourSelection == ColourMode::Win32 ) {
             return Detail::make_unique<Win32ColourImpl>( stream );
         }
 #endif
-        if ( implSelection == ColourMode::ANSI ) {
+        if ( colourSelection == ColourMode::ANSI ) {
             return Detail::make_unique<ANSIColourImpl>( stream );
         }
-        if ( implSelection == ColourMode::None ) {
+        if ( colourSelection == ColourMode::None ) {
             return Detail::make_unique<NoColourImpl>( stream );
         }
 
-        if ( implSelection == ColourMode::PlatformDefault) {
+        if ( colourSelection == ColourMode::PlatformDefault) {
 #if defined( CATCH_CONFIG_COLOUR_WIN32 )
             if ( Win32ColourImpl::useImplementationForStream( *stream ) ) {
                 return Detail::make_unique<Win32ColourImpl>( stream );
@@ -256,7 +256,7 @@ namespace Catch {
             return Detail::make_unique<NoColourImpl>( stream );
         }
 
-        CATCH_ERROR( "Could not create colour impl for selection " << static_cast<int>(implSelection) );
+        CATCH_ERROR( "Could not create colour impl for selection " << static_cast<int>(colourSelection) );
     }
 
     bool isColourImplAvailable( ColourMode colourSelection ) {

--- a/src/catch2/internal/catch_enum_values_registry.hpp
+++ b/src/catch2/internal/catch_enum_values_registry.hpp
@@ -24,7 +24,7 @@ namespace Catch {
 
             std::vector<Catch::Detail::unique_ptr<EnumInfo>> m_enumInfos;
 
-            EnumInfo const& registerEnum( StringRef enumName, StringRef allEnums, std::vector<int> const& values) override;
+            EnumInfo const& registerEnum( StringRef enumName, StringRef allValueNames, std::vector<int> const& values) override;
         };
 
         std::vector<StringRef> parseEnums( StringRef enums );

--- a/src/catch2/internal/catch_jsonwriter.cpp
+++ b/src/catch2/internal/catch_jsonwriter.cpp
@@ -31,7 +31,7 @@ namespace Catch {
         m_os{ os }, m_indent_level{ indent_level } {
         m_os << '{';
     }
-    JsonObjectWriter::JsonObjectWriter( JsonObjectWriter&& source ):
+    JsonObjectWriter::JsonObjectWriter( JsonObjectWriter&& source ) noexcept:
         m_os{ source.m_os },
         m_indent_level{ source.m_indent_level },
         m_should_comma{ source.m_should_comma },
@@ -62,7 +62,7 @@ namespace Catch {
         m_os{ os }, m_indent_level{ indent_level } {
         m_os << '[';
     }
-    JsonArrayWriter::JsonArrayWriter( JsonArrayWriter&& source ):
+    JsonArrayWriter::JsonArrayWriter( JsonArrayWriter&& source ) noexcept:
         m_os{ source.m_os },
         m_indent_level{ source.m_indent_level },
         m_should_comma{ source.m_should_comma },

--- a/src/catch2/internal/catch_jsonwriter.hpp
+++ b/src/catch2/internal/catch_jsonwriter.hpp
@@ -65,7 +65,7 @@ namespace Catch {
         JsonObjectWriter( std::ostream& os );
         JsonObjectWriter( std::ostream& os, std::uint64_t indent_level );
 
-        JsonObjectWriter( JsonObjectWriter&& source );
+        JsonObjectWriter( JsonObjectWriter&& source ) noexcept;
         JsonObjectWriter& operator=( JsonObjectWriter&& source ) = delete;
 
         ~JsonObjectWriter();
@@ -84,7 +84,7 @@ namespace Catch {
         JsonArrayWriter( std::ostream& os );
         JsonArrayWriter( std::ostream& os, std::uint64_t indent_level );
 
-        JsonArrayWriter( JsonArrayWriter&& source );
+        JsonArrayWriter( JsonArrayWriter&& source ) noexcept;
         JsonArrayWriter& operator=( JsonArrayWriter&& source ) = delete;
 
         ~JsonArrayWriter();

--- a/src/catch2/internal/catch_reporter_spec_parser.cpp
+++ b/src/catch2/internal/catch_reporter_spec_parser.cpp
@@ -117,7 +117,7 @@ namespace Catch {
             auto kv = splitKVPair( parts[i] );
             auto key = kv.key, value = kv.value;
 
-            if ( key.empty() || value.empty() ) {
+            if ( key.empty() || value.empty() ) { // NOLINT(bugprone-branch-clone)
                 return {};
             } else if ( key[0] == 'X' ) {
                 // This is a reporter-specific option, we don't check these

--- a/src/catch2/internal/catch_section.hpp
+++ b/src/catch2/internal/catch_section.hpp
@@ -69,7 +69,9 @@ namespace Catch {
     namespace Detail {
         // Intentionally without linkage, as it should only be used as a dummy
         // symbol for static analysis.
-        int GetNewSectionHint();
+        // The arguments are used as a dummy for checking warnings in the passed
+        // expressions.
+        int GetNewSectionHint( StringRef, const char* const = nullptr );
     } // namespace Detail
 } // namespace Catch
 
@@ -80,7 +82,8 @@ namespace Catch {
         CATCH_INTERNAL_SUPPRESS_SHADOW_WARNINGS                             \
         if ( [[maybe_unused]] const int catchInternalPreviousSectionHint =  \
                  catchInternalSectionHint,                                  \
-             catchInternalSectionHint = Catch::Detail::GetNewSectionHint(); \
+             catchInternalSectionHint =                                     \
+                 Catch::Detail::GetNewSectionHint(__VA_ARGS__);             \
              catchInternalPreviousSectionHint == __LINE__ )                 \
         CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
@@ -90,7 +93,8 @@ namespace Catch {
         CATCH_INTERNAL_SUPPRESS_SHADOW_WARNINGS                             \
         if ( [[maybe_unused]] const int catchInternalPreviousSectionHint =  \
                  catchInternalSectionHint,                                  \
-             catchInternalSectionHint = Catch::Detail::GetNewSectionHint(); \
+             catchInternalSectionHint = Catch::Detail::GetNewSectionHint(   \
+                ( Catch::ReusableStringStream() << __VA_ARGS__ ).str());    \
              catchInternalPreviousSectionHint == __LINE__ )                 \
         CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 

--- a/src/catch2/internal/catch_string_manip.cpp
+++ b/src/catch2/internal/catch_string_manip.cpp
@@ -5,6 +5,7 @@
 //        https://www.boost.org/LICENSE_1_0.txt)
 
 // SPDX-License-Identifier: BSL-1.0
+#include <catch2/internal/catch_move_and_forward.hpp>
 #include <catch2/internal/catch_string_manip.hpp>
 #include <catch2/internal/catch_stringref.hpp>
 
@@ -65,17 +66,29 @@ namespace Catch {
     }
 
     bool replaceInPlace( std::string& str, std::string const& replaceThis, std::string const& withThis ) {
-        bool replaced = false;
         std::size_t i = str.find( replaceThis );
-        while( i != std::string::npos ) {
-            replaced = true;
-            str = str.substr( 0, i ) + withThis + str.substr( i+replaceThis.size() );
-            if( i < str.size()-withThis.size() )
-                i = str.find( replaceThis, i+withThis.size() );
+        if (i == std::string::npos) {
+            return false;
+        }
+        std::size_t copyBegin = 0;
+        std::string origStr = CATCH_MOVE(str);
+        str.clear();
+        // There is at least one replacement, so reserve with the best guess
+        // we can make without actually counting the number of occurences.
+        str.reserve(origStr.size() - replaceThis.size() + withThis.size());
+        do {
+            str.append(origStr, copyBegin, i-copyBegin );
+            str += withThis;
+            copyBegin = i + replaceThis.size();
+            if( copyBegin < origStr.size() )
+                i = origStr.find( replaceThis, copyBegin );
             else
                 i = std::string::npos;
+        } while( i != std::string::npos );
+        if ( copyBegin < origStr.size() ) {
+            str.append(origStr, copyBegin, origStr.size() );
         }
-        return replaced;
+        return true;
     }
 
     std::vector<StringRef> splitStringRef( StringRef str, char delimiter ) {

--- a/src/catch2/internal/catch_stringref.hpp
+++ b/src/catch2/internal/catch_stringref.hpp
@@ -97,8 +97,8 @@ namespace Catch {
         constexpr const_iterator end() const { return m_start + m_size; }
 
 
-        friend std::string& operator += (std::string& lhs, StringRef sr);
-        friend std::ostream& operator << (std::ostream& os, StringRef sr);
+        friend std::string& operator += (std::string& lhs, StringRef rhs);
+        friend std::ostream& operator << (std::ostream& os, StringRef str);
         friend std::string operator+(StringRef lhs, StringRef rhs);
 
         /**

--- a/src/catch2/internal/catch_test_registry.hpp
+++ b/src/catch2/internal/catch_test_registry.hpp
@@ -95,7 +95,7 @@ struct AutoReg : Detail::NonCopyable {
 namespace Catch {
     namespace Detail {
         struct DummyUse {
-            DummyUse( void ( * )( int ) );
+            DummyUse( void ( * )( int ), Catch::NameAndTags const& );
         };
     } // namespace Detail
 } // namespace Catch
@@ -107,18 +107,18 @@ namespace Catch {
 // tests can compile. The redefined `TEST_CASE` shadows this with param.
 static int catchInternalSectionHint = 0;
 
-#    define INTERNAL_CATCH_TESTCASE2( fname )                              \
+#    define INTERNAL_CATCH_TESTCASE2( fname, ... )                         \
         static void fname( int );                                          \
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                          \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                           \
         CATCH_INTERNAL_SUPPRESS_UNUSED_VARIABLE_WARNINGS                   \
         static const Catch::Detail::DummyUse INTERNAL_CATCH_UNIQUE_NAME(   \
-            dummyUser )( &(fname) );                                       \
+            dummyUser )( &(fname), Catch::NameAndTags{ __VA_ARGS__ } );    \
         CATCH_INTERNAL_SUPPRESS_SHADOW_WARNINGS                            \
         static void fname( [[maybe_unused]] int catchInternalSectionHint ) \
             CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 #    define INTERNAL_CATCH_TESTCASE( ... ) \
-        INTERNAL_CATCH_TESTCASE2( INTERNAL_CATCH_UNIQUE_NAME( dummyFunction ) )
+        INTERNAL_CATCH_TESTCASE2( INTERNAL_CATCH_UNIQUE_NAME( dummyFunction ), __VA_ARGS__ )
 
 
 #endif // CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT

--- a/src/catch2/reporters/catch_reporter_console.cpp
+++ b/src/catch2/reporters/catch_reporter_console.cpp
@@ -520,8 +520,8 @@ void ConsoleReporter::testRunEnded(TestRunStats const& _testRunStats) {
     m_stream << '\n' << std::flush;
     StreamingReporterBase::testRunEnded(_testRunStats);
 }
-void ConsoleReporter::testRunStarting(TestRunInfo const& _testInfo) {
-    StreamingReporterBase::testRunStarting(_testInfo);
+void ConsoleReporter::testRunStarting(TestRunInfo const& _testRunInfo) {
+    StreamingReporterBase::testRunStarting(_testRunInfo);
     if ( m_config->testSpec().hasFilters() ) {
         m_stream << m_colour->guardColour( Colour::BrightYellow ) << "Filters: "
                  << m_config->testSpec() << '\n';

--- a/src/catch2/reporters/catch_reporter_cumulative_base.cpp
+++ b/src/catch2/reporters/catch_reporter_cumulative_base.cpp
@@ -16,8 +16,7 @@ namespace Catch {
     namespace {
         struct BySectionInfo {
             BySectionInfo( SectionInfo const& other ): m_other( other ) {}
-            BySectionInfo( BySectionInfo const& other ):
-                m_other( other.m_other ) {}
+            BySectionInfo( BySectionInfo const& other ) = default;
             bool operator()(
                 Detail::unique_ptr<CumulativeReporterBase::SectionNode> const&
                     node ) const {

--- a/src/catch2/reporters/catch_reporter_json.cpp
+++ b/src/catch2/reporters/catch_reporter_json.cpp
@@ -133,8 +133,8 @@ namespace Catch {
         return "Outputs listings as JSON. Test listing is Work-in-Progress!";
     }
 
-    void JsonReporter::testRunStarting( TestRunInfo const& testInfo ) {
-        StreamingReporterBase::testRunStarting( testInfo );
+    void JsonReporter::testRunStarting( TestRunInfo const& runInfo ) {
+        StreamingReporterBase::testRunStarting( runInfo );
         endListing();
 
         assert( isInside( Writer::Object ) );

--- a/src/catch2/reporters/catch_reporter_junit.cpp
+++ b/src/catch2/reporters/catch_reporter_junit.cpp
@@ -74,7 +74,7 @@ namespace Catch {
 
         static void normalizeNamespaceMarkers(std::string& str) {
             std::size_t pos = str.find( "::" );
-            while ( pos != str.npos ) {
+            while ( pos != std::string::npos ) {
                 str.replace( pos, 2, "." );
                 pos += 1;
                 pos = str.find( "::", pos );

--- a/src/catch2/reporters/catch_reporter_multi.hpp
+++ b/src/catch2/reporters/catch_reporter_multi.hpp
@@ -53,7 +53,7 @@ namespace Catch {
 
         void assertionEnded( AssertionStats const& assertionStats ) override;
         void sectionEnded( SectionStats const& sectionStats ) override;
-        void testCasePartialEnded(TestCaseStats const& testInfo, uint64_t partNumber) override;
+        void testCasePartialEnded(TestCaseStats const& testStats, uint64_t partNumber) override;
         void testCaseEnded( TestCaseStats const& testCaseStats ) override;
         void testRunEnded( TestRunStats const& testRunStats ) override;
 

--- a/src/catch2/reporters/catch_reporter_sonarqube.hpp
+++ b/src/catch2/reporters/catch_reporter_sonarqube.hpp
@@ -37,7 +37,7 @@ namespace Catch {
             xml.endElement();
         }
 
-        void writeRun( TestRunNode const& groupNode );
+        void writeRun( TestRunNode const& runNode );
 
         void writeTestFile(StringRef filename, std::vector<TestCaseNode const*> const& testCaseNodes);
 

--- a/src/catch2/reporters/catch_reporter_teamcity.hpp
+++ b/src/catch2/reporters/catch_reporter_teamcity.hpp
@@ -35,8 +35,8 @@ namespace Catch {
             return "Reports test results as TeamCity service messages"s;
         }
 
-        void testRunStarting( TestRunInfo const& groupInfo ) override;
-        void testRunEnded( TestRunStats const& testGroupStats ) override;
+        void testRunStarting( TestRunInfo const& runInfo ) override;
+        void testRunEnded( TestRunStats const& runStats ) override;
 
 
         void assertionEnded(AssertionStats const& assertionStats) override;

--- a/tests/ExtraTests/X22-BenchmarksInCumulativeReporter.cpp
+++ b/tests/ExtraTests/X22-BenchmarksInCumulativeReporter.cpp
@@ -34,7 +34,7 @@ public:
         return "Custom reporter for testing cumulative reporter base";
     }
 
-    virtual void testRunEndedCumulative() override;
+    void testRunEndedCumulative() override;
 };
 
 CATCH_REGISTER_REPORTER("testReporter", CumulativeBenchmarkReporter)

--- a/tests/ExtraTests/X29-CustomArgumentsForReporters.cpp
+++ b/tests/ExtraTests/X29-CustomArgumentsForReporters.cpp
@@ -36,6 +36,7 @@ public:
 
     void testRunStarting( Catch::TestRunInfo const& ) override {
         std::vector<std::pair<std::string, std::string>> options;
+        options.reserve( m_customOptions.size() );
         for ( auto const& kv : m_customOptions ) {
             options.push_back( kv );
         }

--- a/tests/ExtraTests/X91-AmalgamatedCatch.cpp
+++ b/tests/ExtraTests/X91-AmalgamatedCatch.cpp
@@ -16,10 +16,10 @@
 TEST_CASE("Just a dummy test") {
     auto i = GENERATE(1, 2, 3);
     SECTION("a") {
-        REQUIRE(1 != 4);
+        REQUIRE(i != 4);
     }
     SECTION("b") {
-        CHECK(1 != 5);
+        CHECK(i != 5);
     }
     REQUIRE_THAT(1,
                  Catch::Matchers::Predicate<int>([](int i) {

--- a/tests/SelfTest/Baselines/compact.sw.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.approved.txt
@@ -1733,13 +1733,13 @@ Tag.tests.cpp:<line number>: passed: testCase.tags, VectorContains( Tag( "tag wi
 Class.tests.cpp:<line number>: passed: Template_Fixture<TestType>::m_a == 1 for: 1 == 1
 Class.tests.cpp:<line number>: passed: Template_Fixture<TestType>::m_a == 1 for: 1 == 1
 Class.tests.cpp:<line number>: passed: Template_Fixture<TestType>::m_a == 1 for: 1.0 == 1
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 1 > 0
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 4 > 0
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 1 > 0
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 4 > 0
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 4 > 0
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 1 > 0
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 4 > 0
+Misc.tests.cpp:<line number>: passed: std::is_default_constructible<TestType>::value for: true
+Misc.tests.cpp:<line number>: passed: std::is_default_constructible<TestType>::value for: true
+Misc.tests.cpp:<line number>: passed: std::is_trivially_copyable<TestType>::value for: true
+Misc.tests.cpp:<line number>: passed: std::is_trivially_copyable<TestType>::value for: true
+Misc.tests.cpp:<line number>: passed: std::is_arithmetic<TestType>::value for: true
+Misc.tests.cpp:<line number>: passed: std::is_arithmetic<TestType>::value for: true
+Misc.tests.cpp:<line number>: passed: std::is_arithmetic<TestType>::value for: true
 Misc.tests.cpp:<line number>: passed: v.size() == 5 for: 5 == 5
 Misc.tests.cpp:<line number>: passed: v.capacity() >= 5 for: 5 >= 5
 Misc.tests.cpp:<line number>: passed: v.size() == 10 for: 10 == 10
@@ -2479,6 +2479,10 @@ StringManip.tests.cpp:<line number>: passed: Catch::replaceInPlace(letters, lett
 StringManip.tests.cpp:<line number>: passed: letters == "replaced" for: "replaced" == "replaced"
 StringManip.tests.cpp:<line number>: passed: !(Catch::replaceInPlace(letters, "x", "z")) for: !false
 StringManip.tests.cpp:<line number>: passed: letters == letters for: "abcdefcg" == "abcdefcg"
+StringManip.tests.cpp:<line number>: passed: Catch::replaceInPlace(letters, "c", "cc") for: true
+StringManip.tests.cpp:<line number>: passed: letters == "abccdefccg" for: "abccdefccg" == "abccdefccg"
+StringManip.tests.cpp:<line number>: passed: Catch::replaceInPlace(s, "--", "-") for: true
+StringManip.tests.cpp:<line number>: passed: s == "--" for: "--" == "--"
 StringManip.tests.cpp:<line number>: passed: Catch::replaceInPlace(s, "'", "|'") for: true
 StringManip.tests.cpp:<line number>: passed: s == "didn|'t" for: "didn|'t" == "didn|'t"
 Stream.tests.cpp:<line number>: passed: Catch::makeStream( "%somestream" )
@@ -2686,6 +2690,6 @@ InternalBenchmark.tests.cpp:<line number>: passed: q3 == 23. for: 23.0 == 23.0
 Misc.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: passed:
 test cases:  417 |  312 passed |  85 failed | 6 skipped | 14 failed as expected
-assertions: 2256 | 2075 passed | 146 failed | 35 failed as expected
+assertions: 2260 | 2079 passed | 146 failed | 35 failed as expected
 
 

--- a/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
@@ -1726,13 +1726,13 @@ Tag.tests.cpp:<line number>: passed: testCase.tags, VectorContains( Tag( "tag wi
 Class.tests.cpp:<line number>: passed: Template_Fixture<TestType>::m_a == 1 for: 1 == 1
 Class.tests.cpp:<line number>: passed: Template_Fixture<TestType>::m_a == 1 for: 1 == 1
 Class.tests.cpp:<line number>: passed: Template_Fixture<TestType>::m_a == 1 for: 1.0 == 1
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 1 > 0
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 4 > 0
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 1 > 0
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 4 > 0
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 4 > 0
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 1 > 0
-Misc.tests.cpp:<line number>: passed: sizeof(TestType) > 0 for: 4 > 0
+Misc.tests.cpp:<line number>: passed: std::is_default_constructible<TestType>::value for: true
+Misc.tests.cpp:<line number>: passed: std::is_default_constructible<TestType>::value for: true
+Misc.tests.cpp:<line number>: passed: std::is_trivially_copyable<TestType>::value for: true
+Misc.tests.cpp:<line number>: passed: std::is_trivially_copyable<TestType>::value for: true
+Misc.tests.cpp:<line number>: passed: std::is_arithmetic<TestType>::value for: true
+Misc.tests.cpp:<line number>: passed: std::is_arithmetic<TestType>::value for: true
+Misc.tests.cpp:<line number>: passed: std::is_arithmetic<TestType>::value for: true
 Misc.tests.cpp:<line number>: passed: v.size() == 5 for: 5 == 5
 Misc.tests.cpp:<line number>: passed: v.capacity() >= 5 for: 5 >= 5
 Misc.tests.cpp:<line number>: passed: v.size() == 10 for: 10 == 10
@@ -2468,6 +2468,10 @@ StringManip.tests.cpp:<line number>: passed: Catch::replaceInPlace(letters, lett
 StringManip.tests.cpp:<line number>: passed: letters == "replaced" for: "replaced" == "replaced"
 StringManip.tests.cpp:<line number>: passed: !(Catch::replaceInPlace(letters, "x", "z")) for: !false
 StringManip.tests.cpp:<line number>: passed: letters == letters for: "abcdefcg" == "abcdefcg"
+StringManip.tests.cpp:<line number>: passed: Catch::replaceInPlace(letters, "c", "cc") for: true
+StringManip.tests.cpp:<line number>: passed: letters == "abccdefccg" for: "abccdefccg" == "abccdefccg"
+StringManip.tests.cpp:<line number>: passed: Catch::replaceInPlace(s, "--", "-") for: true
+StringManip.tests.cpp:<line number>: passed: s == "--" for: "--" == "--"
 StringManip.tests.cpp:<line number>: passed: Catch::replaceInPlace(s, "'", "|'") for: true
 StringManip.tests.cpp:<line number>: passed: s == "didn|'t" for: "didn|'t" == "didn|'t"
 Stream.tests.cpp:<line number>: passed: Catch::makeStream( "%somestream" )
@@ -2675,6 +2679,6 @@ InternalBenchmark.tests.cpp:<line number>: passed: q3 == 23. for: 23.0 == 23.0
 Misc.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: passed:
 test cases:  417 |  312 passed |  85 failed | 6 skipped | 14 failed as expected
-assertions: 2256 | 2075 passed | 146 failed | 35 failed as expected
+assertions: 2260 | 2079 passed | 146 failed | 35 failed as expected
 
 

--- a/tests/SelfTest/Baselines/console.std.approved.txt
+++ b/tests/SelfTest/Baselines/console.std.approved.txt
@@ -1589,5 +1589,5 @@ due to unexpected exception with message:
 
 ===============================================================================
 test cases:  417 |  326 passed |  70 failed | 7 skipped | 14 failed as expected
-assertions: 2239 | 2075 passed | 129 failed | 35 failed as expected
+assertions: 2243 | 2079 passed | 129 failed | 35 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.approved.txt
@@ -11655,9 +11655,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_default_constructible<TestType>::value )
 with expansion:
-  1 > 0
+  true
 
 -------------------------------------------------------------------------------
 Template test case with test types specified inside non-copyable and non-
@@ -11667,9 +11667,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_default_constructible<TestType>::value )
 with expansion:
-  4 > 0
+  true
 
 -------------------------------------------------------------------------------
 Template test case with test types specified inside non-default-constructible
@@ -11679,9 +11679,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_trivially_copyable<TestType>::value )
 with expansion:
-  1 > 0
+  true
 
 -------------------------------------------------------------------------------
 Template test case with test types specified inside non-default-constructible
@@ -11691,9 +11691,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_trivially_copyable<TestType>::value )
 with expansion:
-  4 > 0
+  true
 
 -------------------------------------------------------------------------------
 Template test case with test types specified inside std::tuple - MyTypes - 0
@@ -11702,9 +11702,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_arithmetic<TestType>::value )
 with expansion:
-  4 > 0
+  true
 
 -------------------------------------------------------------------------------
 Template test case with test types specified inside std::tuple - MyTypes - 1
@@ -11713,9 +11713,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_arithmetic<TestType>::value )
 with expansion:
-  1 > 0
+  true
 
 -------------------------------------------------------------------------------
 Template test case with test types specified inside std::tuple - MyTypes - 2
@@ -11724,9 +11724,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_arithmetic<TestType>::value )
 with expansion:
-  4 > 0
+  true
 
 -------------------------------------------------------------------------------
 TemplateTest: vectors can be sized and resized - float
@@ -17291,6 +17291,42 @@ with expansion:
 
 -------------------------------------------------------------------------------
 replaceInPlace
+  no replace in already-replaced string
+  lengthening
+-------------------------------------------------------------------------------
+StringManip.tests.cpp:<line number>
+...............................................................................
+
+StringManip.tests.cpp:<line number>: PASSED:
+  CHECK( Catch::replaceInPlace(letters, "c", "cc") )
+with expansion:
+  true
+
+StringManip.tests.cpp:<line number>: PASSED:
+  CHECK( letters == "abccdefccg" )
+with expansion:
+  "abccdefccg" == "abccdefccg"
+
+-------------------------------------------------------------------------------
+replaceInPlace
+  no replace in already-replaced string
+  shortening
+-------------------------------------------------------------------------------
+StringManip.tests.cpp:<line number>
+...............................................................................
+
+StringManip.tests.cpp:<line number>: PASSED:
+  CHECK( Catch::replaceInPlace(s, "--", "-") )
+with expansion:
+  true
+
+StringManip.tests.cpp:<line number>: PASSED:
+  CHECK( s == "--" )
+with expansion:
+  "--" == "--"
+
+-------------------------------------------------------------------------------
+replaceInPlace
   escape '
 -------------------------------------------------------------------------------
 StringManip.tests.cpp:<line number>
@@ -18732,5 +18768,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  417 |  312 passed |  85 failed | 6 skipped | 14 failed as expected
-assertions: 2256 | 2075 passed | 146 failed | 35 failed as expected
+assertions: 2260 | 2079 passed | 146 failed | 35 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.multi.approved.txt
@@ -11648,9 +11648,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_default_constructible<TestType>::value )
 with expansion:
-  1 > 0
+  true
 
 -------------------------------------------------------------------------------
 Template test case with test types specified inside non-copyable and non-
@@ -11660,9 +11660,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_default_constructible<TestType>::value )
 with expansion:
-  4 > 0
+  true
 
 -------------------------------------------------------------------------------
 Template test case with test types specified inside non-default-constructible
@@ -11672,9 +11672,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_trivially_copyable<TestType>::value )
 with expansion:
-  1 > 0
+  true
 
 -------------------------------------------------------------------------------
 Template test case with test types specified inside non-default-constructible
@@ -11684,9 +11684,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_trivially_copyable<TestType>::value )
 with expansion:
-  4 > 0
+  true
 
 -------------------------------------------------------------------------------
 Template test case with test types specified inside std::tuple - MyTypes - 0
@@ -11695,9 +11695,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_arithmetic<TestType>::value )
 with expansion:
-  4 > 0
+  true
 
 -------------------------------------------------------------------------------
 Template test case with test types specified inside std::tuple - MyTypes - 1
@@ -11706,9 +11706,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_arithmetic<TestType>::value )
 with expansion:
-  1 > 0
+  true
 
 -------------------------------------------------------------------------------
 Template test case with test types specified inside std::tuple - MyTypes - 2
@@ -11717,9 +11717,9 @@ Misc.tests.cpp:<line number>
 ...............................................................................
 
 Misc.tests.cpp:<line number>: PASSED:
-  REQUIRE( sizeof(TestType) > 0 )
+  REQUIRE( std::is_arithmetic<TestType>::value )
 with expansion:
-  4 > 0
+  true
 
 -------------------------------------------------------------------------------
 TemplateTest: vectors can be sized and resized - float
@@ -17280,6 +17280,42 @@ with expansion:
 
 -------------------------------------------------------------------------------
 replaceInPlace
+  no replace in already-replaced string
+  lengthening
+-------------------------------------------------------------------------------
+StringManip.tests.cpp:<line number>
+...............................................................................
+
+StringManip.tests.cpp:<line number>: PASSED:
+  CHECK( Catch::replaceInPlace(letters, "c", "cc") )
+with expansion:
+  true
+
+StringManip.tests.cpp:<line number>: PASSED:
+  CHECK( letters == "abccdefccg" )
+with expansion:
+  "abccdefccg" == "abccdefccg"
+
+-------------------------------------------------------------------------------
+replaceInPlace
+  no replace in already-replaced string
+  shortening
+-------------------------------------------------------------------------------
+StringManip.tests.cpp:<line number>
+...............................................................................
+
+StringManip.tests.cpp:<line number>: PASSED:
+  CHECK( Catch::replaceInPlace(s, "--", "-") )
+with expansion:
+  true
+
+StringManip.tests.cpp:<line number>: PASSED:
+  CHECK( s == "--" )
+with expansion:
+  "--" == "--"
+
+-------------------------------------------------------------------------------
+replaceInPlace
   escape '
 -------------------------------------------------------------------------------
 StringManip.tests.cpp:<line number>
@@ -18721,5 +18757,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  417 |  312 passed |  85 failed | 6 skipped | 14 failed as expected
-assertions: 2256 | 2075 passed | 146 failed | 35 failed as expected
+assertions: 2260 | 2079 passed | 146 failed | 35 failed as expected
 

--- a/tests/SelfTest/Baselines/junit.sw.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="129" skipped="12" tests="2268" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="129" skipped="12" tests="2272" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="random-seed" value="1"/>
       <property name="filters" value="&quot;*&quot; ~[!nonportable] ~[!benchmark] ~[approvals]"/>
@@ -1966,6 +1966,8 @@ at Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="replaceInPlace/replace last char" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="replaceInPlace/replace all chars" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="replaceInPlace/replace no chars" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="replaceInPlace/no replace in already-replaced string/lengthening" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="replaceInPlace/no replace in already-replaced string/shortening" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="replaceInPlace/escape '" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="request an unknown %-starting stream fails" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="resolution" time="{duration}" status="run"/>

--- a/tests/SelfTest/Baselines/junit.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.multi.approved.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="<exe-name>" errors="17" failures="129" skipped="12" tests="2268" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="129" skipped="12" tests="2272" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="random-seed" value="1"/>
       <property name="filters" value="&quot;*&quot; ~[!nonportable] ~[!benchmark] ~[approvals]"/>
@@ -1965,6 +1965,8 @@ at Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="replaceInPlace/replace last char" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="replaceInPlace/replace all chars" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="replaceInPlace/replace no chars" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="replaceInPlace/no replace in already-replaced string/lengthening" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="replaceInPlace/no replace in already-replaced string/shortening" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="replaceInPlace/escape '" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="request an unknown %-starting stream fails" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="resolution" time="{duration}" status="run"/>

--- a/tests/SelfTest/Baselines/sonarqube.sw.approved.txt
+++ b/tests/SelfTest/Baselines/sonarqube.sw.approved.txt
@@ -262,6 +262,8 @@ at AssertionHandler.tests.cpp:<line number>
     <testCase name="replaceInPlace/replace last char" duration="{duration}"/>
     <testCase name="replaceInPlace/replace all chars" duration="{duration}"/>
     <testCase name="replaceInPlace/replace no chars" duration="{duration}"/>
+    <testCase name="replaceInPlace/no replace in already-replaced string/lengthening" duration="{duration}"/>
+    <testCase name="replaceInPlace/no replace in already-replaced string/shortening" duration="{duration}"/>
     <testCase name="replaceInPlace/escape '" duration="{duration}"/>
     <testCase name="splitString" duration="{duration}"/>
     <testCase name="startsWith" duration="{duration}"/>

--- a/tests/SelfTest/Baselines/sonarqube.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/sonarqube.sw.multi.approved.txt
@@ -261,6 +261,8 @@ at AssertionHandler.tests.cpp:<line number>
     <testCase name="replaceInPlace/replace last char" duration="{duration}"/>
     <testCase name="replaceInPlace/replace all chars" duration="{duration}"/>
     <testCase name="replaceInPlace/replace no chars" duration="{duration}"/>
+    <testCase name="replaceInPlace/no replace in already-replaced string/lengthening" duration="{duration}"/>
+    <testCase name="replaceInPlace/no replace in already-replaced string/shortening" duration="{duration}"/>
     <testCase name="replaceInPlace/escape '" duration="{duration}"/>
     <testCase name="splitString" duration="{duration}"/>
     <testCase name="startsWith" duration="{duration}"/>

--- a/tests/SelfTest/Baselines/tap.sw.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.approved.txt
@@ -2804,19 +2804,19 @@ ok {test-number} - Template_Fixture<TestType>::m_a == 1 for: 1 == 1
 # Template test case method with test types specified inside std::tuple - MyTypes - 2
 ok {test-number} - Template_Fixture<TestType>::m_a == 1 for: 1.0 == 1
 # Template test case with test types specified inside non-copyable and non-movable std::tuple - NonCopyableAndNonMovableTypes - 0
-ok {test-number} - sizeof(TestType) > 0 for: 1 > 0
+ok {test-number} - std::is_default_constructible<TestType>::value for: true
 # Template test case with test types specified inside non-copyable and non-movable std::tuple - NonCopyableAndNonMovableTypes - 1
-ok {test-number} - sizeof(TestType) > 0 for: 4 > 0
+ok {test-number} - std::is_default_constructible<TestType>::value for: true
 # Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 0
-ok {test-number} - sizeof(TestType) > 0 for: 1 > 0
+ok {test-number} - std::is_trivially_copyable<TestType>::value for: true
 # Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 1
-ok {test-number} - sizeof(TestType) > 0 for: 4 > 0
+ok {test-number} - std::is_trivially_copyable<TestType>::value for: true
 # Template test case with test types specified inside std::tuple - MyTypes - 0
-ok {test-number} - sizeof(TestType) > 0 for: 4 > 0
+ok {test-number} - std::is_arithmetic<TestType>::value for: true
 # Template test case with test types specified inside std::tuple - MyTypes - 1
-ok {test-number} - sizeof(TestType) > 0 for: 1 > 0
+ok {test-number} - std::is_arithmetic<TestType>::value for: true
 # Template test case with test types specified inside std::tuple - MyTypes - 2
-ok {test-number} - sizeof(TestType) > 0 for: 4 > 0
+ok {test-number} - std::is_arithmetic<TestType>::value for: true
 # TemplateTest: vectors can be sized and resized - float
 ok {test-number} - v.size() == 5 for: 5 == 5
 # TemplateTest: vectors can be sized and resized - float
@@ -4198,6 +4198,14 @@ ok {test-number} - !(Catch::replaceInPlace(letters, "x", "z")) for: !false
 # replaceInPlace
 ok {test-number} - letters == letters for: "abcdefcg" == "abcdefcg"
 # replaceInPlace
+ok {test-number} - Catch::replaceInPlace(letters, "c", "cc") for: true
+# replaceInPlace
+ok {test-number} - letters == "abccdefccg" for: "abccdefccg" == "abccdefccg"
+# replaceInPlace
+ok {test-number} - Catch::replaceInPlace(s, "--", "-") for: true
+# replaceInPlace
+ok {test-number} - s == "--" for: "--" == "--"
+# replaceInPlace
 ok {test-number} - Catch::replaceInPlace(s, "'", "|'") for: true
 # replaceInPlace
 ok {test-number} - s == "didn|'t" for: "didn|'t" == "didn|'t"
@@ -4541,5 +4549,5 @@ ok {test-number} - q3 == 23. for: 23.0 == 23.0
 ok {test-number} -
 # xmlentitycheck
 ok {test-number} -
-1..2268
+1..2272
 

--- a/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
@@ -2797,19 +2797,19 @@ ok {test-number} - Template_Fixture<TestType>::m_a == 1 for: 1 == 1
 # Template test case method with test types specified inside std::tuple - MyTypes - 2
 ok {test-number} - Template_Fixture<TestType>::m_a == 1 for: 1.0 == 1
 # Template test case with test types specified inside non-copyable and non-movable std::tuple - NonCopyableAndNonMovableTypes - 0
-ok {test-number} - sizeof(TestType) > 0 for: 1 > 0
+ok {test-number} - std::is_default_constructible<TestType>::value for: true
 # Template test case with test types specified inside non-copyable and non-movable std::tuple - NonCopyableAndNonMovableTypes - 1
-ok {test-number} - sizeof(TestType) > 0 for: 4 > 0
+ok {test-number} - std::is_default_constructible<TestType>::value for: true
 # Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 0
-ok {test-number} - sizeof(TestType) > 0 for: 1 > 0
+ok {test-number} - std::is_trivially_copyable<TestType>::value for: true
 # Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 1
-ok {test-number} - sizeof(TestType) > 0 for: 4 > 0
+ok {test-number} - std::is_trivially_copyable<TestType>::value for: true
 # Template test case with test types specified inside std::tuple - MyTypes - 0
-ok {test-number} - sizeof(TestType) > 0 for: 4 > 0
+ok {test-number} - std::is_arithmetic<TestType>::value for: true
 # Template test case with test types specified inside std::tuple - MyTypes - 1
-ok {test-number} - sizeof(TestType) > 0 for: 1 > 0
+ok {test-number} - std::is_arithmetic<TestType>::value for: true
 # Template test case with test types specified inside std::tuple - MyTypes - 2
-ok {test-number} - sizeof(TestType) > 0 for: 4 > 0
+ok {test-number} - std::is_arithmetic<TestType>::value for: true
 # TemplateTest: vectors can be sized and resized - float
 ok {test-number} - v.size() == 5 for: 5 == 5
 # TemplateTest: vectors can be sized and resized - float
@@ -4187,6 +4187,14 @@ ok {test-number} - !(Catch::replaceInPlace(letters, "x", "z")) for: !false
 # replaceInPlace
 ok {test-number} - letters == letters for: "abcdefcg" == "abcdefcg"
 # replaceInPlace
+ok {test-number} - Catch::replaceInPlace(letters, "c", "cc") for: true
+# replaceInPlace
+ok {test-number} - letters == "abccdefccg" for: "abccdefccg" == "abccdefccg"
+# replaceInPlace
+ok {test-number} - Catch::replaceInPlace(s, "--", "-") for: true
+# replaceInPlace
+ok {test-number} - s == "--" for: "--" == "--"
+# replaceInPlace
 ok {test-number} - Catch::replaceInPlace(s, "'", "|'") for: true
 # replaceInPlace
 ok {test-number} - s == "didn|'t" for: "didn|'t" == "didn|'t"
@@ -4530,5 +4538,5 @@ ok {test-number} - q3 == 23. for: 23.0 == 23.0
 ok {test-number} -
 # xmlentitycheck
 ok {test-number} -
-1..2268
+1..2272
 

--- a/tests/SelfTest/Baselines/xml.sw.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.approved.txt
@@ -13560,10 +13560,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside non-copyable and non-movable std::tuple - NonCopyableAndNonMovableTypes - 0" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_default_constructible&lt;TestType>::value
       </Original>
       <Expanded>
-        1 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -13571,10 +13571,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside non-copyable and non-movable std::tuple - NonCopyableAndNonMovableTypes - 1" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_default_constructible&lt;TestType>::value
       </Original>
       <Expanded>
-        4 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -13582,10 +13582,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 0" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_trivially_copyable&lt;TestType>::value
       </Original>
       <Expanded>
-        1 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -13593,10 +13593,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 1" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_trivially_copyable&lt;TestType>::value
       </Original>
       <Expanded>
-        4 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -13604,10 +13604,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside std::tuple - MyTypes - 0" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_arithmetic&lt;TestType>::value
       </Original>
       <Expanded>
-        4 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -13615,10 +13615,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside std::tuple - MyTypes - 1" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_arithmetic&lt;TestType>::value
       </Original>
       <Expanded>
-        1 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -13626,10 +13626,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside std::tuple - MyTypes - 2" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_arithmetic&lt;TestType>::value
       </Original>
       <Expanded>
-        4 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -20034,6 +20034,50 @@ b1!
       </Expression>
       <OverallResults successes="2" failures="0" expectedFailures="0" skipped="false"/>
     </Section>
+    <Section name="no replace in already-replaced string" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+      <Section name="lengthening" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+        <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+          <Original>
+            Catch::replaceInPlace(letters, "c", "cc")
+          </Original>
+          <Expanded>
+            true
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+          <Original>
+            letters == "abccdefccg"
+          </Original>
+          <Expanded>
+            "abccdefccg" == "abccdefccg"
+          </Expanded>
+        </Expression>
+        <OverallResults successes="2" failures="0" expectedFailures="0" skipped="false"/>
+      </Section>
+      <OverallResults successes="2" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Section name="no replace in already-replaced string" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+      <Section name="shortening" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+        <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+          <Original>
+            Catch::replaceInPlace(s, "--", "-")
+          </Original>
+          <Expanded>
+            true
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+          <Original>
+            s == "--"
+          </Original>
+          <Expanded>
+            "--" == "--"
+          </Expanded>
+        </Expression>
+        <OverallResults successes="2" failures="0" expectedFailures="0" skipped="false"/>
+      </Section>
+      <OverallResults successes="2" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
     <Section name="escape '" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
       <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
         <Original>
@@ -21675,6 +21719,6 @@ b1!
     </Section>
     <OverallResult success="true" skips="0"/>
   </TestCase>
-  <OverallResults successes="2075" failures="146" expectedFailures="35" skips="12"/>
+  <OverallResults successes="2079" failures="146" expectedFailures="35" skips="12"/>
   <OverallResultsCases successes="312" failures="85" expectedFailures="14" skips="6"/>
 </Catch2TestRun>

--- a/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
@@ -13560,10 +13560,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside non-copyable and non-movable std::tuple - NonCopyableAndNonMovableTypes - 0" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_default_constructible&lt;TestType>::value
       </Original>
       <Expanded>
-        1 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -13571,10 +13571,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside non-copyable and non-movable std::tuple - NonCopyableAndNonMovableTypes - 1" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_default_constructible&lt;TestType>::value
       </Original>
       <Expanded>
-        4 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -13582,10 +13582,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 0" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_trivially_copyable&lt;TestType>::value
       </Original>
       <Expanded>
-        1 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -13593,10 +13593,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside non-default-constructible std::tuple - MyNonDefaultConstructibleTypes - 1" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_trivially_copyable&lt;TestType>::value
       </Original>
       <Expanded>
-        4 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -13604,10 +13604,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside std::tuple - MyTypes - 0" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_arithmetic&lt;TestType>::value
       </Original>
       <Expanded>
-        4 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -13615,10 +13615,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside std::tuple - MyTypes - 1" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_arithmetic&lt;TestType>::value
       </Original>
       <Expanded>
-        1 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -13626,10 +13626,10 @@ Message from section two
   <TestCase name="Template test case with test types specified inside std::tuple - MyTypes - 2" tags="[list][template]" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
     <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/UsageTests/Misc.tests.cpp" >
       <Original>
-        sizeof(TestType) > 0
+        std::is_arithmetic&lt;TestType>::value
       </Original>
       <Expanded>
-        4 > 0
+        true
       </Expanded>
     </Expression>
     <OverallResult success="true" skips="0"/>
@@ -20033,6 +20033,50 @@ b1!
       </Expression>
       <OverallResults successes="2" failures="0" expectedFailures="0" skipped="false"/>
     </Section>
+    <Section name="no replace in already-replaced string" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+      <Section name="lengthening" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+        <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+          <Original>
+            Catch::replaceInPlace(letters, "c", "cc")
+          </Original>
+          <Expanded>
+            true
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+          <Original>
+            letters == "abccdefccg"
+          </Original>
+          <Expanded>
+            "abccdefccg" == "abccdefccg"
+          </Expanded>
+        </Expression>
+        <OverallResults successes="2" failures="0" expectedFailures="0" skipped="false"/>
+      </Section>
+      <OverallResults successes="2" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Section name="no replace in already-replaced string" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+      <Section name="shortening" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+        <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+          <Original>
+            Catch::replaceInPlace(s, "--", "-")
+          </Original>
+          <Expanded>
+            true
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
+          <Original>
+            s == "--"
+          </Original>
+          <Expanded>
+            "--" == "--"
+          </Expanded>
+        </Expression>
+        <OverallResults successes="2" failures="0" expectedFailures="0" skipped="false"/>
+      </Section>
+      <OverallResults successes="2" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
     <Section name="escape '" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
       <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/StringManip.tests.cpp" >
         <Original>
@@ -21674,6 +21718,6 @@ b1!
     </Section>
     <OverallResult success="true" skips="0"/>
   </TestCase>
-  <OverallResults successes="2075" failures="146" expectedFailures="35" skips="12"/>
+  <OverallResults successes="2079" failures="146" expectedFailures="35" skips="12"/>
   <OverallResultsCases successes="312" failures="85" expectedFailures="14" skips="6"/>
 </Catch2TestRun>

--- a/tests/SelfTest/IntrospectiveTests/Details.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/Details.tests.cpp
@@ -120,13 +120,13 @@ TEST_CASE( "Optional supports move ops", "[optional][approvals]" ) {
     }
     SECTION( "Move construction from optional" ) {
         Optional<MoveChecker> opt_B( CATCH_MOVE( opt_A ) );
-        REQUIRE( opt_A->has_moved );
+        REQUIRE( opt_A->has_moved ); // NOLINT(clang-analyzer-cplusplus.Move)
     }
     SECTION( "Move assignment from optional" ) {
         Optional<MoveChecker> opt_B( opt_A );
         REQUIRE_FALSE( opt_A->has_moved );
         opt_B = CATCH_MOVE( opt_A );
-        REQUIRE( opt_A->has_moved );
+        REQUIRE( opt_A->has_moved ); // NOLINT(clang-analyzer-cplusplus.Move)
     }
 }
 

--- a/tests/SelfTest/IntrospectiveTests/GeneratorsImpl.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/GeneratorsImpl.tests.cpp
@@ -18,7 +18,6 @@
 #include <catch2/generators/catch_generators_adapters.hpp>
 #include <catch2/generators/catch_generators_random.hpp>
 #include <catch2/generators/catch_generators_range.hpp>
-#include <catch2/generators/catch_generator_exception.hpp>
 
 // Tests of generator implementation details
 TEST_CASE("Generators internals", "[generators][internals]") {

--- a/tests/SelfTest/IntrospectiveTests/Reporters.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/Reporters.tests.cpp
@@ -107,7 +107,7 @@ TEST_CASE( "Reporter's write listings to provided stream", "[reporters]" ) {
     for (auto const& factory : factories) {
         INFO("Tested reporter: " << factory.first);
         auto sstream = Catch::Detail::make_unique<StringIStream>();
-        auto& sstreamRef = *sstream.get();
+        auto& sstreamRef = *sstream;
 
         Catch::ConfigData cfg_data;
         cfg_data.rngSeed = 1234;

--- a/tests/SelfTest/IntrospectiveTests/StringManip.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/StringManip.tests.cpp
@@ -57,6 +57,17 @@ TEST_CASE("replaceInPlace", "[string-manip]") {
         CHECK_FALSE(Catch::replaceInPlace(letters, "x", "z"));
         CHECK(letters == letters);
     }
+    SECTION("no replace in already-replaced string") {
+        SECTION("lengthening") {
+            CHECK(Catch::replaceInPlace(letters, "c", "cc"));
+            CHECK(letters == "abccdefccg");
+        }
+        SECTION("shortening") {
+            std::string s = "----";
+            CHECK(Catch::replaceInPlace(s, "--", "-"));
+            CHECK(s == "--");
+        }
+    }
     SECTION("escape '") {
         std::string s = "didn't";
         CHECK(Catch::replaceInPlace(s, "'", "|'"));

--- a/tests/SelfTest/IntrospectiveTests/TestSpec.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/TestSpec.tests.cpp
@@ -236,7 +236,7 @@ TEST_CASE( "Parse test names and tags", "[command-line][test-spec][approvals]" )
         CHECK( spec.matches( *tcD ) == false );
     }
     SECTION( "two wildcarded names" ) {
-        TestSpec spec = parseTestSpec( "\"longer*\"\"*spaces\"" );
+        TestSpec spec = parseTestSpec( R"("longer*""*spaces")" );
         CHECK( spec.hasFilters() == true );
         CHECK( spec.matches( *tcA ) == false );
         CHECK( spec.matches( *tcB ) == false );

--- a/tests/SelfTest/IntrospectiveTests/TextFlow.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/TextFlow.tests.cpp
@@ -152,7 +152,7 @@ TEST_CASE( "TextFlow::Column respects indentation for empty lines",
 
     std::string written = as_written(col);
 
-    REQUIRE(as_written(col) == "  \n  \n  third line");
+    REQUIRE(written == "  \n  \n  third line");
 }
 
 TEST_CASE( "TextFlow::Column leading/trailing whitespace",

--- a/tests/SelfTest/UsageTests/Benchmark.tests.cpp
+++ b/tests/SelfTest/UsageTests/Benchmark.tests.cpp
@@ -90,14 +90,14 @@ TEST_CASE("Benchmark containers", "[!benchmark]") {
         };
         REQUIRE(v.size() == size);
 
-        int array[size];
+        int array[size] {};
         BENCHMARK("A fixed size array that should require no allocations") {
             for (int i = 0; i < size; ++i)
                 array[i] = i;
         };
         int sum = 0;
-        for (int i = 0; i < size; ++i)
-            sum += array[i];
+        for (int val : array)
+            sum += val;
         REQUIRE(sum > size);
 
         SECTION("XYZ") {
@@ -121,8 +121,8 @@ TEST_CASE("Benchmark containers", "[!benchmark]") {
                 runs = benchmarkIndex;
             };
 
-            for (size_t i = 0; i < v.size(); ++i) {
-                REQUIRE(v[i] == runs);
+            for (int val : v) {
+                REQUIRE(val == runs);
             }
         }
     }
@@ -135,8 +135,8 @@ TEST_CASE("Benchmark containers", "[!benchmark]") {
             for (int i = 0; i < size; ++i)
                 v[i] = generated;
         };
-        for (size_t i = 0; i < v.size(); ++i) {
-            REQUIRE(v[i] == generated);
+        for (int val : v) {
+            REQUIRE(val == generated);
         }
     }
 

--- a/tests/SelfTest/UsageTests/Class.tests.cpp
+++ b/tests/SelfTest/UsageTests/Class.tests.cpp
@@ -39,7 +39,7 @@ namespace {
     };
 
     template <typename T> struct Template_Fixture_2 {
-        Template_Fixture_2() {}
+        Template_Fixture_2() = default;
 
         T m_a;
     };

--- a/tests/SelfTest/UsageTests/Exception.tests.cpp
+++ b/tests/SelfTest/UsageTests/Exception.tests.cpp
@@ -119,7 +119,7 @@ TEST_CASE( "When unchecked exceptions are thrown, but caught, they do not affect
     try {
         throw std::domain_error( "unexpected exception" );
     }
-    catch(...) {}
+    catch(...) {} // NOLINT(bugprone-empty-catch)
 }
 
 
@@ -152,7 +152,7 @@ TEST_CASE( "Custom exceptions can be translated when testing for throwing as som
 }
 
 TEST_CASE( "Unexpected exceptions can be translated", "[.][failing][!throws]"  ) {
-    throw double( 3.14 );
+    throw double( 3.14 ); // NOLINT(readability-redundant-casting): the type is important here, so we want to be explicit
 }
 
 TEST_CASE("Thrown string literals are translated", "[.][failing][!throws]") {

--- a/tests/SelfTest/UsageTests/Matchers.tests.cpp
+++ b/tests/SelfTest/UsageTests/Matchers.tests.cpp
@@ -1027,7 +1027,6 @@ TEST_CASE( "Combining MatchNotOfGeneric does not nest",
 }
 
 struct EvilAddressOfOperatorUsed : std::exception {
-    EvilAddressOfOperatorUsed() {}
     const char* what() const noexcept override {
         return "overloaded address-of operator of matcher was used instead of "
                "std::addressof";
@@ -1035,7 +1034,6 @@ struct EvilAddressOfOperatorUsed : std::exception {
 };
 
 struct EvilCommaOperatorUsed : std::exception {
-    EvilCommaOperatorUsed() {}
     const char* what() const noexcept override {
         return "overloaded comma operator of matcher was used";
     }
@@ -1073,7 +1071,6 @@ struct ImmovableMatcher : Catch::Matchers::MatcherGenericBase {
 };
 
 struct MatcherWasMovedOrCopied : std::exception {
-    MatcherWasMovedOrCopied() {}
     const char* what() const noexcept override {
         return "attempted to copy or move a matcher";
     }
@@ -1081,17 +1078,20 @@ struct MatcherWasMovedOrCopied : std::exception {
 
 struct ThrowOnCopyOrMoveMatcher : Catch::Matchers::MatcherGenericBase {
     ThrowOnCopyOrMoveMatcher() = default;
-    [[noreturn]] ThrowOnCopyOrMoveMatcher( ThrowOnCopyOrMoveMatcher const& ):
-        Catch::Matchers::MatcherGenericBase() {
+
+    [[noreturn]] ThrowOnCopyOrMoveMatcher( ThrowOnCopyOrMoveMatcher const& other ):
+        Catch::Matchers::MatcherGenericBase( other ) {
         throw MatcherWasMovedOrCopied();
     }
-    [[noreturn]] ThrowOnCopyOrMoveMatcher( ThrowOnCopyOrMoveMatcher&& ):
-        Catch::Matchers::MatcherGenericBase() {
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    [[noreturn]] ThrowOnCopyOrMoveMatcher( ThrowOnCopyOrMoveMatcher&& other ):
+        Catch::Matchers::MatcherGenericBase( CATCH_MOVE(other) ) {
         throw MatcherWasMovedOrCopied();
     }
     ThrowOnCopyOrMoveMatcher& operator=( ThrowOnCopyOrMoveMatcher const& ) {
         throw MatcherWasMovedOrCopied();
     }
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
     ThrowOnCopyOrMoveMatcher& operator=( ThrowOnCopyOrMoveMatcher&& ) {
         throw MatcherWasMovedOrCopied();
     }

--- a/tests/SelfTest/UsageTests/Message.tests.cpp
+++ b/tests/SelfTest/UsageTests/Message.tests.cpp
@@ -80,20 +80,20 @@ TEST_CASE( "Output from all sections is reported", "[failing][messages][.]" ) {
 
 TEST_CASE( "Standard output from all sections is reported", "[messages][.]" ) {
     SECTION( "one" ) {
-        std::cout << "Message from section one" << std::endl;
+        std::cout << "Message from section one\n";
     }
 
     SECTION( "two" ) {
-        std::cout << "Message from section two" << std::endl;
+        std::cout << "Message from section two\n";
     }
 }
 
 TEST_CASE( "Standard error is reported and redirected", "[messages][.][approvals]" ) {
     SECTION( "std::cerr" ) {
-        std::cerr << "Write to std::cerr" << std::endl;
+        std::cerr << "Write to std::cerr\n";
     }
     SECTION( "std::clog" ) {
-        std::clog << "Write to std::clog" << std::endl;
+        std::clog << "Write to std::clog\n";
     }
     SECTION( "Interleaved writes to cerr and clog" ) {
         std::cerr << "Inter";
@@ -101,7 +101,7 @@ TEST_CASE( "Standard error is reported and redirected", "[messages][.][approvals
         std::cerr << ' ';
         std::clog << "writes";
         std::cerr << " to error";
-        std::clog << " streams" << std::endl;
+        std::clog << " streams\n" << std::flush;
     }
 }
 

--- a/tests/SelfTest/UsageTests/Misc.tests.cpp
+++ b/tests/SelfTest/UsageTests/Misc.tests.cpp
@@ -158,9 +158,9 @@ TEST_CASE( "looped tests", "[.][failing]" ) {
 }
 
 TEST_CASE( "Sends stuff to stdout and stderr", "[.]" ) {
-    std::cout << "A string sent directly to stdout" << std::endl;
-    std::cerr << "A string sent directly to stderr" << std::endl;
-    std::clog << "A string sent to stderr via clog" << std::endl;
+    std::cout << "A string sent directly to stdout\n" << std::flush;
+    std::cerr << "A string sent directly to stderr\n" << std::flush;
+    std::clog << "A string sent to stderr via clog\n" << std::flush;
 }
 
 TEST_CASE( "null strings" ) {
@@ -396,7 +396,7 @@ TEMPLATE_PRODUCT_TEST_CASE("Product with differing arities", "[template][product
 using MyTypes = std::tuple<int, char, float>;
 TEMPLATE_LIST_TEST_CASE("Template test case with test types specified inside std::tuple", "[template][list]", MyTypes)
 {
-    REQUIRE(sizeof(TestType) > 0);
+    REQUIRE(std::is_arithmetic<TestType>::value);
 }
 
 struct NonDefaultConstructibleType {
@@ -406,7 +406,7 @@ struct NonDefaultConstructibleType {
 using MyNonDefaultConstructibleTypes = std::tuple<NonDefaultConstructibleType, float>;
 TEMPLATE_LIST_TEST_CASE("Template test case with test types specified inside non-default-constructible std::tuple", "[template][list]", MyNonDefaultConstructibleTypes)
 {
-    REQUIRE(sizeof(TestType) > 0);
+    REQUIRE(std::is_trivially_copyable<TestType>::value);
 }
 
 struct NonCopyableAndNonMovableType {
@@ -421,7 +421,7 @@ struct NonCopyableAndNonMovableType {
 using NonCopyableAndNonMovableTypes = std::tuple<NonCopyableAndNonMovableType, float>;
 TEMPLATE_LIST_TEST_CASE("Template test case with test types specified inside non-copyable and non-movable std::tuple", "[template][list]", NonCopyableAndNonMovableTypes)
 {
-    REQUIRE(sizeof(TestType) > 0);
+    REQUIRE(std::is_default_constructible<TestType>::value);
 }
 
 // https://github.com/philsquared/Catch/issues/166

--- a/tests/SelfTest/UsageTests/Tricky.tests.cpp
+++ b/tests/SelfTest/UsageTests/Tricky.tests.cpp
@@ -261,7 +261,7 @@ TEST_CASE( "non streamable - with conv. op", "[Tricky]" )
 
 inline void foo() {}
 
-typedef void (*fooptr_t)();
+using fooptr_t = void (*)();
 
 TEST_CASE( "Comparing function pointers", "[Tricky][function pointer]" )
 {
@@ -281,7 +281,7 @@ struct S
 
 TEST_CASE( "Comparing member function pointers", "[Tricky][member function pointer][approvals]" )
 {
-    typedef void (S::*MF)();
+    using MF = void (S::*)();
     MF m = &S::f;
 
     CHECK( m == &S::f );

--- a/tools/scripts/releaseCommon.py
+++ b/tools/scripts/releaseCommon.py
@@ -89,7 +89,7 @@ def updateCmakeFile(version):
 def updateMesonFile(version):
     with open(mesonPath, 'rb') as file:
         lines = file.readlines()
-    replacementRegex = re.compile(b'''version\s*:\s*'(\\d+.\\d+.\\d+)', # CML version placeholder, don't delete''')
+    replacementRegex = re.compile(b'''version\\s*:\\s*'(\\d+.\\d+.\\d+)', # CML version placeholder, don't delete''')
     replacement = '''version: '{0}', # CML version placeholder, don't delete'''.format(version.getVersionString()).encode('ascii')
     with open(mesonPath, 'wb') as file:
         for line in lines:


### PR DESCRIPTION
## Description

As the title says, it's fairly straightforward.

And also add configuration for `clang-tidy`, run it in CI, and fix/suppress the resulting warnings.

## GitHub Issues

Closes #2816 