### PR TITLE
conanfile: fix cmake_target_name of Catch2::Catch2.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -115,6 +115,7 @@ class CatchConan(ConanFile):
 
         # Catch2
         self.cpp_info.components["catch2base"].set_property("cmake_file_name", "Catch2::Catch2")
+        self.cpp_info.components["catch2base"].set_property("cmake_target_name", "Catch2::Catch2")
         self.cpp_info.components["catch2base"].set_property("pkg_config_name", "catch2")
         self.cpp_info.components["catch2base"].libs = ["Catch2" + lib_suffix]
         self.cpp_info.components["catch2base"].builddirs.append("lib/cmake/Catch2")


### PR DESCRIPTION
## Description

The "Catch2 without default main" target doesn't have a specific name in Conan, and defaults to catch2::catch2base. This commit switches it back to Catch2::Catch2, as described in the docs.
