### PR TITLE
Add workaround for unguarded use of __has_extension

### DIFF
--- a/src/catch2/internal/catch_platform.hpp
+++ b/src/catch2/internal/catch_platform.hpp
@@ -11,6 +11,9 @@
 // See e.g.:
 // https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/TargetConditionals.h.auto.html
 #ifdef __APPLE__
+#  ifndef __has_extension
+#    define __has_extension(x) 0
+#  endif
 #  include <TargetConditionals.h>
 #  if (defined(TARGET_OS_OSX) && TARGET_OS_OSX == 1) || \
       (defined(TARGET_OS_MAC) && TARGET_OS_MAC == 1)


### PR DESCRIPTION
## Description
In recent update, Apple's `TargetConditionals.h` contains unguarded use of `__has_extension`. This PR add a workaround for this.

## GitHub Issues
Fixes #2837