### PR TITLE
Mention SUCCEED along with FAIL in logging.md

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -114,6 +114,10 @@ Similar to `INFO`, but messages are not limited to their own scope: They are rem
 
 The message is always reported but does not fail the test.
 
+**SUCCEED(** _message expression_ **)**
+
+The message is reported and the test case succeeds.
+
 **FAIL(** _message expression_ **)**
 
 The message is reported and the test case fails.


### PR DESCRIPTION

## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

I found it confusing that logging.md mentions `FAIL` but not `SUCCEED`, this probably wasn't intentional.

## GitHub Issues
N/A