### PR TITLE
fix double promotion in catch_approx.cpp

### DIFF
--- a/src/catch2/catch_approx.cpp
+++ b/src/catch2/catch_approx.cpp
@@ -25,7 +25,7 @@ bool marginComparison(double lhs, double rhs, double margin) {
 namespace Catch {
 
     Approx::Approx ( double value )
-    :   m_epsilon( std::numeric_limits<float>::epsilon()*100. ),
+    :   m_epsilon( static_cast<double>(std::numeric_limits<float>::epsilon())*100. ),
         m_margin( 0.0 ),
         m_scale( 0.0 ),
         m_value( value )


### PR DESCRIPTION
## Description
Fix double promotion in catch_approx.cpp

## GitHub Issues

Closes #2820 
