### PR TITLE
Add workaround for unguarded use of __has_extension (for v2.x)

### DIFF
--- a/include/internal/catch_platform.h
+++ b/include/internal/catch_platform.h
@@ -12,6 +12,9 @@
 // See e.g.:
 // https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/TargetConditionals.h.auto.html
 #ifdef __APPLE__
+#  ifndef __has_extension
+#    define __has_extension(x) 0
+#  endif
 #  include <TargetConditionals.h>
 #  if (defined(TARGET_OS_OSX) && TARGET_OS_OSX == 1) || \
       (defined(TARGET_OS_MAC) && TARGET_OS_MAC == 1)


### PR DESCRIPTION
This is a backport of #2839, for v2.x branch.