### PR TITLE
Handle ANSI escape sequences when performing column wrapping

### DIFF
--- a/src/catch2/internal/catch_textflow.cpp
+++ b/src/catch2/internal/catch_textflow.cpp
@@ -109,6 +109,7 @@ namespace Catch {
         }
 
         void AnsiSkippingString::const_iterator::advance() {
+            assert( m_it != m_string->end() );
             m_it++;
             tryParseAnsiEscapes();
         }
@@ -150,6 +151,7 @@ namespace Catch {
                 return;
             }
 
+            assert( m_lineStart != current_line.end() );
             if ( *m_lineStart == '\n' ) { ++m_parsedTo; }
 
             const auto maxLineLength = m_column.m_width - indentSize();

--- a/src/catch2/internal/catch_textflow.cpp
+++ b/src/catch2/internal/catch_textflow.cpp
@@ -231,7 +231,7 @@ namespace Catch {
         }
 
         std::string Column::const_iterator::operator*() const {
-            assert( m_lineStart != m_parsedTo );
+            assert( m_lineStart <= m_parsedTo );
             return addIndentAndSuffix( m_lineStart, m_lineEnd );
         }
 

--- a/src/catch2/internal/catch_textflow.cpp
+++ b/src/catch2/internal/catch_textflow.cpp
@@ -33,8 +33,8 @@ namespace Catch {
         void AnsiSkippingString::preprocessString() {
             for ( auto it = m_string.begin(); it != m_string.end(); ) {
                 // try to read through an ansi sequence
-                while ( it + 1 < m_string.end() && *it == '\033' &&
-                        *( it + 1 ) == '[' ) {
+                while ( it != m_string.end() && *it == '\033' &&
+                        it + 1 != m_string.end() && *( it + 1 ) == '[' ) {
                     auto cursor = it + 2;
                     while ( cursor != m_string.end() &&
                             ( isdigit( *cursor ) || *cursor == ';' ) ) {
@@ -94,8 +94,8 @@ namespace Catch {
         void AnsiSkippingString::const_iterator::tryParseAnsiEscapes() {
             // check if we've landed on an ansi sequence, and if so read through
             // it
-            while ( m_it + 1 < m_string->end() && *m_it == '\033' &&
-                    *( m_it + 1 ) == '[' ) {
+            while ( m_it != m_string->end() && *m_it == '\033' &&
+                    m_it + 1 != m_string->end() &&  *( m_it + 1 ) == '[' ) {
                 auto cursor = m_it + 2;
                 while ( cursor != m_string->end() &&
                         ( isdigit( *cursor ) || *cursor == ';' ) ) {

--- a/src/catch2/internal/catch_textflow.cpp
+++ b/src/catch2/internal/catch_textflow.cpp
@@ -33,7 +33,7 @@ namespace Catch {
         void AnsiSkippingString::preprocessString() {
             for(auto it = m_string.begin(); it != m_string.end(); ) {
                 // try to read through an ansi sequence
-                while(*it == '\033' && it + 1 != m_string.end() && *(it + 1) == '[') {
+                while(it != m_string.end() && *it == '\033' && it + 1 != m_string.end() && *(it + 1) == '[') {
                     auto cursor = it + 2;
                     while(cursor != m_string.end() && (isdigit(*cursor) || *cursor == ';')) {
                         ++cursor;
@@ -122,8 +122,13 @@ namespace Catch {
         void Column::const_iterator::calcLength() {
             m_addHyphen = false;
             m_parsedTo = m_lineStart;
-
             AnsiSkippingString const& current_line = m_column.m_string;
+
+            if(m_parsedTo == current_line.end()) {
+                m_lineEnd = m_parsedTo;
+                return;
+            }
+
             if ( *m_lineStart == '\n' ) {
                 ++m_parsedTo;
             }
@@ -154,10 +159,8 @@ namespace Catch {
                     --m_lineEnd;
                 }
 
-                // If we found one, then that is where we linebreak
-                if ( lineLength > 0 ) {
-                } else {
-                    // Otherwise we have to split text with a hyphen
+                // If we found one, then that is where we linebreak, otherwise we have to split text with a hyphen
+                if ( lineLength == 0 ) {
                     m_addHyphen = true;
                     m_lineEnd = m_parsedTo.oneBefore();
                 }

--- a/src/catch2/internal/catch_textflow.hpp
+++ b/src/catch2/internal/catch_textflow.hpp
@@ -46,7 +46,8 @@ namespace Catch {
             // constant value" warning on MSVC
             static constexpr char sentinel = static_cast<char>( 0xffu );
 
-            AnsiSkippingString( std::string const& text );
+            explicit AnsiSkippingString( std::string const& text );
+            explicit AnsiSkippingString( std::string&& text );
 
             const_iterator begin() const;
             const_iterator end() const;

--- a/src/catch2/internal/catch_textflow.hpp
+++ b/src/catch2/internal/catch_textflow.hpp
@@ -111,6 +111,9 @@ namespace Catch {
             bool operator!=( const_iterator const& other ) const {
                 return !operator==( other );
             }
+            bool operator<=( const_iterator const& other ) const {
+                return m_it <= other.m_it;
+            }
 
             const_iterator oneBefore() const {
                 auto it = *this;

--- a/src/catch2/internal/catch_textflow.hpp
+++ b/src/catch2/internal/catch_textflow.hpp
@@ -40,7 +40,8 @@ namespace Catch {
         public:
             class const_iterator;
             using iterator = const_iterator;
-            static constexpr char sentinel = static_cast<char>(0xff);
+            // note: must be u-suffixed or this will cause a "truncation of constant value" warning on MSVC
+            static constexpr char sentinel = static_cast<char>(0xffu);
 
             AnsiSkippingString(std::string const& text);
 

--- a/src/catch2/internal/catch_textflow.hpp
+++ b/src/catch2/internal/catch_textflow.hpp
@@ -21,14 +21,16 @@ namespace Catch {
         class Columns;
 
         /**
-         * Abstraction for a string with ansi escape sequences that automatically skips over escapes when iterating.
-         * Only graphical escape sequences are considered.
+         * Abstraction for a string with ansi escape sequences that
+         * automatically skips over escapes when iterating. Only graphical
+         * escape sequences are considered.
          *
          * Internal representation:
          * An escape sequence looks like \033[39;49m
-         * We need bidirectional iteration and the unbound length of escape sequences poses a problem for operator--
-         * To make this work we'll replace the last `m` with a 0xff (this is a codepoint that won't have any utf-8
-         * meaning).
+         * We need bidirectional iteration and the unbound length of escape
+         * sequences poses a problem for operator-- To make this work we'll
+         * replace the last `m` with a 0xff (this is a codepoint that won't have
+         * any utf-8 meaning).
          */
         class AnsiSkippingString {
             std::string m_string;
@@ -40,19 +42,19 @@ namespace Catch {
         public:
             class const_iterator;
             using iterator = const_iterator;
-            // note: must be u-suffixed or this will cause a "truncation of constant value" warning on MSVC
-            static constexpr char sentinel = static_cast<char>(0xffu);
+            // note: must be u-suffixed or this will cause a "truncation of
+            // constant value" warning on MSVC
+            static constexpr char sentinel = static_cast<char>( 0xffu );
 
-            AnsiSkippingString(std::string const& text);
+            AnsiSkippingString( std::string const& text );
 
             const_iterator begin() const;
             const_iterator end() const;
 
-            size_t size() const {
-                return m_size;
-            }
+            size_t size() const { return m_size; }
 
-            std::string substring(const_iterator begin, const_iterator end) const;
+            std::string substring( const_iterator begin,
+                                   const_iterator end ) const;
         };
 
         class AnsiSkippingString::const_iterator {
@@ -63,7 +65,7 @@ namespace Catch {
             std::string::const_iterator m_it;
 
             explicit const_iterator( const std::string& string, EndTag ):
-                m_string(&string), m_it(string.end()) {}
+                m_string( &string ), m_it( string.end() ) {}
 
             void tryParseAnsiEscapes();
             void advance();
@@ -76,13 +78,12 @@ namespace Catch {
             using reference = value_type&;
             using iterator_category = std::bidirectional_iterator_tag;
 
-            explicit const_iterator( const std::string& string ): m_string(&string), m_it(string.begin()) {
+            explicit const_iterator( const std::string& string ):
+                m_string( &string ), m_it( string.begin() ) {
                 tryParseAnsiEscapes();
             }
 
-            char operator*() const {
-                return *m_it;
-            }
+            char operator*() const { return *m_it; }
 
             const_iterator& operator++() {
                 advance();
@@ -128,7 +129,8 @@ namespace Catch {
             AnsiSkippingString m_string;
             // Width of the column for linebreaking
             size_t m_width = CATCH_CONFIG_CONSOLE_WIDTH - 1;
-            // Indentation of other lines (including first if initial indent is unset)
+            // Indentation of other lines (including first if initial indent is
+            // unset)
             size_t m_indent = 0;
             // Indentation of the first line
             size_t m_initialIndent = std::string::npos;
@@ -152,7 +154,10 @@ namespace Catch {
                 bool m_addHyphen = false;
 
                 const_iterator( Column const& column, EndTag ):
-                    m_column( column ), m_lineStart( m_column.m_string.end() ), m_lineEnd(column.m_string.end()), m_parsedTo(column.m_string.end()) {}
+                    m_column( column ),
+                    m_lineStart( m_column.m_string.end() ),
+                    m_lineEnd( column.m_string.end() ),
+                    m_parsedTo( column.m_string.end() ) {}
 
                 // Calculates the length of the current line
                 void calcLength();
@@ -162,8 +167,9 @@ namespace Catch {
 
                 // Creates an indented and (optionally) suffixed string from
                 // current iterator position, indentation and length.
-                std::string addIndentAndSuffix( AnsiSkippingString::const_iterator start,
-                                                AnsiSkippingString::const_iterator end ) const;
+                std::string addIndentAndSuffix(
+                    AnsiSkippingString::const_iterator start,
+                    AnsiSkippingString::const_iterator end ) const;
 
             public:
                 using difference_type = std::ptrdiff_t;
@@ -180,7 +186,8 @@ namespace Catch {
                 const_iterator operator++( int );
 
                 bool operator==( const_iterator const& other ) const {
-                    return m_lineStart == other.m_lineStart && &m_column == &other.m_column;
+                    return m_lineStart == other.m_lineStart &&
+                           &m_column == &other.m_column;
                 }
                 bool operator!=( const_iterator const& other ) const {
                     return !operator==( other );
@@ -190,7 +197,7 @@ namespace Catch {
 
             explicit Column( std::string const& text ): m_string( text ) {}
             explicit Column( std::string&& text ):
-                m_string( CATCH_MOVE(text)) {}
+                m_string( CATCH_MOVE( text ) ) {}
 
             Column& width( size_t newWidth ) & {
                 assert( newWidth > 0 );
@@ -221,7 +228,9 @@ namespace Catch {
 
             size_t width() const { return m_width; }
             const_iterator begin() const { return const_iterator( *this ); }
-            const_iterator end() const { return { *this, const_iterator::EndTag{} }; }
+            const_iterator end() const {
+                return { *this, const_iterator::EndTag{} };
+            }
 
             friend std::ostream& operator<<( std::ostream& os,
                                              Column const& col );

--- a/src/catch2/internal/catch_textflow.hpp
+++ b/src/catch2/internal/catch_textflow.hpp
@@ -47,16 +47,16 @@ namespace Catch {
 
                 Column const& m_column;
                 // Where does the current line start?
-                size_t m_lineStart = 0;
+                std::string::const_iterator m_lineStart;
                 // How long should the current line be?
-                size_t m_lineLength = 0;
+                std::string::const_iterator m_lineEnd;
                 // How far have we checked the string to iterate?
-                size_t m_parsedTo = 0;
+                std::string::const_iterator m_parsedTo;
                 // Should a '-' be appended to the line?
                 bool m_addHyphen = false;
 
                 const_iterator( Column const& column, EndTag ):
-                    m_column( column ), m_lineStart( m_column.m_string.size() ) {}
+                    m_column( column ), m_lineStart( m_column.m_string.end() ), m_lineEnd(column.m_string.end()) {}
 
                 // Calculates the length of the current line
                 void calcLength();
@@ -66,8 +66,8 @@ namespace Catch {
 
                 // Creates an indented and (optionally) suffixed string from
                 // current iterator position, indentation and length.
-                std::string addIndentAndSuffix( size_t position,
-                                                size_t length ) const;
+                std::string addIndentAndSuffix( std::string::const_iterator start,
+                                                std::string::const_iterator end ) const;
 
             public:
                 using difference_type = std::ptrdiff_t;

--- a/src/catch2/internal/catch_textflow.hpp
+++ b/src/catch2/internal/catch_textflow.hpp
@@ -26,7 +26,7 @@ namespace Catch {
          *
          * Internal representation:
          * An escape sequence looks like \033[39;49m
-         * We need bidirectional iteration and tne unbound length of escape sequences poses a problem for operator--
+         * We need bidirectional iteration and the unbound length of escape sequences poses a problem for operator--
          * To make this work we'll replace the last `m` with a 0xff (this is a codepoint that won't have any utf-8
          * meaning).
          */


### PR DESCRIPTION
## Description
This PR adds functionality to skip around ANSI escape sequences in catch_textflow so they do not contribute to line length and line wrapping code does not split escape sequences in the middle. I've implemented this by creating a `AnsiSkippingString` abstraction that has a bidirectional iterator that can skip around escape sequences while iterating. Additionally I refactored `Column::const_iterator` to be iterator-based rather than index-based so this abstraction is a simple drop-in for `std::string`.

Currently only color sequences are handled, other escape sequences are left unaffected.

Motivation: Text with ANSI color sequences gets messed up when being output by Catch2 #2833.


For example, the current behavior of string with lots of escapes:
![image](https://github.com/catchorg/Catch2/assets/51220084/fbd9320f-2ca9-45ae-b741-ae00679c572c)
The example I have handy is a syntax-highlighted assertion from another library.

Behavior with this PR:
![image](https://github.com/catchorg/Catch2/assets/51220084/0a60148b-9e3b-4d9f-bade-da094be6e9c1)



## GitHub Issues
Closes #2833