### PR TITLE
Compiler compatibility for Visual Studio 2017 (v141) 

### DIFF
--- a/src/catch2/internal/catch_random_integer_helpers.hpp
+++ b/src/catch2/internal/catch_random_integer_helpers.hpp
@@ -41,9 +41,8 @@ namespace Catch {
         struct ExtendedMultResult {
             T upper;
             T lower;
-            friend bool operator==( ExtendedMultResult const& lhs,
-                                    ExtendedMultResult const& rhs ) {
-                return lhs.upper == rhs.upper && lhs.lower == rhs.lower;
+            bool operator==( ExtendedMultResult const& rhs ) const {
+                return upper == rhs.upper && lower == rhs.lower;
             }
         };
 


### PR DESCRIPTION
## Description
The problem with (and only with)  Visual Studio 2017 was that the `friend bool operator==` could not sufficient resolved / matched for a template class. In this case it was caused by the  `ExtendedMultResult`. 
An detailed description of the porblem and the boiled down problem can be found in the issue #2792.

As Martin mentioned in the issue #2792: Make the operator not-friend is a sufficient solution.

## GitHub Issues
Compiler problem with operator and include catch_all.hpp #2792 
