### PR TITLE
Use built-in CMake feature for requiring a specific language standard

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -362,29 +362,10 @@ set_target_properties(Catch2 PROPERTIES
                                 VERSION ${PROJECT_VERSION}
                               SOVERSION ${PROJECT_VERSION})
 
-# depend on bunch of C++11 and C++14 features to have C++14 enabled by default
+# require C++14
 target_compile_features(Catch2
   PUBLIC
-    cxx_alignas
-    cxx_alignof
-    cxx_attributes
-    cxx_auto_type
-    cxx_constexpr
-    cxx_defaulted_functions
-    cxx_deleted_functions
-    cxx_final
-    cxx_lambdas
-    cxx_noexcept
-    cxx_override
-    cxx_range_for
-    cxx_rvalue_references
-    cxx_static_assert
-    cxx_strong_enums
-    cxx_trailing_return_types
-    cxx_unicode_literals
-    cxx_user_literals
-    cxx_variable_templates
-    cxx_variadic_macros
+    cxx_std_14
 )
 
 configure_file(
@@ -475,26 +456,7 @@ if (CATCH_BUILD_EXAMPLES OR CATCH_BUILD_EXTRA_TESTS)
     )
     target_compile_features(Catch2_buildall_interface
       INTERFACE
-        cxx_alignas
-        cxx_alignof
-        cxx_attributes
-        cxx_auto_type
-        cxx_constexpr
-        cxx_defaulted_functions
-        cxx_deleted_functions
-        cxx_final
-        cxx_lambdas
-        cxx_noexcept
-        cxx_override
-        cxx_range_for
-        cxx_rvalue_references
-        cxx_static_assert
-        cxx_strong_enums
-        cxx_trailing_return_types
-        cxx_unicode_literals
-        cxx_user_literals
-        cxx_variable_templates
-        cxx_variadic_macros
+        cxx_std_14
     )
 endif()
 


### PR DESCRIPTION
## Description

This feature was added in CMake 3.8. Requiring specific language features is an outdated approach that CMake stopped supporting in favor of simply specifying the specific language standard you want.

Catch2 currently uses CMake 3.10 so here is a link to the CMake 3.10 docs which show that this feature exists.

https://cmake.org/cmake/help/v3.10/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
