### PR TITLE
Ignore C++98 related compiler warnings

### DIFF
--- a/tests/SelfTest/TestRegistrations.cpp
+++ b/tests/SelfTest/TestRegistrations.cpp
@@ -20,7 +20,6 @@ CATCH_REGISTER_TAG_ALIAS("[@tricky]", "[tricky]~[.]")
 #ifdef __clang__
 #   pragma clang diagnostic ignored "-Wpadded"
 #   pragma clang diagnostic ignored "-Wweak-vtables"
-#   pragma clang diagnostic ignored "-Wc++98-compat"
 #endif
 
 /**

--- a/tests/SelfTest/UsageTests/Misc.tests.cpp
+++ b/tests/SelfTest/UsageTests/Misc.tests.cpp
@@ -11,11 +11,6 @@
 #include <catch2/internal/catch_config_wchar.hpp>
 #include <catch2/internal/catch_windows_h_proxy.hpp>
 
-#ifdef __clang__
-#   pragma clang diagnostic ignored "-Wc++98-compat"
-#   pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
-#endif
-
 
 #include <iostream>
 #include <cerrno>


### PR DESCRIPTION
## Description
Catch2 has long since required a standard newer than C++98 so we can safely ignore any warnings related to such old standards.
