### PR TITLE
Ignore all files with the name CMakeUserPresets.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ Build
 cmake-build-*
 benchmark-dir
 .conan/test_package/build
-.conan/test_package/CMakeUserPresets.json
+**/CMakeUserPresets.json
 bazel-*
 MODULE.bazel.lock
 build-fuzzers


### PR DESCRIPTION
This PR will make sure that all files with the name "CMakeUserPresets.json" are ignored. This is the recommendation of the [CMake Preset docs](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html). Before this PR, only ".conan/test_package/CMakeUserPresets.json" was ignored.

This will allow developers to specify their own presets for local development without the fear of accidentally pushing them to others.
