### PR TITLE
Cmake labels (take-over #2832)

### DIFF
--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -86,9 +86,6 @@ function(catch_discover_tests_impl)
     )
   endif()
 
-  # Remove any leading or trailing whitespace from the output
-  string(STRIP "${test_cases}" test_cases)
-
   # Prepare reporter
   if(reporter)
     set(reporter_arg "--reporter ${reporter}")

--- a/extras/catch_amalgamated.cpp
+++ b/extras/catch_amalgamated.cpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: BSL-1.0
 
 //  Catch v3.6.0
-//  Generated: 2024-05-10 11:52:28.385302
+//  Generated: 2024-05-14 10:26:40.575000
 //  ----------------------------------------------------------
 //  This file is an amalgamation of multiple different files.
 //  You probably shouldn't edit it directly.
@@ -8468,28 +8468,53 @@ namespace Catch {
 namespace Catch {
 
     namespace {
+        std::string createOpenBracket( int const& indent ) {
+            ReusableStringStream rss;
+            rss << '[';
+            if ( indent > 0 ) { rss << std::string( indent, '=' ); }
+            rss << '[';
+            return rss.str();
+        }
+        std::string createCloseBracket( int const& indent ) {
+            ReusableStringStream rss;
+            rss << ']';
+            if ( indent > 0 ) { rss << std::string( indent, '=' ); }
+            rss << ']';
+            return rss.str();
+        }
         std::ostream& tagWriter( std::ostream& out,
-                                 std::vector<Tag> const& tags ) {
+                                 std::vector<Tag> const& tags,
+                                 int const& indent ) {
             out << ';';
             if ( tags.empty() ) { return out; }
 
-            out << "[=[" << "[==[" << tags.front().original << "]==]";
+            out << createOpenBracket( indent );
+
+            out << createOpenBracket( indent + 1 ) << tags.front().original
+                << createCloseBracket( indent + 1 );
             for ( auto it = std::next( tags.begin() ); it != tags.end();
                   ++it ) {
-                out << ';' << "[==[" << it->original << "]==]";
+                out << ';' << createOpenBracket( indent + 1 ) << it->original
+                    << createCloseBracket( indent + 1 );
             }
-            out << "]=]";
+
+            out << createCloseBracket( indent );
+
             return out;
         }
 
         std::ostream& testWriter( std::ostream& out,
-                                  TestCaseHandle const& test ) {
+                                  TestCaseHandle const& test,
+                                  int const& indent ) {
             auto const& info = test.getTestCaseInfo();
-            out << "[[" << "[=[" << info.name << "]=]" << ';' << "[=["
-                << info.className << "]=]" << ';' << "[=[" << info.lineInfo.file
-                << "]=]" << ';' << "[=[" << info.lineInfo.line << "]=]";
-            tagWriter( out, info.tags );
-            out << "]]";
+            out << createOpenBracket( indent )
+                << createOpenBracket( indent + 1 ) << info.name
+                << createCloseBracket( indent + 1 ) << ';' << info.className
+                << ';' << createOpenBracket( indent + 1 ) << info.lineInfo.file
+                << createCloseBracket( indent + 1 ) << ';'
+                << info.lineInfo.line;
+            tagWriter( out, info.tags, indent );
+            out << createCloseBracket( indent );
 
             return out;
         }
@@ -8505,16 +8530,29 @@ namespace Catch {
 
         if ( descriptions.empty() ) { return; }
 
-        m_stream << "[[" << "[=[" << descriptions.front().name << "]=]" << ';'
-                 << "[=[" << descriptions.front().description << "]=]" << "]]";
+        int indent = 0;
+
+        m_stream << createOpenBracket( indent );
+
+        m_stream << createOpenBracket( indent + 1 )
+                 << createOpenBracket( indent + 2 ) << descriptions.front().name
+                 << createCloseBracket( indent + 2 ) << ';'
+                 << createOpenBracket( indent + 2 )
+                 << descriptions.front().description
+                 << createCloseBracket( indent + 2 )
+                 << createCloseBracket( indent + 1 );
         for ( auto it = std::next( descriptions.begin() );
               it != descriptions.end();
               ++it ) {
-            m_stream << ';' << "[[" << "[=[" << it->name << "]=]" << ';'
-                     << "[=[" << it->description << "]=]" << "]]";
+            m_stream << ';' << createOpenBracket( indent + 1 )
+                     << createOpenBracket( indent + 2 ) << it->name
+                     << createCloseBracket( indent + 2 ) << ';'
+                     << createOpenBracket( indent + 2 ) << it->description
+                     << createCloseBracket( indent + 2 )
+                     << createCloseBracket( indent + 1 );
         }
 
-        m_stream << '\n';
+        m_stream << createCloseBracket( indent );
     }
 
     void CMakeReporter::listListeners(
@@ -8522,43 +8560,68 @@ namespace Catch {
 
         if ( descriptions.empty() ) { return; }
 
-        m_stream << "[[" << "[=[" << descriptions.front().name << "]=]" << ';'
-                 << "[=[" << descriptions.front().description << "]=]" << "]]";
+        int indent = 0;
+
+        m_stream << createOpenBracket( indent );
+
+        m_stream << createOpenBracket( indent + 1 )
+                 << createOpenBracket( indent + 2 ) << descriptions.front().name
+                 << createCloseBracket( indent + 2 ) << ';'
+                 << createOpenBracket( indent + 2 )
+                 << descriptions.front().description
+                 << createCloseBracket( indent + 2 )
+                 << createCloseBracket( indent + 1 );
         for ( auto it = std::next( descriptions.begin() );
               it != descriptions.end();
               ++it ) {
-            m_stream << ';' << "[[" << "[=[" << it->name << "]=]" << ';'
-                     << "[=[" << it->description << "]=]" << "]]";
+            m_stream << ';' << createOpenBracket( indent + 1 )
+                     << createOpenBracket( indent + 2 ) << it->name
+                     << createCloseBracket( indent + 2 ) << ';'
+                     << createOpenBracket( indent + 2 ) << it->description
+                     << createCloseBracket( indent + 2 )
+                     << createCloseBracket( indent + 1 );
         }
 
-        m_stream << '\n';
+        m_stream << createCloseBracket( indent );
     }
 
     void CMakeReporter::listTests( std::vector<TestCaseHandle> const& tests ) {
         if ( tests.empty() ) { return; }
 
-        testWriter( m_stream, tests.front() );
+        int indent = 0;
+
+        m_stream << createOpenBracket( indent );
+
+        testWriter( m_stream, tests.front(), indent + 1 );
 
         for ( auto it = std::next( tests.begin() ); it != tests.end(); ++it ) {
             m_stream << ';';
-            testWriter( m_stream, *it );
+            testWriter( m_stream, *it, indent + 1 );
         }
 
-        m_stream << '\n';
+        m_stream << createCloseBracket( indent );
     }
 
     void CMakeReporter::listTags( std::vector<TagInfo> const& tags ) {
         if ( tags.empty() ) { return; }
 
-        m_stream << "[[" << "[=[" << tags.front().count << "]=]" << ';' << "[=["
-                 << tags.front().all() << "]=]" << "]]";
+        int indent = 0;
+
+        m_stream << createOpenBracket( indent );
+
+        m_stream << createOpenBracket( indent + 1 ) << tags.front().count << ';'
+                 << createOpenBracket( indent + 2 ) << tags.front().all()
+                 << createCloseBracket( indent + 2 )
+                 << createCloseBracket( indent + 1 );
 
         for ( auto it = std::next( tags.begin() ); it != tags.end(); ++it ) {
-            m_stream << ';' << "[[" << "[=[" << it->count << "]=]" << ';'
-                     << "[=[" << it->all() << "]=]" << "]]";
+            m_stream << ';' << createOpenBracket( indent + 1 ) << it->count
+                     << ';' << createOpenBracket( indent + 2 ) << it->all()
+                     << createCloseBracket( indent + 2 )
+                     << createCloseBracket( indent + 1 );
         }
 
-        m_stream << '\n';
+        m_stream << createCloseBracket( indent );
     }
 
 } // end namespace Catch

--- a/extras/catch_amalgamated.cpp
+++ b/extras/catch_amalgamated.cpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: BSL-1.0
 
 //  Catch v3.6.0
-//  Generated: 2024-05-10 11:46:09.025442
+//  Generated: 2024-05-10 11:52:28.385302
 //  ----------------------------------------------------------
 //  This file is an amalgamation of multiple different files.
 //  You probably shouldn't edit it directly.
@@ -8468,27 +8468,6 @@ namespace Catch {
 namespace Catch {
 
     namespace {
-        // template <typename T>
-        // std::string escapeString( T const& str ) {
-        //     ReusableStringStream rss;
-        //     for ( auto const& c : str ) {
-        //         switch ( c ) {
-        //         case ';':
-        //             rss << R"(\\;)";
-        //             break;
-        //         default:
-        //             rss << c;
-        //             break;
-        //         }
-        //     }
-
-        //     return rss.str();
-        // }
-
-        // std::string escapeCString( const char* const& str ) {
-        //     return escapeString( std::string( str ) );
-        // }
-
         std::ostream& tagWriter( std::ostream& out,
                                  std::vector<Tag> const& tags ) {
             out << ';';

--- a/extras/catch_amalgamated.cpp
+++ b/extras/catch_amalgamated.cpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: BSL-1.0
 
 //  Catch v3.6.0
-//  Generated: 2024-05-14 10:26:40.575000
+//  Generated: 2024-05-14 10:28:47.764955
 //  ----------------------------------------------------------
 //  This file is an amalgamation of multiple different files.
 //  You probably shouldn't edit it directly.

--- a/extras/catch_amalgamated.cpp
+++ b/extras/catch_amalgamated.cpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: BSL-1.0
 
 //  Catch v3.6.0
-//  Generated: 2024-05-08 15:27:20.167906
+//  Generated: 2024-05-10 11:46:09.025442
 //  ----------------------------------------------------------
 //  This file is an amalgamation of multiple different files.
 //  You probably shouldn't edit it directly.
@@ -8468,49 +8468,49 @@ namespace Catch {
 namespace Catch {
 
     namespace {
-        template <typename T>
-        std::string escapeString( T const& str ) {
-            ReusableStringStream rss;
-            for ( auto const& c : str ) {
-                switch ( c ) {
-                case ';':
-                    rss << R"(\\;)";
-                    break;
-                default:
-                    rss << c;
-                    break;
-                }
-            }
+        // template <typename T>
+        // std::string escapeString( T const& str ) {
+        //     ReusableStringStream rss;
+        //     for ( auto const& c : str ) {
+        //         switch ( c ) {
+        //         case ';':
+        //             rss << R"(\\;)";
+        //             break;
+        //         default:
+        //             rss << c;
+        //             break;
+        //         }
+        //     }
 
-            return rss.str();
-        }
+        //     return rss.str();
+        // }
 
-        std::string escapeCString( const char* const& str ) {
-            return escapeString( std::string( str ) );
-        }
+        // std::string escapeCString( const char* const& str ) {
+        //     return escapeString( std::string( str ) );
+        // }
 
         std::ostream& tagWriter( std::ostream& out,
                                  std::vector<Tag> const& tags ) {
-            if ( tags.empty() ) {
-                out << "\\;";
-                return out;
-            }
-            out << "\\;" << escapeString( tags.front().original );
+            out << ';';
+            if ( tags.empty() ) { return out; }
+
+            out << "[=[" << "[==[" << tags.front().original << "]==]";
             for ( auto it = std::next( tags.begin() ); it != tags.end();
                   ++it ) {
-                out << ',' << escapeString( it->original );
+                out << ';' << "[==[" << it->original << "]==]";
             }
+            out << "]=]";
             return out;
         }
 
         std::ostream& testWriter( std::ostream& out,
                                   TestCaseHandle const& test ) {
             auto const& info = test.getTestCaseInfo();
-            out << escapeString( info.name ) << "\\;"
-                << escapeString( info.className ) << "\\;"
-                << escapeCString( info.lineInfo.file ) << "\\;"
-                << info.lineInfo.line;
+            out << "[[" << "[=[" << info.name << "]=]" << ';' << "[=["
+                << info.className << "]=]" << ';' << "[=[" << info.lineInfo.file
+                << "]=]" << ';' << "[=[" << info.lineInfo.line << "]=]";
             tagWriter( out, info.tags );
+            out << "]]";
 
             return out;
         }
@@ -8526,13 +8526,13 @@ namespace Catch {
 
         if ( descriptions.empty() ) { return; }
 
-        m_stream << descriptions.front().name << "\\;"
-                 << descriptions.front().description;
+        m_stream << "[[" << "[=[" << descriptions.front().name << "]=]" << ';'
+                 << "[=[" << descriptions.front().description << "]=]" << "]]";
         for ( auto it = std::next( descriptions.begin() );
               it != descriptions.end();
               ++it ) {
-            m_stream << ";" << escapeString( it->name ) << "\\;"
-                     << escapeString( it->description );
+            m_stream << ';' << "[[" << "[=[" << it->name << "]=]" << ';'
+                     << "[=[" << it->description << "]=]" << "]]";
         }
 
         m_stream << '\n';
@@ -8543,13 +8543,13 @@ namespace Catch {
 
         if ( descriptions.empty() ) { return; }
 
-        m_stream << descriptions.front().name << "\\;"
-                 << descriptions.front().description;
+        m_stream << "[[" << "[=[" << descriptions.front().name << "]=]" << ';'
+                 << "[=[" << descriptions.front().description << "]=]" << "]]";
         for ( auto it = std::next( descriptions.begin() );
               it != descriptions.end();
               ++it ) {
-            m_stream << ";" << escapeString( it->name ) << "\\;"
-                     << escapeString( it->description );
+            m_stream << ';' << "[[" << "[=[" << it->name << "]=]" << ';'
+                     << "[=[" << it->description << "]=]" << "]]";
         }
 
         m_stream << '\n';
@@ -8571,11 +8571,12 @@ namespace Catch {
     void CMakeReporter::listTags( std::vector<TagInfo> const& tags ) {
         if ( tags.empty() ) { return; }
 
-        m_stream << tags.front().count << "\\;"
-                 << escapeString( tags.front().all() );
+        m_stream << "[[" << "[=[" << tags.front().count << "]=]" << ';' << "[=["
+                 << tags.front().all() << "]=]" << "]]";
 
         for ( auto it = std::next( tags.begin() ); it != tags.end(); ++it ) {
-            m_stream << ";" << it->count << "\\;" << escapeString( it->all() );
+            m_stream << ';' << "[[" << "[=[" << it->count << "]=]" << ';'
+                     << "[=[" << it->all() << "]=]" << "]]";
         }
 
         m_stream << '\n';

--- a/extras/catch_amalgamated.cpp
+++ b/extras/catch_amalgamated.cpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: BSL-1.0
 
 //  Catch v3.6.0
-//  Generated: 2024-05-05 20:53:27.562886
+//  Generated: 2024-05-08 15:27:20.167906
 //  ----------------------------------------------------------
 //  This file is an amalgamation of multiple different files.
 //  You probably shouldn't edit it directly.
@@ -5127,6 +5127,8 @@ namespace Catch {
         // we have to add the elements manually
         m_impl->factories["Automake"] =
             Detail::make_unique<ReporterFactory<AutomakeReporter>>();
+        m_impl->factories["CMake"] =
+            Detail::make_unique<ReporterFactory<CMakeReporter>>();
         m_impl->factories["compact"] =
             Detail::make_unique<ReporterFactory<CompactReporter>>();
         m_impl->factories["console"] =
@@ -8455,6 +8457,128 @@ namespace Catch {
 
     void AutomakeReporter::skipTest(TestCaseInfo const& testInfo) {
         m_stream << ":test-result: SKIP " << testInfo.name << '\n';
+    }
+
+} // end namespace Catch
+
+
+
+#include <ostream>
+
+namespace Catch {
+
+    namespace {
+        template <typename T>
+        std::string escapeString( T const& str ) {
+            ReusableStringStream rss;
+            for ( auto const& c : str ) {
+                switch ( c ) {
+                case ';':
+                    rss << R"(\\;)";
+                    break;
+                default:
+                    rss << c;
+                    break;
+                }
+            }
+
+            return rss.str();
+        }
+
+        std::string escapeCString( const char* const& str ) {
+            return escapeString( std::string( str ) );
+        }
+
+        std::ostream& tagWriter( std::ostream& out,
+                                 std::vector<Tag> const& tags ) {
+            if ( tags.empty() ) {
+                out << "\\;";
+                return out;
+            }
+            out << "\\;" << escapeString( tags.front().original );
+            for ( auto it = std::next( tags.begin() ); it != tags.end();
+                  ++it ) {
+                out << ',' << escapeString( it->original );
+            }
+            return out;
+        }
+
+        std::ostream& testWriter( std::ostream& out,
+                                  TestCaseHandle const& test ) {
+            auto const& info = test.getTestCaseInfo();
+            out << escapeString( info.name ) << "\\;"
+                << escapeString( info.className ) << "\\;"
+                << escapeCString( info.lineInfo.file ) << "\\;"
+                << info.lineInfo.line;
+            tagWriter( out, info.tags );
+
+            return out;
+        }
+
+    } // namespace
+
+    std::string CMakeReporter::getDescription() {
+        return "Outputs listings as a CMake list";
+    }
+
+    void CMakeReporter::listReporters(
+        std::vector<ReporterDescription> const& descriptions ) {
+
+        if ( descriptions.empty() ) { return; }
+
+        m_stream << descriptions.front().name << "\\;"
+                 << descriptions.front().description;
+        for ( auto it = std::next( descriptions.begin() );
+              it != descriptions.end();
+              ++it ) {
+            m_stream << ";" << escapeString( it->name ) << "\\;"
+                     << escapeString( it->description );
+        }
+
+        m_stream << '\n';
+    }
+
+    void CMakeReporter::listListeners(
+        std::vector<ListenerDescription> const& descriptions ) {
+
+        if ( descriptions.empty() ) { return; }
+
+        m_stream << descriptions.front().name << "\\;"
+                 << descriptions.front().description;
+        for ( auto it = std::next( descriptions.begin() );
+              it != descriptions.end();
+              ++it ) {
+            m_stream << ";" << escapeString( it->name ) << "\\;"
+                     << escapeString( it->description );
+        }
+
+        m_stream << '\n';
+    }
+
+    void CMakeReporter::listTests( std::vector<TestCaseHandle> const& tests ) {
+        if ( tests.empty() ) { return; }
+
+        testWriter( m_stream, tests.front() );
+
+        for ( auto it = std::next( tests.begin() ); it != tests.end(); ++it ) {
+            m_stream << ';';
+            testWriter( m_stream, *it );
+        }
+
+        m_stream << '\n';
+    }
+
+    void CMakeReporter::listTags( std::vector<TagInfo> const& tags ) {
+        if ( tags.empty() ) { return; }
+
+        m_stream << tags.front().count << "\\;"
+                 << escapeString( tags.front().all() );
+
+        for ( auto it = std::next( tags.begin() ); it != tags.end(); ++it ) {
+            m_stream << ";" << it->count << "\\;" << escapeString( it->all() );
+        }
+
+        m_stream << '\n';
     }
 
 } // end namespace Catch

--- a/extras/catch_amalgamated.hpp
+++ b/extras/catch_amalgamated.hpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: BSL-1.0
 
 //  Catch v3.6.0
-//  Generated: 2024-05-08 15:27:20.160378
+//  Generated: 2024-05-10 11:46:09.017879
 //  ----------------------------------------------------------
 //  This file is an amalgamation of multiple different files.
 //  You probably shouldn't edit it directly.

--- a/extras/catch_amalgamated.hpp
+++ b/extras/catch_amalgamated.hpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: BSL-1.0
 
 //  Catch v3.6.0
-//  Generated: 2024-05-05 20:53:27.071502
+//  Generated: 2024-05-08 15:27:20.160378
 //  ----------------------------------------------------------
 //  This file is an amalgamation of multiple different files.
 //  You probably shouldn't edit it directly.
@@ -13150,6 +13150,31 @@ namespace Catch {
 } // end namespace Catch
 
 #endif // CATCH_REPORTER_AUTOMAKE_HPP_INCLUDED
+
+
+#ifndef CATCH_REPORTER_CMAKE_HPP_INCLUDED
+#define CATCH_REPORTER_CMAKE_HPP_INCLUDED
+
+
+namespace Catch {
+
+    class CMakeReporter final : public StreamingReporterBase {
+    public:
+        using StreamingReporterBase::StreamingReporterBase;
+
+        static std::string getDescription();
+
+        void listReporters(
+            std::vector<ReporterDescription> const& descriptions ) override;
+        void listListeners(
+            std::vector<ListenerDescription> const& descriptions ) override;
+        void listTests( std::vector<TestCaseHandle> const& tests ) override;
+        void listTags( std::vector<TagInfo> const& tags ) override;
+    };
+
+} // end namespace Catch
+
+#endif // CATCH_REPORTER_CMAKE_HPP_INCLUDED
 
 
 #ifndef CATCH_REPORTER_COMPACT_HPP_INCLUDED

--- a/extras/catch_amalgamated.hpp
+++ b/extras/catch_amalgamated.hpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: BSL-1.0
 
 //  Catch v3.6.0
-//  Generated: 2024-05-10 11:52:28.378012
+//  Generated: 2024-05-14 10:26:40.566294
 //  ----------------------------------------------------------
 //  This file is an amalgamation of multiple different files.
 //  You probably shouldn't edit it directly.

--- a/extras/catch_amalgamated.hpp
+++ b/extras/catch_amalgamated.hpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: BSL-1.0
 
 //  Catch v3.6.0
-//  Generated: 2024-05-14 10:26:40.566294
+//  Generated: 2024-05-14 10:28:47.756940
 //  ----------------------------------------------------------
 //  This file is an amalgamation of multiple different files.
 //  You probably shouldn't edit it directly.

--- a/extras/catch_amalgamated.hpp
+++ b/extras/catch_amalgamated.hpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: BSL-1.0
 
 //  Catch v3.6.0
-//  Generated: 2024-05-10 11:46:09.017879
+//  Generated: 2024-05-10 11:52:28.378012
 //  ----------------------------------------------------------
 //  This file is an amalgamation of multiple different files.
 //  You probably shouldn't edit it directly.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -289,6 +289,7 @@ set(MATCHER_FILES ${MATCHER_HEADERS} ${MATCHER_SOURCES})
 
 set(REPORTER_HEADERS
   ${SOURCES_DIR}/reporters/catch_reporter_automake.hpp
+  ${SOURCES_DIR}/reporters/catch_reporter_cmake.hpp
   ${SOURCES_DIR}/reporters/catch_reporter_common_base.hpp
   ${SOURCES_DIR}/reporters/catch_reporter_compact.hpp
   ${SOURCES_DIR}/reporters/catch_reporter_console.hpp
@@ -308,6 +309,7 @@ set(REPORTER_HEADERS
 )
 set(REPORTER_SOURCES
   ${SOURCES_DIR}/reporters/catch_reporter_automake.cpp
+  ${SOURCES_DIR}/reporters/catch_reporter_cmake.cpp
   ${SOURCES_DIR}/reporters/catch_reporter_common_base.cpp
   ${SOURCES_DIR}/reporters/catch_reporter_compact.cpp
   ${SOURCES_DIR}/reporters/catch_reporter_console.cpp

--- a/src/catch2/internal/catch_reporter_registry.cpp
+++ b/src/catch2/internal/catch_reporter_registry.cpp
@@ -11,6 +11,7 @@
 #include <catch2/internal/catch_move_and_forward.hpp>
 #include <catch2/internal/catch_reporter_registry.hpp>
 #include <catch2/reporters/catch_reporter_automake.hpp>
+#include <catch2/reporters/catch_reporter_cmake.hpp>
 #include <catch2/reporters/catch_reporter_compact.hpp>
 #include <catch2/reporters/catch_reporter_console.hpp>
 #include <catch2/reporters/catch_reporter_json.hpp>
@@ -34,6 +35,8 @@ namespace Catch {
         // we have to add the elements manually
         m_impl->factories["Automake"] =
             Detail::make_unique<ReporterFactory<AutomakeReporter>>();
+        m_impl->factories["CMake"] =
+            Detail::make_unique<ReporterFactory<CMakeReporter>>();
         m_impl->factories["compact"] =
             Detail::make_unique<ReporterFactory<CompactReporter>>();
         m_impl->factories["console"] =

--- a/src/catch2/meson.build
+++ b/src/catch2/meson.build
@@ -282,6 +282,7 @@ internal_sources = files(
 
 reporter_headers = [
   'reporters/catch_reporter_automake.hpp',
+  'reporters/catch_reporter_cmake.hpp',
   'reporters/catch_reporter_common_base.hpp',
   'reporters/catch_reporter_compact.hpp',
   'reporters/catch_reporter_console.hpp',
@@ -302,6 +303,7 @@ reporter_headers = [
 
 reporter_sources = files(
   'reporters/catch_reporter_automake.cpp',
+  'reporters/catch_reporter_cmake.cpp',
   'reporters/catch_reporter_common_base.cpp',
   'reporters/catch_reporter_compact.cpp',
   'reporters/catch_reporter_console.cpp',

--- a/src/catch2/reporters/catch_reporter_cmake.cpp
+++ b/src/catch2/reporters/catch_reporter_cmake.cpp
@@ -16,49 +16,28 @@
 namespace Catch {
 
     namespace {
-        template <typename T>
-        std::string escapeString( T const& str ) {
-            ReusableStringStream rss;
-            for ( auto const& c : str ) {
-                switch ( c ) {
-                case ';':
-                    rss << R"(\\;)";
-                    break;
-                default:
-                    rss << c;
-                    break;
-                }
-            }
-
-            return rss.str();
-        }
-
-        std::string escapeCString( const char* const& str ) {
-            return escapeString( std::string( str ) );
-        }
-
         std::ostream& tagWriter( std::ostream& out,
                                  std::vector<Tag> const& tags ) {
-            if ( tags.empty() ) {
-                out << "\\;";
-                return out;
-            }
-            out << "\\;" << escapeString( tags.front().original );
+            out << ';';
+            if ( tags.empty() ) { return out; }
+
+            out << "[=[" << "[==[" << tags.front().original << "]==]";
             for ( auto it = std::next( tags.begin() ); it != tags.end();
                   ++it ) {
-                out << ',' << escapeString( it->original );
+                out << ';' << "[==[" << it->original << "]==]";
             }
+            out << "]=]";
             return out;
         }
 
         std::ostream& testWriter( std::ostream& out,
                                   TestCaseHandle const& test ) {
             auto const& info = test.getTestCaseInfo();
-            out << escapeString( info.name ) << "\\;"
-                << escapeString( info.className ) << "\\;"
-                << escapeCString( info.lineInfo.file ) << "\\;"
-                << info.lineInfo.line;
+            out << "[[" << "[=[" << info.name << "]=]" << ';' << "[=["
+                << info.className << "]=]" << ';' << "[=[" << info.lineInfo.file
+                << "]=]" << ';' << "[=[" << info.lineInfo.line << "]=]";
             tagWriter( out, info.tags );
+            out << "]]";
 
             return out;
         }
@@ -74,13 +53,13 @@ namespace Catch {
 
         if ( descriptions.empty() ) { return; }
 
-        m_stream << descriptions.front().name << "\\;"
-                 << descriptions.front().description;
+        m_stream << "[[" << "[=[" << descriptions.front().name << "]=]" << ';'
+                 << "[=[" << descriptions.front().description << "]=]" << "]]";
         for ( auto it = std::next( descriptions.begin() );
               it != descriptions.end();
               ++it ) {
-            m_stream << ";" << escapeString( it->name ) << "\\;"
-                     << escapeString( it->description );
+            m_stream << ';' << "[[" << "[=[" << it->name << "]=]" << ';'
+                     << "[=[" << it->description << "]=]" << "]]";
         }
 
         m_stream << '\n';
@@ -91,13 +70,13 @@ namespace Catch {
 
         if ( descriptions.empty() ) { return; }
 
-        m_stream << descriptions.front().name << "\\;"
-                 << descriptions.front().description;
+        m_stream << "[[" << "[=[" << descriptions.front().name << "]=]" << ';'
+                 << "[=[" << descriptions.front().description << "]=]" << "]]";
         for ( auto it = std::next( descriptions.begin() );
               it != descriptions.end();
               ++it ) {
-            m_stream << ";" << escapeString( it->name ) << "\\;"
-                     << escapeString( it->description );
+            m_stream << ';' << "[[" << "[=[" << it->name << "]=]" << ';'
+                     << "[=[" << it->description << "]=]" << "]]";
         }
 
         m_stream << '\n';
@@ -119,11 +98,12 @@ namespace Catch {
     void CMakeReporter::listTags( std::vector<TagInfo> const& tags ) {
         if ( tags.empty() ) { return; }
 
-        m_stream << tags.front().count << "\\;"
-                 << escapeString( tags.front().all() );
+        m_stream << "[[" << "[=[" << tags.front().count << "]=]" << ';' << "[=["
+                 << tags.front().all() << "]=]" << "]]";
 
         for ( auto it = std::next( tags.begin() ); it != tags.end(); ++it ) {
-            m_stream << ";" << it->count << "\\;" << escapeString( it->all() );
+            m_stream << ';' << "[[" << "[=[" << it->count << "]=]" << ';'
+                     << "[=[" << it->all() << "]=]" << "]]";
         }
 
         m_stream << '\n';

--- a/src/catch2/reporters/catch_reporter_cmake.cpp
+++ b/src/catch2/reporters/catch_reporter_cmake.cpp
@@ -1,0 +1,132 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+#include <catch2/catch_test_case_info.hpp>
+#include <catch2/internal/catch_reusable_string_stream.hpp>
+#include <catch2/internal/catch_stringref.hpp>
+#include <catch2/reporters/catch_reporter_cmake.hpp>
+#include <catch2/reporters/catch_reporter_helpers.hpp>
+
+#include <ostream>
+
+namespace Catch {
+
+    namespace {
+        template <typename T>
+        std::string escapeString( T const& str ) {
+            ReusableStringStream rss;
+            for ( auto const& c : str ) {
+                switch ( c ) {
+                case ';':
+                    rss << R"(\\;)";
+                    break;
+                default:
+                    rss << c;
+                    break;
+                }
+            }
+
+            return rss.str();
+        }
+
+        std::string escapeCString( const char* const& str ) {
+            return escapeString( std::string( str ) );
+        }
+
+        std::ostream& tagWriter( std::ostream& out,
+                                 std::vector<Tag> const& tags ) {
+            if ( tags.empty() ) {
+                out << "\\;";
+                return out;
+            }
+            out << "\\;" << escapeString( tags.front().original );
+            for ( auto it = std::next( tags.begin() ); it != tags.end();
+                  ++it ) {
+                out << ',' << escapeString( it->original );
+            }
+            return out;
+        }
+
+        std::ostream& testWriter( std::ostream& out,
+                                  TestCaseHandle const& test ) {
+            auto const& info = test.getTestCaseInfo();
+            out << escapeString( info.name ) << "\\;"
+                << escapeString( info.className ) << "\\;"
+                << escapeCString( info.lineInfo.file ) << "\\;"
+                << info.lineInfo.line;
+            tagWriter( out, info.tags );
+
+            return out;
+        }
+
+    } // namespace
+
+    std::string CMakeReporter::getDescription() {
+        return "Outputs listings as a CMake list";
+    }
+
+    void CMakeReporter::listReporters(
+        std::vector<ReporterDescription> const& descriptions ) {
+
+        if ( descriptions.empty() ) { return; }
+
+        m_stream << descriptions.front().name << "\\;"
+                 << descriptions.front().description;
+        for ( auto it = std::next( descriptions.begin() );
+              it != descriptions.end();
+              ++it ) {
+            m_stream << ";" << escapeString( it->name ) << "\\;"
+                     << escapeString( it->description );
+        }
+
+        m_stream << '\n';
+    }
+
+    void CMakeReporter::listListeners(
+        std::vector<ListenerDescription> const& descriptions ) {
+
+        if ( descriptions.empty() ) { return; }
+
+        m_stream << descriptions.front().name << "\\;"
+                 << descriptions.front().description;
+        for ( auto it = std::next( descriptions.begin() );
+              it != descriptions.end();
+              ++it ) {
+            m_stream << ";" << escapeString( it->name ) << "\\;"
+                     << escapeString( it->description );
+        }
+
+        m_stream << '\n';
+    }
+
+    void CMakeReporter::listTests( std::vector<TestCaseHandle> const& tests ) {
+        if ( tests.empty() ) { return; }
+
+        testWriter( m_stream, tests.front() );
+
+        for ( auto it = std::next( tests.begin() ); it != tests.end(); ++it ) {
+            m_stream << ';';
+            testWriter( m_stream, *it );
+        }
+
+        m_stream << '\n';
+    }
+
+    void CMakeReporter::listTags( std::vector<TagInfo> const& tags ) {
+        if ( tags.empty() ) { return; }
+
+        m_stream << tags.front().count << "\\;"
+                 << escapeString( tags.front().all() );
+
+        for ( auto it = std::next( tags.begin() ); it != tags.end(); ++it ) {
+            m_stream << ";" << it->count << "\\;" << escapeString( it->all() );
+        }
+
+        m_stream << '\n';
+    }
+
+} // end namespace Catch

--- a/src/catch2/reporters/catch_reporter_cmake.cpp
+++ b/src/catch2/reporters/catch_reporter_cmake.cpp
@@ -16,28 +16,53 @@
 namespace Catch {
 
     namespace {
+        std::string createOpenBracket( int const& indent ) {
+            ReusableStringStream rss;
+            rss << '[';
+            if ( indent > 0 ) { rss << std::string( indent, '=' ); }
+            rss << '[';
+            return rss.str();
+        }
+        std::string createCloseBracket( int const& indent ) {
+            ReusableStringStream rss;
+            rss << ']';
+            if ( indent > 0 ) { rss << std::string( indent, '=' ); }
+            rss << ']';
+            return rss.str();
+        }
         std::ostream& tagWriter( std::ostream& out,
-                                 std::vector<Tag> const& tags ) {
+                                 std::vector<Tag> const& tags,
+                                 int const& indent ) {
             out << ';';
             if ( tags.empty() ) { return out; }
 
-            out << "[=[" << "[==[" << tags.front().original << "]==]";
+            out << createOpenBracket( indent );
+
+            out << createOpenBracket( indent + 1 ) << tags.front().original
+                << createCloseBracket( indent + 1 );
             for ( auto it = std::next( tags.begin() ); it != tags.end();
                   ++it ) {
-                out << ';' << "[==[" << it->original << "]==]";
+                out << ';' << createOpenBracket( indent + 1 ) << it->original
+                    << createCloseBracket( indent + 1 );
             }
-            out << "]=]";
+
+            out << createCloseBracket( indent );
+
             return out;
         }
 
         std::ostream& testWriter( std::ostream& out,
-                                  TestCaseHandle const& test ) {
+                                  TestCaseHandle const& test,
+                                  int const& indent ) {
             auto const& info = test.getTestCaseInfo();
-            out << "[[" << "[=[" << info.name << "]=]" << ';' << "[=["
-                << info.className << "]=]" << ';' << "[=[" << info.lineInfo.file
-                << "]=]" << ';' << "[=[" << info.lineInfo.line << "]=]";
-            tagWriter( out, info.tags );
-            out << "]]";
+            out << createOpenBracket( indent )
+                << createOpenBracket( indent + 1 ) << info.name
+                << createCloseBracket( indent + 1 ) << ';' << info.className
+                << ';' << createOpenBracket( indent + 1 ) << info.lineInfo.file
+                << createCloseBracket( indent + 1 ) << ';'
+                << info.lineInfo.line;
+            tagWriter( out, info.tags, indent );
+            out << createCloseBracket( indent );
 
             return out;
         }
@@ -53,16 +78,29 @@ namespace Catch {
 
         if ( descriptions.empty() ) { return; }
 
-        m_stream << "[[" << "[=[" << descriptions.front().name << "]=]" << ';'
-                 << "[=[" << descriptions.front().description << "]=]" << "]]";
+        int indent = 0;
+
+        m_stream << createOpenBracket( indent );
+
+        m_stream << createOpenBracket( indent + 1 )
+                 << createOpenBracket( indent + 2 ) << descriptions.front().name
+                 << createCloseBracket( indent + 2 ) << ';'
+                 << createOpenBracket( indent + 2 )
+                 << descriptions.front().description
+                 << createCloseBracket( indent + 2 )
+                 << createCloseBracket( indent + 1 );
         for ( auto it = std::next( descriptions.begin() );
               it != descriptions.end();
               ++it ) {
-            m_stream << ';' << "[[" << "[=[" << it->name << "]=]" << ';'
-                     << "[=[" << it->description << "]=]" << "]]";
+            m_stream << ';' << createOpenBracket( indent + 1 )
+                     << createOpenBracket( indent + 2 ) << it->name
+                     << createCloseBracket( indent + 2 ) << ';'
+                     << createOpenBracket( indent + 2 ) << it->description
+                     << createCloseBracket( indent + 2 )
+                     << createCloseBracket( indent + 1 );
         }
 
-        m_stream << '\n';
+        m_stream << createCloseBracket( indent );
     }
 
     void CMakeReporter::listListeners(
@@ -70,43 +108,68 @@ namespace Catch {
 
         if ( descriptions.empty() ) { return; }
 
-        m_stream << "[[" << "[=[" << descriptions.front().name << "]=]" << ';'
-                 << "[=[" << descriptions.front().description << "]=]" << "]]";
+        int indent = 0;
+
+        m_stream << createOpenBracket( indent );
+
+        m_stream << createOpenBracket( indent + 1 )
+                 << createOpenBracket( indent + 2 ) << descriptions.front().name
+                 << createCloseBracket( indent + 2 ) << ';'
+                 << createOpenBracket( indent + 2 )
+                 << descriptions.front().description
+                 << createCloseBracket( indent + 2 )
+                 << createCloseBracket( indent + 1 );
         for ( auto it = std::next( descriptions.begin() );
               it != descriptions.end();
               ++it ) {
-            m_stream << ';' << "[[" << "[=[" << it->name << "]=]" << ';'
-                     << "[=[" << it->description << "]=]" << "]]";
+            m_stream << ';' << createOpenBracket( indent + 1 )
+                     << createOpenBracket( indent + 2 ) << it->name
+                     << createCloseBracket( indent + 2 ) << ';'
+                     << createOpenBracket( indent + 2 ) << it->description
+                     << createCloseBracket( indent + 2 )
+                     << createCloseBracket( indent + 1 );
         }
 
-        m_stream << '\n';
+        m_stream << createCloseBracket( indent );
     }
 
     void CMakeReporter::listTests( std::vector<TestCaseHandle> const& tests ) {
         if ( tests.empty() ) { return; }
 
-        testWriter( m_stream, tests.front() );
+        int indent = 0;
+
+        m_stream << createOpenBracket( indent );
+
+        testWriter( m_stream, tests.front(), indent + 1 );
 
         for ( auto it = std::next( tests.begin() ); it != tests.end(); ++it ) {
             m_stream << ';';
-            testWriter( m_stream, *it );
+            testWriter( m_stream, *it, indent + 1 );
         }
 
-        m_stream << '\n';
+        m_stream << createCloseBracket( indent );
     }
 
     void CMakeReporter::listTags( std::vector<TagInfo> const& tags ) {
         if ( tags.empty() ) { return; }
 
-        m_stream << "[[" << "[=[" << tags.front().count << "]=]" << ';' << "[=["
-                 << tags.front().all() << "]=]" << "]]";
+        int indent = 0;
+
+        m_stream << createOpenBracket( indent );
+
+        m_stream << createOpenBracket( indent + 1 ) << tags.front().count << ';'
+                 << createOpenBracket( indent + 2 ) << tags.front().all()
+                 << createCloseBracket( indent + 2 )
+                 << createCloseBracket( indent + 1 );
 
         for ( auto it = std::next( tags.begin() ); it != tags.end(); ++it ) {
-            m_stream << ';' << "[[" << "[=[" << it->count << "]=]" << ';'
-                     << "[=[" << it->all() << "]=]" << "]]";
+            m_stream << ';' << createOpenBracket( indent + 1 ) << it->count
+                     << ';' << createOpenBracket( indent + 2 ) << it->all()
+                     << createCloseBracket( indent + 2 )
+                     << createCloseBracket( indent + 1 );
         }
 
-        m_stream << '\n';
+        m_stream << createCloseBracket( indent );
     }
 
 } // end namespace Catch

--- a/src/catch2/reporters/catch_reporter_cmake.hpp
+++ b/src/catch2/reporters/catch_reporter_cmake.hpp
@@ -1,0 +1,31 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+#ifndef CATCH_REPORTER_CMAKE_HPP_INCLUDED
+#define CATCH_REPORTER_CMAKE_HPP_INCLUDED
+
+#include <catch2/reporters/catch_reporter_streaming_base.hpp>
+
+namespace Catch {
+
+    class CMakeReporter final : public StreamingReporterBase {
+    public:
+        using StreamingReporterBase::StreamingReporterBase;
+
+        static std::string getDescription();
+
+        void listReporters(
+            std::vector<ReporterDescription> const& descriptions ) override;
+        void listListeners(
+            std::vector<ListenerDescription> const& descriptions ) override;
+        void listTests( std::vector<TestCaseHandle> const& tests ) override;
+        void listTags( std::vector<TagInfo> const& tags ) override;
+    };
+
+} // end namespace Catch
+
+#endif // CATCH_REPORTER_CMAKE_HPP_INCLUDED

--- a/src/catch2/reporters/catch_reporters_all.hpp
+++ b/src/catch2/reporters/catch_reporters_all.hpp
@@ -22,6 +22,7 @@
 #define CATCH_REPORTERS_ALL_HPP_INCLUDED
 
 #include <catch2/reporters/catch_reporter_automake.hpp>
+#include <catch2/reporters/catch_reporter_cmake.hpp>
 #include <catch2/reporters/catch_reporter_common_base.hpp>
 #include <catch2/reporters/catch_reporter_compact.hpp>
 #include <catch2/reporters/catch_reporter_console.hpp>

--- a/tests/SelfTest/Baselines/compact.sw.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.approved.txt
@@ -1508,6 +1508,15 @@ Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fa
 
 " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: Automake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "1\;[fakeTag]
+" contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
+Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fake reporter"s) for: "fake reporter\;fake description
+" contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
+Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag
+" ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
+Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
 Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "All available tags:
    1  [fakeTag]
 1 tag
@@ -2841,6 +2850,6 @@ InternalBenchmark.tests.cpp:<line number>: passed: q3 == 23. for: 23.0 == 23.0
 Misc.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: passed:
 test cases:  416 |  311 passed |  85 failed | 6 skipped | 14 failed as expected
-assertions: 2255 | 2074 passed | 146 failed | 35 failed as expected
+assertions: 2261 | 2080 passed | 146 failed | 35 failed as expected
 
 

--- a/tests/SelfTest/Baselines/compact.sw.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.approved.txt
@@ -1508,13 +1508,13 @@ Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fa
 
 " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: Automake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
-Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "1\;[fakeTag]
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "[[[=[1]=];[=[[fakeTag]]=]]]
 " contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
-Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fake reporter"s) for: "fake reporter\;fake description
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fake reporter"s) for: "[[[=[fake reporter]=];[=[fake description]=]]]
 " contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
-Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==[fakeTestTag]==]]=]]]
 " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
 Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "All available tags:

--- a/tests/SelfTest/Baselines/compact.sw.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.approved.txt
@@ -1508,14 +1508,11 @@ Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fa
 
 " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: Automake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
-Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "[[[=[1]=];[=[[fakeTag]]=]]]
-" contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "[[[=[1;[==[[fakeTag]]==]]=]]]" contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
-Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fake reporter"s) for: "[[[=[fake reporter]=];[=[fake description]=]]]
-" contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fake reporter"s) for: "[[[=[[==[fake reporter]==];[==[fake description]==]]=]]]" contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
-Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==[fakeTestTag]==]]=]]]
-" ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "[[[=[[==[fake test name]==];;[==[fake-file.cpp]==];123456789;[=[[==[fakeTestTag]==]]=]]=]]]" ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
 Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "All available tags:
    1  [fakeTag]

--- a/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
@@ -1506,6 +1506,15 @@ Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fa
 
 " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: Automake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "1\;[fakeTag]
+" contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
+Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fake reporter"s) for: "fake reporter\;fake description
+" contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
+Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag
+" ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
+Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
 Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "All available tags:
    1  [fakeTag]
 1 tag
@@ -2830,6 +2839,6 @@ InternalBenchmark.tests.cpp:<line number>: passed: q3 == 23. for: 23.0 == 23.0
 Misc.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: passed:
 test cases:  416 |  311 passed |  85 failed | 6 skipped | 14 failed as expected
-assertions: 2255 | 2074 passed | 146 failed | 35 failed as expected
+assertions: 2261 | 2080 passed | 146 failed | 35 failed as expected
 
 

--- a/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
@@ -1506,13 +1506,13 @@ Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fa
 
 " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: Automake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
-Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "1\;[fakeTag]
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "[[[=[1]=];[=[[fakeTag]]=]]]
 " contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
-Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fake reporter"s) for: "fake reporter\;fake description
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fake reporter"s) for: "[[[=[fake reporter]=];[=[fake description]=]]]
 " contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
-Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==[fakeTestTag]==]]=]]]
 " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
 Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "All available tags:

--- a/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
@@ -1506,14 +1506,11 @@ Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fa
 
 " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: Automake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
-Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "[[[=[1]=];[=[[fakeTag]]=]]]
-" contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "[[[=[1;[==[[fakeTag]]==]]=]]]" contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
-Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fake reporter"s) for: "[[[=[fake reporter]=];[=[fake description]=]]]
-" contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fake reporter"s) for: "[[[=[[==[fake reporter]==];[==[fake description]==]]=]]]" contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
-Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==[fakeTestTag]==]]=]]]
-" ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
+Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "[[[=[[==[fake test name]==];;[==[fake-file.cpp]==];123456789;[=[[==[fakeTestTag]==]]=]]=]]]" ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
 Reporters.tests.cpp:<line number>: passed: !(factories.empty()) for: !false
 Reporters.tests.cpp:<line number>: passed: listingString, ContainsSubstring("fakeTag"s) for: "All available tags:
    1  [fakeTag]

--- a/tests/SelfTest/Baselines/console.std.approved.txt
+++ b/tests/SelfTest/Baselines/console.std.approved.txt
@@ -1599,5 +1599,5 @@ due to unexpected exception with message:
 
 ===============================================================================
 test cases:  416 |  325 passed |  70 failed | 7 skipped | 14 failed as expected
-assertions: 2238 | 2074 passed | 129 failed | 35 failed as expected
+assertions: 2244 | 2080 passed | 129 failed | 35 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.approved.txt
@@ -10024,8 +10024,7 @@ Reporters.tests.cpp:<line number>
 Reporters.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( listingString, ContainsSubstring("fakeTag"s) )
 with expansion:
-  "[[[=[1]=];[=[[fakeTag]]=]]]
-  " contains: "fakeTag"
+  "[[[=[1;[==[[fakeTag]]==]]=]]]" contains: "fakeTag"
 with message:
   Tested reporter: CMake
 
@@ -10050,8 +10049,8 @@ Reporters.tests.cpp:<line number>
 Reporters.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( listingString, ContainsSubstring("fake reporter"s) )
 with expansion:
-  "[[[=[fake reporter]=];[=[fake description]=]]]
-  " contains: "fake reporter"
+  "[[[=[[==[fake reporter]==];[==[fake description]==]]=]]]" contains: "fake
+  reporter"
 with message:
   Tested reporter: CMake
 
@@ -10076,9 +10075,9 @@ Reporters.tests.cpp:<line number>
 Reporters.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) )
 with expansion:
-  "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==
-  [fakeTestTag]==]]=]]]
-  " ( contains: "fake test name" and contains: "fakeTestTag" )
+  "[[[=[[==[fake test name]==];;[==[fake-file.cpp]==];123456789;[=[[==
+  [fakeTestTag]==]]=]]=]]]" ( contains: "fake test name" and contains:
+  "fakeTestTag" )
 with message:
   Tested reporter: CMake
 

--- a/tests/SelfTest/Baselines/console.sw.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.approved.txt
@@ -10024,7 +10024,7 @@ Reporters.tests.cpp:<line number>
 Reporters.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( listingString, ContainsSubstring("fakeTag"s) )
 with expansion:
-  "1\;[fakeTag]
+  "[[[=[1]=];[=[[fakeTag]]=]]]
   " contains: "fakeTag"
 with message:
   Tested reporter: CMake
@@ -10050,7 +10050,7 @@ Reporters.tests.cpp:<line number>
 Reporters.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( listingString, ContainsSubstring("fake reporter"s) )
 with expansion:
-  "fake reporter\;fake description
+  "[[[=[fake reporter]=];[=[fake description]=]]]
   " contains: "fake reporter"
 with message:
   Tested reporter: CMake
@@ -10076,7 +10076,8 @@ Reporters.tests.cpp:<line number>
 Reporters.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) )
 with expansion:
-  "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag
+  "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==
+  [fakeTestTag]==]]=]]]
   " ( contains: "fake test name" and contains: "fakeTestTag" )
 with message:
   Tested reporter: CMake

--- a/tests/SelfTest/Baselines/console.sw.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.approved.txt
@@ -10016,6 +10016,84 @@ with expansion:
 
 -------------------------------------------------------------------------------
 Reporter's write listings to provided stream
+  CMake reporter lists tags
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE_THAT( listingString, ContainsSubstring("fakeTag"s) )
+with expansion:
+  "1\;[fakeTag]
+  " contains: "fakeTag"
+with message:
+  Tested reporter: CMake
+
+-------------------------------------------------------------------------------
+Reporter's write listings to provided stream
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE_FALSE( factories.empty() )
+with expansion:
+  !false
+
+-------------------------------------------------------------------------------
+Reporter's write listings to provided stream
+  CMake reporter lists reporters
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE_THAT( listingString, ContainsSubstring("fake reporter"s) )
+with expansion:
+  "fake reporter\;fake description
+  " contains: "fake reporter"
+with message:
+  Tested reporter: CMake
+
+-------------------------------------------------------------------------------
+Reporter's write listings to provided stream
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE_FALSE( factories.empty() )
+with expansion:
+  !false
+
+-------------------------------------------------------------------------------
+Reporter's write listings to provided stream
+  CMake reporter lists tests
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE_THAT( listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) )
+with expansion:
+  "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag
+  " ( contains: "fake test name" and contains: "fakeTestTag" )
+with message:
+  Tested reporter: CMake
+
+-------------------------------------------------------------------------------
+Reporter's write listings to provided stream
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE_FALSE( factories.empty() )
+with expansion:
+  !false
+
+-------------------------------------------------------------------------------
+Reporter's write listings to provided stream
   compact reporter lists tags
 -------------------------------------------------------------------------------
 Reporters.tests.cpp:<line number>
@@ -18895,5 +18973,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  416 |  311 passed |  85 failed | 6 skipped | 14 failed as expected
-assertions: 2255 | 2074 passed | 146 failed | 35 failed as expected
+assertions: 2261 | 2080 passed | 146 failed | 35 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.multi.approved.txt
@@ -10014,6 +10014,84 @@ with expansion:
 
 -------------------------------------------------------------------------------
 Reporter's write listings to provided stream
+  CMake reporter lists tags
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE_THAT( listingString, ContainsSubstring("fakeTag"s) )
+with expansion:
+  "1\;[fakeTag]
+  " contains: "fakeTag"
+with message:
+  Tested reporter: CMake
+
+-------------------------------------------------------------------------------
+Reporter's write listings to provided stream
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE_FALSE( factories.empty() )
+with expansion:
+  !false
+
+-------------------------------------------------------------------------------
+Reporter's write listings to provided stream
+  CMake reporter lists reporters
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE_THAT( listingString, ContainsSubstring("fake reporter"s) )
+with expansion:
+  "fake reporter\;fake description
+  " contains: "fake reporter"
+with message:
+  Tested reporter: CMake
+
+-------------------------------------------------------------------------------
+Reporter's write listings to provided stream
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE_FALSE( factories.empty() )
+with expansion:
+  !false
+
+-------------------------------------------------------------------------------
+Reporter's write listings to provided stream
+  CMake reporter lists tests
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE_THAT( listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) )
+with expansion:
+  "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag
+  " ( contains: "fake test name" and contains: "fakeTestTag" )
+with message:
+  Tested reporter: CMake
+
+-------------------------------------------------------------------------------
+Reporter's write listings to provided stream
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE_FALSE( factories.empty() )
+with expansion:
+  !false
+
+-------------------------------------------------------------------------------
+Reporter's write listings to provided stream
   compact reporter lists tags
 -------------------------------------------------------------------------------
 Reporters.tests.cpp:<line number>
@@ -18884,5 +18962,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  416 |  311 passed |  85 failed | 6 skipped | 14 failed as expected
-assertions: 2255 | 2074 passed | 146 failed | 35 failed as expected
+assertions: 2261 | 2080 passed | 146 failed | 35 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.multi.approved.txt
@@ -10022,8 +10022,7 @@ Reporters.tests.cpp:<line number>
 Reporters.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( listingString, ContainsSubstring("fakeTag"s) )
 with expansion:
-  "[[[=[1]=];[=[[fakeTag]]=]]]
-  " contains: "fakeTag"
+  "[[[=[1;[==[[fakeTag]]==]]=]]]" contains: "fakeTag"
 with message:
   Tested reporter: CMake
 
@@ -10048,8 +10047,8 @@ Reporters.tests.cpp:<line number>
 Reporters.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( listingString, ContainsSubstring("fake reporter"s) )
 with expansion:
-  "[[[=[fake reporter]=];[=[fake description]=]]]
-  " contains: "fake reporter"
+  "[[[=[[==[fake reporter]==];[==[fake description]==]]=]]]" contains: "fake
+  reporter"
 with message:
   Tested reporter: CMake
 
@@ -10074,9 +10073,9 @@ Reporters.tests.cpp:<line number>
 Reporters.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) )
 with expansion:
-  "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==
-  [fakeTestTag]==]]=]]]
-  " ( contains: "fake test name" and contains: "fakeTestTag" )
+  "[[[=[[==[fake test name]==];;[==[fake-file.cpp]==];123456789;[=[[==
+  [fakeTestTag]==]]=]]=]]]" ( contains: "fake test name" and contains:
+  "fakeTestTag" )
 with message:
   Tested reporter: CMake
 

--- a/tests/SelfTest/Baselines/console.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.multi.approved.txt
@@ -10022,7 +10022,7 @@ Reporters.tests.cpp:<line number>
 Reporters.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( listingString, ContainsSubstring("fakeTag"s) )
 with expansion:
-  "1\;[fakeTag]
+  "[[[=[1]=];[=[[fakeTag]]=]]]
   " contains: "fakeTag"
 with message:
   Tested reporter: CMake
@@ -10048,7 +10048,7 @@ Reporters.tests.cpp:<line number>
 Reporters.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( listingString, ContainsSubstring("fake reporter"s) )
 with expansion:
-  "fake reporter\;fake description
+  "[[[=[fake reporter]=];[=[fake description]=]]]
   " contains: "fake reporter"
 with message:
   Tested reporter: CMake
@@ -10074,7 +10074,8 @@ Reporters.tests.cpp:<line number>
 Reporters.tests.cpp:<line number>: PASSED:
   REQUIRE_THAT( listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) )
 with expansion:
-  "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag
+  "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==
+  [fakeTestTag]==]]=]]]
   " ( contains: "fake test name" and contains: "fakeTestTag" )
 with message:
   Tested reporter: CMake

--- a/tests/SelfTest/Baselines/junit.sw.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="129" skipped="12" tests="2267" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="129" skipped="12" tests="2273" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="random-seed" value="1"/>
       <property name="filters" value="&quot;*&quot; ~[!nonportable] ~[!benchmark] ~[approvals]"/>
@@ -1213,6 +1213,9 @@ at Matchers.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/Automake reporter lists tags" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/Automake reporter lists reporters" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/Automake reporter lists tests" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/CMake reporter lists tags" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/CMake reporter lists reporters" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/CMake reporter lists tests" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/compact reporter lists tags" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/compact reporter lists reporters" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/compact reporter lists tests" time="{duration}" status="run"/>

--- a/tests/SelfTest/Baselines/junit.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.multi.approved.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="<exe-name>" errors="17" failures="129" skipped="12" tests="2267" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="129" skipped="12" tests="2273" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="random-seed" value="1"/>
       <property name="filters" value="&quot;*&quot; ~[!nonportable] ~[!benchmark] ~[approvals]"/>
@@ -1212,6 +1212,9 @@ at Matchers.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/Automake reporter lists tags" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/Automake reporter lists reporters" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/Automake reporter lists tests" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/CMake reporter lists tags" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/CMake reporter lists reporters" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/CMake reporter lists tests" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/compact reporter lists tags" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/compact reporter lists reporters" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Reporter's write listings to provided stream/compact reporter lists tests" time="{duration}" status="run"/>

--- a/tests/SelfTest/Baselines/sonarqube.sw.approved.txt
+++ b/tests/SelfTest/Baselines/sonarqube.sw.approved.txt
@@ -192,6 +192,9 @@ at AssertionHandler.tests.cpp:<line number>
     <testCase name="Reporter's write listings to provided stream/Automake reporter lists tags" duration="{duration}"/>
     <testCase name="Reporter's write listings to provided stream/Automake reporter lists reporters" duration="{duration}"/>
     <testCase name="Reporter's write listings to provided stream/Automake reporter lists tests" duration="{duration}"/>
+    <testCase name="Reporter's write listings to provided stream/CMake reporter lists tags" duration="{duration}"/>
+    <testCase name="Reporter's write listings to provided stream/CMake reporter lists reporters" duration="{duration}"/>
+    <testCase name="Reporter's write listings to provided stream/CMake reporter lists tests" duration="{duration}"/>
     <testCase name="Reporter's write listings to provided stream/compact reporter lists tags" duration="{duration}"/>
     <testCase name="Reporter's write listings to provided stream/compact reporter lists reporters" duration="{duration}"/>
     <testCase name="Reporter's write listings to provided stream/compact reporter lists tests" duration="{duration}"/>

--- a/tests/SelfTest/Baselines/sonarqube.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/sonarqube.sw.multi.approved.txt
@@ -191,6 +191,9 @@ at AssertionHandler.tests.cpp:<line number>
     <testCase name="Reporter's write listings to provided stream/Automake reporter lists tags" duration="{duration}"/>
     <testCase name="Reporter's write listings to provided stream/Automake reporter lists reporters" duration="{duration}"/>
     <testCase name="Reporter's write listings to provided stream/Automake reporter lists tests" duration="{duration}"/>
+    <testCase name="Reporter's write listings to provided stream/CMake reporter lists tags" duration="{duration}"/>
+    <testCase name="Reporter's write listings to provided stream/CMake reporter lists reporters" duration="{duration}"/>
+    <testCase name="Reporter's write listings to provided stream/CMake reporter lists tests" duration="{duration}"/>
     <testCase name="Reporter's write listings to provided stream/compact reporter lists tags" duration="{duration}"/>
     <testCase name="Reporter's write listings to provided stream/compact reporter lists reporters" duration="{duration}"/>
     <testCase name="Reporter's write listings to provided stream/compact reporter lists tests" duration="{duration}"/>

--- a/tests/SelfTest/Baselines/tap.sw.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.approved.txt
@@ -2471,15 +2471,15 @@ ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && Cont
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
-ok {test-number} - listingString, ContainsSubstring("fakeTag"s) for: "[[[=[1]=];[=[[fakeTag]]=]]] " contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
+ok {test-number} - listingString, ContainsSubstring("fakeTag"s) for: "[[[=[1;[==[[fakeTag]]==]]=]]]" contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
-ok {test-number} - listingString, ContainsSubstring("fake reporter"s) for: "[[[=[fake reporter]=];[=[fake description]=]]] " contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
+ok {test-number} - listingString, ContainsSubstring("fake reporter"s) for: "[[[=[[==[fake reporter]==];[==[fake description]==]]=]]]" contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
-ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==[fakeTestTag]==]]=]]] " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
+ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "[[[=[[==[fake test name]==];;[==[fake-file.cpp]==];123456789;[=[[==[fakeTestTag]==]]=]]=]]]" ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream

--- a/tests/SelfTest/Baselines/tap.sw.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.approved.txt
@@ -2471,6 +2471,18 @@ ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && Cont
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
+ok {test-number} - listingString, ContainsSubstring("fakeTag"s) for: "1\;[fakeTag] " contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
+# Reporter's write listings to provided stream
+ok {test-number} - !(factories.empty()) for: !false
+# Reporter's write listings to provided stream
+ok {test-number} - listingString, ContainsSubstring("fake reporter"s) for: "fake reporter\;fake description " contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
+# Reporter's write listings to provided stream
+ok {test-number} - !(factories.empty()) for: !false
+# Reporter's write listings to provided stream
+ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
+# Reporter's write listings to provided stream
+ok {test-number} - !(factories.empty()) for: !false
+# Reporter's write listings to provided stream
 ok {test-number} - listingString, ContainsSubstring("fakeTag"s) for: "All available tags:    1  [fakeTag] 1 tag  " contains: "fakeTag" with 1 message: 'Tested reporter: compact'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
@@ -4539,5 +4551,5 @@ ok {test-number} - q3 == 23. for: 23.0 == 23.0
 ok {test-number} -
 # xmlentitycheck
 ok {test-number} -
-1..2267
+1..2273
 

--- a/tests/SelfTest/Baselines/tap.sw.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.approved.txt
@@ -2471,15 +2471,15 @@ ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && Cont
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
-ok {test-number} - listingString, ContainsSubstring("fakeTag"s) for: "1\;[fakeTag] " contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
+ok {test-number} - listingString, ContainsSubstring("fakeTag"s) for: "[[[=[1]=];[=[[fakeTag]]=]]] " contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
-ok {test-number} - listingString, ContainsSubstring("fake reporter"s) for: "fake reporter\;fake description " contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
+ok {test-number} - listingString, ContainsSubstring("fake reporter"s) for: "[[[=[fake reporter]=];[=[fake description]=]]] " contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
-ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
+ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==[fakeTestTag]==]]=]]] " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream

--- a/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
@@ -2469,15 +2469,15 @@ ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && Cont
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
-ok {test-number} - listingString, ContainsSubstring("fakeTag"s) for: "[[[=[1]=];[=[[fakeTag]]=]]] " contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
+ok {test-number} - listingString, ContainsSubstring("fakeTag"s) for: "[[[=[1;[==[[fakeTag]]==]]=]]]" contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
-ok {test-number} - listingString, ContainsSubstring("fake reporter"s) for: "[[[=[fake reporter]=];[=[fake description]=]]] " contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
+ok {test-number} - listingString, ContainsSubstring("fake reporter"s) for: "[[[=[[==[fake reporter]==];[==[fake description]==]]=]]]" contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
-ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==[fakeTestTag]==]]=]]] " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
+ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "[[[=[[==[fake test name]==];;[==[fake-file.cpp]==];123456789;[=[[==[fakeTestTag]==]]=]]=]]]" ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream

--- a/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
@@ -2469,15 +2469,15 @@ ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && Cont
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
-ok {test-number} - listingString, ContainsSubstring("fakeTag"s) for: "1\;[fakeTag] " contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
+ok {test-number} - listingString, ContainsSubstring("fakeTag"s) for: "[[[=[1]=];[=[[fakeTag]]=]]] " contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
-ok {test-number} - listingString, ContainsSubstring("fake reporter"s) for: "fake reporter\;fake description " contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
+ok {test-number} - listingString, ContainsSubstring("fake reporter"s) for: "[[[=[fake reporter]=];[=[fake description]=]]] " contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
-ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
+ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==[fakeTestTag]==]]=]]] " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream

--- a/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
@@ -2469,6 +2469,18 @@ ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && Cont
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
 # Reporter's write listings to provided stream
+ok {test-number} - listingString, ContainsSubstring("fakeTag"s) for: "1\;[fakeTag] " contains: "fakeTag" with 1 message: 'Tested reporter: CMake'
+# Reporter's write listings to provided stream
+ok {test-number} - !(factories.empty()) for: !false
+# Reporter's write listings to provided stream
+ok {test-number} - listingString, ContainsSubstring("fake reporter"s) for: "fake reporter\;fake description " contains: "fake reporter" with 1 message: 'Tested reporter: CMake'
+# Reporter's write listings to provided stream
+ok {test-number} - !(factories.empty()) for: !false
+# Reporter's write listings to provided stream
+ok {test-number} - listingString, ContainsSubstring( "fake test name"s ) && ContainsSubstring( "fakeTestTag"s ) for: "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag " ( contains: "fake test name" and contains: "fakeTestTag" ) with 1 message: 'Tested reporter: CMake'
+# Reporter's write listings to provided stream
+ok {test-number} - !(factories.empty()) for: !false
+# Reporter's write listings to provided stream
 ok {test-number} - listingString, ContainsSubstring("fakeTag"s) for: "All available tags:    1  [fakeTag] 1 tag  " contains: "fakeTag" with 1 message: 'Tested reporter: compact'
 # Reporter's write listings to provided stream
 ok {test-number} - !(factories.empty()) for: !false
@@ -4528,5 +4540,5 @@ ok {test-number} - q3 == 23. for: 23.0 == 23.0
 ok {test-number} -
 # xmlentitycheck
 ok {test-number} -
-1..2267
+1..2273
 

--- a/tests/SelfTest/Baselines/xml.sw.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.approved.txt
@@ -11938,7 +11938,7 @@ Approx( 0.98999999999999999 )
           listingString, ContainsSubstring("fakeTag"s)
         </Original>
         <Expanded>
-          "1\;[fakeTag]
+          "[[[=[1]=];[=[[fakeTag]]=]]]
 " contains: "fakeTag"
         </Expanded>
       </Expression>
@@ -11961,7 +11961,7 @@ Approx( 0.98999999999999999 )
           listingString, ContainsSubstring("fake reporter"s)
         </Original>
         <Expanded>
-          "fake reporter\;fake description
+          "[[[=[fake reporter]=];[=[fake description]=]]]
 " contains: "fake reporter"
         </Expanded>
       </Expression>
@@ -11984,7 +11984,7 @@ Approx( 0.98999999999999999 )
           listingString, ContainsSubstring( "fake test name"s ) &amp;&amp; ContainsSubstring( "fakeTestTag"s )
         </Original>
         <Expanded>
-          "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag
+          "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==[fakeTestTag]==]]=]]]
 " ( contains: "fake test name" and contains: "fakeTestTag" )
         </Expanded>
       </Expression>

--- a/tests/SelfTest/Baselines/xml.sw.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.approved.txt
@@ -11929,6 +11929,75 @@ Approx( 0.98999999999999999 )
         !false
       </Expanded>
     </Expression>
+    <Section name="CMake reporter lists tags" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Info filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        Tested reporter: CMake
+      </Info>
+      <Expression success="true" type="REQUIRE_THAT" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          listingString, ContainsSubstring("fakeTag"s)
+        </Original>
+        <Expanded>
+          "1\;[fakeTag]
+" contains: "fakeTag"
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Original>
+        !(factories.empty())
+      </Original>
+      <Expanded>
+        !false
+      </Expanded>
+    </Expression>
+    <Section name="CMake reporter lists reporters" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Info filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        Tested reporter: CMake
+      </Info>
+      <Expression success="true" type="REQUIRE_THAT" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          listingString, ContainsSubstring("fake reporter"s)
+        </Original>
+        <Expanded>
+          "fake reporter\;fake description
+" contains: "fake reporter"
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Original>
+        !(factories.empty())
+      </Original>
+      <Expanded>
+        !false
+      </Expanded>
+    </Expression>
+    <Section name="CMake reporter lists tests" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Info filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        Tested reporter: CMake
+      </Info>
+      <Expression success="true" type="REQUIRE_THAT" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          listingString, ContainsSubstring( "fake test name"s ) &amp;&amp; ContainsSubstring( "fakeTestTag"s )
+        </Original>
+        <Expanded>
+          "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag
+" ( contains: "fake test name" and contains: "fakeTestTag" )
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Original>
+        !(factories.empty())
+      </Original>
+      <Expanded>
+        !false
+      </Expanded>
+    </Expression>
     <Section name="compact reporter lists tags" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
       <Info filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
         Tested reporter: compact
@@ -21832,6 +21901,6 @@ Approx( -1.95996398454005449 )
     </Section>
     <OverallResult success="true" skips="0"/>
   </TestCase>
-  <OverallResults successes="2074" failures="146" expectedFailures="35" skips="12"/>
+  <OverallResults successes="2080" failures="146" expectedFailures="35" skips="12"/>
   <OverallResultsCases successes="311" failures="85" expectedFailures="14" skips="6"/>
 </Catch2TestRun>

--- a/tests/SelfTest/Baselines/xml.sw.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.approved.txt
@@ -11938,8 +11938,7 @@ Approx( 0.98999999999999999 )
           listingString, ContainsSubstring("fakeTag"s)
         </Original>
         <Expanded>
-          "[[[=[1]=];[=[[fakeTag]]=]]]
-" contains: "fakeTag"
+          "[[[=[1;[==[[fakeTag]]==]]=]]]" contains: "fakeTag"
         </Expanded>
       </Expression>
       <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
@@ -11961,8 +11960,7 @@ Approx( 0.98999999999999999 )
           listingString, ContainsSubstring("fake reporter"s)
         </Original>
         <Expanded>
-          "[[[=[fake reporter]=];[=[fake description]=]]]
-" contains: "fake reporter"
+          "[[[=[[==[fake reporter]==];[==[fake description]==]]=]]]" contains: "fake reporter"
         </Expanded>
       </Expression>
       <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
@@ -11984,8 +11982,7 @@ Approx( 0.98999999999999999 )
           listingString, ContainsSubstring( "fake test name"s ) &amp;&amp; ContainsSubstring( "fakeTestTag"s )
         </Original>
         <Expanded>
-          "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==[fakeTestTag]==]]=]]]
-" ( contains: "fake test name" and contains: "fakeTestTag" )
+          "[[[=[[==[fake test name]==];;[==[fake-file.cpp]==];123456789;[=[[==[fakeTestTag]==]]=]]=]]]" ( contains: "fake test name" and contains: "fakeTestTag" )
         </Expanded>
       </Expression>
       <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>

--- a/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
@@ -11929,6 +11929,75 @@ Approx( 0.98999999999999999 )
         !false
       </Expanded>
     </Expression>
+    <Section name="CMake reporter lists tags" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Info filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        Tested reporter: CMake
+      </Info>
+      <Expression success="true" type="REQUIRE_THAT" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          listingString, ContainsSubstring("fakeTag"s)
+        </Original>
+        <Expanded>
+          "1\;[fakeTag]
+" contains: "fakeTag"
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Original>
+        !(factories.empty())
+      </Original>
+      <Expanded>
+        !false
+      </Expanded>
+    </Expression>
+    <Section name="CMake reporter lists reporters" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Info filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        Tested reporter: CMake
+      </Info>
+      <Expression success="true" type="REQUIRE_THAT" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          listingString, ContainsSubstring("fake reporter"s)
+        </Original>
+        <Expanded>
+          "fake reporter\;fake description
+" contains: "fake reporter"
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Original>
+        !(factories.empty())
+      </Original>
+      <Expanded>
+        !false
+      </Expanded>
+    </Expression>
+    <Section name="CMake reporter lists tests" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Info filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        Tested reporter: CMake
+      </Info>
+      <Expression success="true" type="REQUIRE_THAT" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          listingString, ContainsSubstring( "fake test name"s ) &amp;&amp; ContainsSubstring( "fakeTestTag"s )
+        </Original>
+        <Expanded>
+          "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag
+" ( contains: "fake test name" and contains: "fakeTestTag" )
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Expression success="true" type="REQUIRE_FALSE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Original>
+        !(factories.empty())
+      </Original>
+      <Expanded>
+        !false
+      </Expanded>
+    </Expression>
     <Section name="compact reporter lists tags" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
       <Info filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
         Tested reporter: compact
@@ -21831,6 +21900,6 @@ Approx( -1.95996398454005449 )
     </Section>
     <OverallResult success="true" skips="0"/>
   </TestCase>
-  <OverallResults successes="2074" failures="146" expectedFailures="35" skips="12"/>
+  <OverallResults successes="2080" failures="146" expectedFailures="35" skips="12"/>
   <OverallResultsCases successes="311" failures="85" expectedFailures="14" skips="6"/>
 </Catch2TestRun>

--- a/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
@@ -11938,7 +11938,7 @@ Approx( 0.98999999999999999 )
           listingString, ContainsSubstring("fakeTag"s)
         </Original>
         <Expanded>
-          "1\;[fakeTag]
+          "[[[=[1]=];[=[[fakeTag]]=]]]
 " contains: "fakeTag"
         </Expanded>
       </Expression>
@@ -11961,7 +11961,7 @@ Approx( 0.98999999999999999 )
           listingString, ContainsSubstring("fake reporter"s)
         </Original>
         <Expanded>
-          "fake reporter\;fake description
+          "[[[=[fake reporter]=];[=[fake description]=]]]
 " contains: "fake reporter"
         </Expanded>
       </Expression>
@@ -11984,7 +11984,7 @@ Approx( 0.98999999999999999 )
           listingString, ContainsSubstring( "fake test name"s ) &amp;&amp; ContainsSubstring( "fakeTestTag"s )
         </Original>
         <Expanded>
-          "fake test name/;/;fake-file.cpp\;123456789\;fakeTestTag
+          "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==[fakeTestTag]==]]=]]]
 " ( contains: "fake test name" and contains: "fakeTestTag" )
         </Expanded>
       </Expression>

--- a/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
@@ -11938,8 +11938,7 @@ Approx( 0.98999999999999999 )
           listingString, ContainsSubstring("fakeTag"s)
         </Original>
         <Expanded>
-          "[[[=[1]=];[=[[fakeTag]]=]]]
-" contains: "fakeTag"
+          "[[[=[1;[==[[fakeTag]]==]]=]]]" contains: "fakeTag"
         </Expanded>
       </Expression>
       <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
@@ -11961,8 +11960,7 @@ Approx( 0.98999999999999999 )
           listingString, ContainsSubstring("fake reporter"s)
         </Original>
         <Expanded>
-          "[[[=[fake reporter]=];[=[fake description]=]]]
-" contains: "fake reporter"
+          "[[[=[[==[fake reporter]==];[==[fake description]==]]=]]]" contains: "fake reporter"
         </Expanded>
       </Expression>
       <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
@@ -11984,8 +11982,7 @@ Approx( 0.98999999999999999 )
           listingString, ContainsSubstring( "fake test name"s ) &amp;&amp; ContainsSubstring( "fakeTestTag"s )
         </Original>
         <Expanded>
-          "[[[=[fake test name]=];[=[]=];[=[fake-file.cpp]=];[=[123456789]=];[=[[==[fakeTestTag]==]]=]]]
-" ( contains: "fake test name" and contains: "fakeTestTag" )
+          "[[[=[[==[fake test name]==];;[==[fake-file.cpp]==];123456789;[=[[==[fakeTestTag]==]]=]]=]]]" ( contains: "fake test name" and contains: "fakeTestTag" )
         </Expanded>
       </Expression>
       <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>

--- a/tests/TestScripts/DiscoverTests/register-tests.cpp
+++ b/tests/TestScripts/DiscoverTests/register-tests.cpp
@@ -8,9 +8,12 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-TEST_CASE("@Script[C:\\EPM1A]=x;\"SCALA_ZERO:\"", "[script regressions]"){}
-TEST_CASE("Some test") {}
+TEST_CASE( "@Script[C:\\EPM1A]=x;\"SCALA_ZERO:\"", "[script regressions]" ) {}
+TEST_CASE( "Some test" ) {}
 TEST_CASE( "Let's have a test case with a long name. Longer. No, even longer. "
            "Really looooooooooooong. Even longer than that. Multiple lines "
            "worth of test name. Yep, like this." ) {}
-TEST_CASE( "And now a test case with weird tags.", "[tl;dr][tl;dw][foo,bar]" ) {}
+TEST_CASE( "And now a test case with weird tags.",
+           "[tl;dr][tl;dw][foo,bar][foo$bar]" ) {}
+TEST_CASE( "And now another [==] test case with weird tags.",
+           "[tl;dr][tl;dw][foo,bar]" ) {}


### PR DESCRIPTION
Continuing where @uyha (#2690) and @LecrisUT (#2832) left off

Adds a CMake reporter to list test cases.

Test cases are reported as a CMake list of lists with list elements wrapped in long form arguments.

Here is example output from `./debug-build/tests/ctest-registration-test/tests --reporter cmake --list-tests`
```
[[[=[@Script[C:\EPM1A]=x;"SCALA_ZERO:"]=];[=[]=];[=[/home/abiddulph/Projects/Catch2/tests/TestScripts/DiscoverTests/register-tests.cpp]=];[=[11]=];[=[[==[script regressions]==]]=]]];[[[=[Some test]=];[=[]=];[=[/home/abiddulph/Projects/Catch2/tests/TestScripts/DiscoverTests/register-tests.cpp]=];[=[12]=];]];[[[=[Let's have a test case with a long name. Longer. No, even longer. Really looooooooooooong. Even longer than that. Multiple lines worth of test name. Yep, like this.]=];[=[]=];[=[/home/abiddulph/Projects/Catch2/tests/TestScripts/DiscoverTests/register-tests.cpp]=];[=[13]=];]];[[[=[And now a test case with weird tags.]=];[=[]=];[=[/home/abiddulph/Projects/Catch2/tests/TestScripts/DiscoverTests/register-tests.cpp]=];[=[16]=];[=[[==[foo,bar]==];[==[tl;dr]==];[==[tl;dw]==]]=]]]
```