### PR TITLE
Handle active Sections for fatal errors

### DIFF
--- a/src/catch2/internal/catch_run_context.cpp
+++ b/src/catch2/internal/catch_run_context.cpp
@@ -450,6 +450,13 @@ namespace Catch {
         assertionEnded(CATCH_MOVE(result) );
         resetAssertionInfo();
 
+        // Best effort cleanup for sections that have not been destructed yet
+        // Since this is a fatal error, we have not had and won't have the opportunity to destruct them properly
+        while (!m_activeSections.empty()) {
+            auto nl = m_activeSections.back()->nameAndLocation();
+            SectionEndInfo endInfo{ SectionInfo(CATCH_MOVE(nl.location), CATCH_MOVE(nl.name)), {}, 0.0 };
+            sectionEndedEarly(CATCH_MOVE(endInfo));
+        }
         handleUnfinishedSections();
 
         // Recreate section for test case (as we will lose the one that was in scope)

--- a/tests/ExtraTests/CMakeLists.txt
+++ b/tests/ExtraTests/CMakeLists.txt
@@ -467,6 +467,18 @@ set_tests_properties(
     PASS_REGULAR_EXPRESSION "Errors occurred during startup!"
 )
 
+add_executable(ReportingCrashWithJunitReporter ${TESTS_DIR}/X36-ReportingCrashWithJunitReporter.cpp)
+target_link_libraries(ReportingCrashWithJunitReporter PRIVATE Catch2::Catch2WithMain)
+add_test(
+  NAME Reporters::CrashInJunitReporter
+  COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:ReportingCrashWithJunitReporter> --reporter JUnit
+)
+set_tests_properties(
+    Reporters::CrashInJunitReporter
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION "</testsuites>"
+    LABELS "uses-signals"
+)
 
 add_executable(AssertionStartingEventGoesBeforeAssertionIsEvaluated
   X20-AssertionStartingEventGoesBeforeAssertionIsEvaluated.cpp

--- a/tests/ExtraTests/X36-ReportingCrashWithJunitReporter.cpp
+++ b/tests/ExtraTests/X36-ReportingCrashWithJunitReporter.cpp
@@ -1,0 +1,32 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+/**\file
+ * Checks that signals/SEH within open section does not hard crash JUnit
+ * (or similar reporter) while we are trying to report fatal error.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <csignal>
+
+// On Windows we need to send SEH and not signal to test the
+// RunContext::handleFatalErrorCondition code path
+#if defined( _MSC_VER )
+#    include <windows.h>
+#endif
+
+TEST_CASE( "raises signal" ) {
+    SECTION( "section" ) {
+#if defined( _MSC_VER )
+        RaiseException( 0xC0000005, 0, 0, NULL );
+#else
+        std::raise( SIGILL );
+#endif
+    }
+}

--- a/tools/misc/appveyorTestRunScript.bat
+++ b/tools/misc/appveyorTestRunScript.bat
@@ -5,7 +5,7 @@ reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug\AutoExclusion
 cd Build
 if "%CONFIGURATION%"=="Debug" (
   if "%coverage%"=="1" (
-    ctest -j 2 -C %CONFIGURATION% -D ExperimentalMemCheck || exit /b !ERRORLEVEL!
+    ctest -j 2 -C %CONFIGURATION% -D ExperimentalMemCheck -LE uses-signals || exit /b !ERRORLEVEL!
     python ..\tools\misc\appveyorMergeCoverageScript.py || exit /b !ERRORLEVEL!
     codecov --root .. --no-color --disable gcov -f cobertura.xml -t %CODECOV_TOKEN% || exit /b !ERRORLEVEL!
   ) else (


### PR DESCRIPTION
Closes #1210

When a signal is caught, the destructors of Sections will not be called. Thus, we must call `sectionEndedEarly` manually for those Sections.

Example test case:
```
TEST_CASE("broken") {
   SECTION("section") {
      /// Use illegal cpu instruction
      __asm__ __volatile__("ud2" : : : "memory");
   }
}
```
