### PR TITLE
conanfile: set compatibility_cppstd = False.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -19,6 +19,7 @@ class CatchConan(ConanFile):
     license = "BSL-1.0"
     version = "latest"
     settings = "os", "compiler", "build_type", "arch"
+    extension_properties = {"compatibility_cppstd": False}
 
     options = {
         "shared": [True, False],


### PR DESCRIPTION
## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

The Catch libraries have different API/ABI depending on the C++ standard they are compiled with. For example, [StringMaker::convert(std::string_view)](https://github.com/catchorg/Catch2/blob/53ddf37af4488cac7724761858ae3cca9d2d65e7/src/catch2/catch_tostring.cpp#L129) isn't in the binary when compiled with C++14, only with C++17 or later.

By default, Conan is allowed to serve Catch libraries compiled in C++14 to a project using C++17/20, potentially causing linker errors because of missing symbols (see https://github.com/catchorg/Catch2/issues/2605). This PR overrides this default using [conan extension properties](https://docs.conan.io/2/reference/conanfile/attributes.html#extension-properties): the C++ standard used to build the Catch library will exactly match the one of the requiring project (building Catch from source if necessary).

This is probably much more constraining than necessary (I assume it will prevent conan from using a `c++17` catch2 binary into a `gnu17` project). But that's the only simple solution I have. And as a user, locally rebuilding Catch "just in case" is much better than getting linker errors.

## Note:

Right now for Windows, the [conan-center catch2 package](https://conan.io/center/recipes/catch2) has only prebuilt binaries for C++14. So many Windows users are at risk of getting served C++14 Catch2 binaries in all their non-C++14 projects.

This can also happen on other platforms: if the first Catch2 binaries that ends up in your Conan cache were build in C++14, Conan will currently serve them in all your future C++17/20 projects.