### PR TITLE
Adding unapproved.txt files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ msvc-sln*
 docs/doxygen
 *.cache
 compile_commands.json
+**/*.unapproved.txt


### PR DESCRIPTION
## Description

Adding .unapproved.txt files to the gitignore.  

.unapproved.txt files are generated by the acceptance tests so they should not be committed.
