### PR TITLE
Add parens around std::min and std::max to fix compilation on Windows.

### DIFF
--- a/extras/catch_amalgamated.cpp
+++ b/extras/catch_amalgamated.cpp
@@ -4208,7 +4208,7 @@ namespace Catch {
     FatalConditionHandler::FatalConditionHandler() {
         assert(!altStackMem && "Cannot initialize POSIX signal handler when one already exists");
         if (altStackSize == 0) {
-            altStackSize = std::max(static_cast<size_t>(SIGSTKSZ), minStackSizeForErrors);
+            altStackSize = (std::max)(static_cast<size_t>(SIGSTKSZ), minStackSizeForErrors);
         }
         altStackMem = new char[altStackSize]();
     }
@@ -9799,7 +9799,7 @@ namespace Catch {
 
             SummaryColumn&& addRow( std::uint64_t count ) && {
                 std::string row = std::to_string(count);
-                auto const new_width = std::max( m_width, row.size() );
+                auto const new_width = (std::max)( m_width, row.size() );
                 if ( new_width > m_width ) {
                     for ( auto& oldRow : m_rows ) {
                         oldRow.insert( 0, new_width - m_width, ' ' );

--- a/extras/catch_amalgamated.hpp
+++ b/extras/catch_amalgamated.hpp
@@ -2105,7 +2105,7 @@ namespace Catch {
             template <typename Clock>
             ExecutionPlan prepare(const IConfig &cfg, Environment env) const {
                 auto min_time = env.clock_resolution.mean * Detail::minimum_ticks;
-                auto run_time = std::max(min_time, std::chrono::duration_cast<decltype(min_time)>(cfg.benchmarkWarmupTime()));
+                auto run_time = (std::max)(min_time, std::chrono::duration_cast<decltype(min_time)>(cfg.benchmarkWarmupTime()));
                 auto&& test = Detail::run_for_at_least<Clock>(std::chrono::duration_cast<IDuration>(run_time), 1, fun);
                 int new_iters = static_cast<int>(std::ceil(min_time * test.iterations / test.elapsed));
                 return { new_iters, test.elapsed / test.iterations * new_iters * cfg.benchmarkSamples(), fun, std::chrono::duration_cast<FDuration>(cfg.benchmarkWarmupTime()), Detail::warmup_iterations };

--- a/src/catch2/benchmark/catch_benchmark.hpp
+++ b/src/catch2/benchmark/catch_benchmark.hpp
@@ -47,7 +47,7 @@ namespace Catch {
             template <typename Clock>
             ExecutionPlan prepare(const IConfig &cfg, Environment env) const {
                 auto min_time = env.clock_resolution.mean * Detail::minimum_ticks;
-                auto run_time = std::max(min_time, std::chrono::duration_cast<decltype(min_time)>(cfg.benchmarkWarmupTime()));
+                auto run_time = (std::max)(min_time, std::chrono::duration_cast<decltype(min_time)>(cfg.benchmarkWarmupTime()));
                 auto&& test = Detail::run_for_at_least<Clock>(std::chrono::duration_cast<IDuration>(run_time), 1, fun);
                 int new_iters = static_cast<int>(std::ceil(min_time * test.iterations / test.elapsed));
                 return { new_iters, test.elapsed / test.iterations * new_iters * cfg.benchmarkSamples(), fun, std::chrono::duration_cast<FDuration>(cfg.benchmarkWarmupTime()), Detail::warmup_iterations };

--- a/src/catch2/internal/catch_fatal_condition_handler.cpp
+++ b/src/catch2/internal/catch_fatal_condition_handler.cpp
@@ -203,7 +203,7 @@ namespace Catch {
     FatalConditionHandler::FatalConditionHandler() {
         assert(!altStackMem && "Cannot initialize POSIX signal handler when one already exists");
         if (altStackSize == 0) {
-            altStackSize = std::max(static_cast<size_t>(SIGSTKSZ), minStackSizeForErrors);
+            altStackSize = (std::max)(static_cast<size_t>(SIGSTKSZ), minStackSizeForErrors);
         }
         altStackMem = new char[altStackSize]();
     }

--- a/src/catch2/internal/catch_stringref.cpp
+++ b/src/catch2/internal/catch_stringref.cpp
@@ -27,7 +27,7 @@ namespace Catch {
 
     int StringRef::compare( StringRef rhs ) const {
         auto cmpResult =
-            strncmp( m_start, rhs.m_start, std::min( m_size, rhs.m_size ) );
+            strncmp( m_start, rhs.m_start, (std::min)( m_size, rhs.m_size ) );
 
         // This means that strncmp found a difference before the strings
         // ended, and we can return it directly

--- a/src/catch2/reporters/catch_reporter_helpers.cpp
+++ b/src/catch2/reporters/catch_reporter_helpers.cpp
@@ -243,7 +243,7 @@ namespace Catch {
 
             SummaryColumn&& addRow( std::uint64_t count ) && {
                 std::string row = std::to_string(count);
-                auto const new_width = std::max( m_width, row.size() );
+                auto const new_width = (std::max)( m_width, row.size() );
                 if ( new_width > m_width ) {
                     for ( auto& oldRow : m_rows ) {
                         oldRow.insert( 0, new_width - m_width, ' ' );


### PR DESCRIPTION
## Description
Compilation on Windows fails do to unparenthesized `std::min` and `std::max`.  This change adds the parentheses. 