### PR TITLE
avoid useless case (FDuration pointer deref to FDuration=

### DIFF
--- a/src/catch2/benchmark/detail/catch_analyse.cpp
+++ b/src/catch2/benchmark/detail/catch_analyse.cpp
@@ -63,8 +63,8 @@ namespace Catch {
                     FDuration mean = FDuration(0);
                     int i = 0;
                     for (auto it = first; it < last; ++it, ++i) {
-                        samples.push_back(FDuration(*it));
-                        mean += FDuration(*it);
+                        samples.push_back(*it);
+                        mean += *it;
                     }
                     mean /= i;
 


### PR DESCRIPTION
## Description

Useless cast from FDuration to FDuration in `catch_analyse.cpp`

Found with the GCC warning: -Wuseless-cast

* Parameter: `FDuration* first`
* `auto it = first;` // it is also `FDuration*`
* `std::vector<FDuration> samples;`
* `samples.push_back(FDuration(*it));` push_back expects `FDuration`, so no cast needed.

same for `mean += FDuration(*it);`: `mean` is defined as `FDuration mean = FDuration(0);`, so `mean += *it;` should be fine.
