### PR TITLE
Fix build on ARM64EC

### DIFF
--- a/src/catch2/internal/catch_random_integer_helpers.hpp
+++ b/src/catch2/internal/catch_random_integer_helpers.hpp
@@ -39,7 +39,6 @@
     !defined( CATCH_CONFIG_MSVC_UMUL128 )
 #    define CATCH_CONFIG_MSVC_UMUL128
 #    include <intrin.h>
-#    pragma intrinsic( _umul128 )
 #endif
 
 

--- a/src/catch2/internal/catch_random_integer_helpers.hpp
+++ b/src/catch2/internal/catch_random_integer_helpers.hpp
@@ -26,9 +26,6 @@
 // important for perf.
 #elif defined( _MSC_VER ) && defined( _M_X64 )
 #    define CATCH_CONFIG_INTERNAL_MSVC_UMUL128
-#    if defined( _M_ARM64EC )
-#        define CATCH_CONFIG_INTERNAL_MSVC_ARM64EC
-#    endif
 #endif
 
 #if defined( CATCH_CONFIG_INTERNAL_UINT128 ) && \
@@ -42,9 +39,7 @@
     !defined( CATCH_CONFIG_MSVC_UMUL128 )
 #    define CATCH_CONFIG_MSVC_UMUL128
 #    include <intrin.h>
-#    if !defined( CATCH_CONFIG_INTERNAL_MSVC_ARM64EC )
-#        pragma intrinsic( _umul128 )
-#    endif
+#    pragma intrinsic( _umul128 )
 #endif
 
 

--- a/src/catch2/internal/catch_random_integer_helpers.hpp
+++ b/src/catch2/internal/catch_random_integer_helpers.hpp
@@ -26,6 +26,9 @@
 // important for perf.
 #elif defined( _MSC_VER ) && defined( _M_X64 )
 #    define CATCH_CONFIG_INTERNAL_MSVC_UMUL128
+#    if defined( _M_ARM64EC )
+#        define CATCH_CONFIG_INTERNAL_MSVC_ARM64EC
+#    endif
 #endif
 
 #if defined( CATCH_CONFIG_INTERNAL_UINT128 ) && \
@@ -39,7 +42,9 @@
     !defined( CATCH_CONFIG_MSVC_UMUL128 )
 #    define CATCH_CONFIG_MSVC_UMUL128
 #    include <intrin.h>
-#    pragma intrinsic( _umul128 )
+#    if !defined( CATCH_CONFIG_INTERNAL_MSVC_ARM64EC )
+#        pragma intrinsic( _umul128 )
+#    endif
 #endif
 
 


### PR DESCRIPTION
Fixes build break due to `#pragma intrinsic( _umul128 )` on ARM64EC. This intrinsic only exists on x64. However, ARM64EC builds also define `_M_X64` so the `#pragma intrinsic` needs to be excluded on those.