### PR TITLE
Specify minimum C++ version for amalgamated test build

### DIFF
--- a/tests/ExtraTests/CMakeLists.txt
+++ b/tests/ExtraTests/CMakeLists.txt
@@ -556,6 +556,7 @@ add_executable(AmalgamatedTestCompilation
   ${CATCH_DIR}/extras/catch_amalgamated.cpp
 )
 target_include_directories(AmalgamatedTestCompilation PRIVATE ${CATCH_DIR}/extras)
+target_compile_features(AmalgamatedTestCompilation PRIVATE cxx_std_14)
 
 add_test(NAME AmalgamatedFileTest COMMAND AmalgamatedTestCompilation)
 set_tests_properties(


### PR DESCRIPTION
## Description

This target previously did not specify its minimum C++ standard. AppleClang was emitting warnings about the use of C++11 features which is fixed by telling CMake that this target requires C++14. Because this target does not link to the existing CMake targets it never inherited that C++ standard requirement.