### PR TITLE
Introduce box plot drawing script

### DIFF
--- a/extras/boxplot_xml.R
+++ b/extras/boxplot_xml.R
@@ -1,0 +1,34 @@
+library(XML)
+library(ggplot2)
+
+args <- commandArgs(trailingOnly = TRUE)
+data <- xmlParse(args[1])
+
+for (test_case in data["//TestCase"]) {
+  test_case_name <- xpathSApply(test_case, "./@name", paste)
+  results <- xpathSApply(test_case, ".//BenchmarkResults")
+  samples <- xpathSApply(test_case, ".//sample", xmlValue)
+  counts <- xpathSApply(test_case, ".//BenchmarkResults", function(r) {
+    xmlGetAttr(r, "samples", default = 0, converter = as.integer)
+  })
+  names <- xpathSApply(test_case, ".//BenchmarkResults/@name", paste)
+
+  if (length(names) == 0 || sum(counts) == 0) next
+  names <- rep(names, counts)
+
+  df <- data.frame(
+    methods = names,
+    samples = as.numeric(samples)
+  )
+
+  p <- ggplot(df, aes(x = methods, y = samples, fill = methods)) +
+    geom_boxplot(size = 0.5, staplewidth = 0.5) +
+    theme(axis.text.x = element_text(angle = -45, vjust = 1, hjust = 0)) +
+    labs(x = "Benchmark", y = "Time [ns]", title = test_case_name, fill = "Benchmark") +
+    scale_y_continuous(limits = c(0, NA))
+  print(p)
+  test_case_name |>
+    gsub(pattern = "\\s", replacement = "_") |>
+    paste(".png", sep = "") |>
+    ggsave()
+}

--- a/src/catch2/reporters/catch_reporter_xml.cpp
+++ b/src/catch2/reporters/catch_reporter_xml.cpp
@@ -250,6 +250,12 @@ namespace Catch {
             .writeAttribute("lowSevere"_sr, benchmarkStats.outliers.low_severe)
             .writeAttribute("highMild"_sr, benchmarkStats.outliers.high_mild)
             .writeAttribute("highSevere"_sr, benchmarkStats.outliers.high_severe);
+        auto samples = m_xml.scopedElement("samples");
+        for (auto const& sample : benchmarkStats.samples) {
+            m_xml.startElement("sample", XmlFormatting::Indent)
+                .writeText(std::to_string(sample.count()), XmlFormatting::None)
+                .endElement(XmlFormatting::Newline);
+        }
         m_xml.endElement();
     }
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
This adds a script that is drawing a box plot from the `BENCHMARK` measurement data. It is implemented in `R` using `XML` and `ggplot2` libraries. Xml reporter has been adjusted to include the measurement data.

Each `TEST_CASE` is drawn as a single plot and then exported as a png file named after the test case, with spaces replaced with underscore.
All plots are also saved to a single file `Rplots.pdf`.
Tests that don't have any measurement data are skipped.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
N/A

### Example plots from existing benchmark tests:

![Failing_benchmarks](https://github.com/catchorg/Catch2/assets/3284364/6e115848-7e70-429e-8192-33a47a01cace)
![Benchmark_containers](https://github.com/catchorg/Catch2/assets/3284364/893d4809-7213-45a0-b506-c4488f854f4c)
![Benchmark_Fibonacci](https://github.com/catchorg/Catch2/assets/3284364/6fa82fd3-d2bc-4bff-a339-b89ca031ccaa)
![Skip_benchmark_macros](https://github.com/catchorg/Catch2/assets/3284364/be171ded-10a5-42b6-b394-28fd86e7adaa)
