### PR TITLE
Suppress GCC useless-cast warning from CHECK_THROWS_MATCHES

### DIFF
--- a/src/catch2/matchers/internal/catch_matchers_impl.hpp
+++ b/src/catch2/matchers/internal/catch_matchers_impl.hpp
@@ -87,7 +87,10 @@ namespace Catch {
         Catch::AssertionHandler catchAssertionHandler( macroName##_catch_sr, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(__VA_ARGS__) ", " CATCH_INTERNAL_STRINGIFY(exceptionType) ", " CATCH_INTERNAL_STRINGIFY(matcher), resultDisposition ); \
         if( catchAssertionHandler.allowThrows() ) \
             try { \
+                CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
+                CATCH_INTERNAL_SUPPRESS_USELESS_CAST_WARNINGS \
                 static_cast<void>(__VA_ARGS__ ); \
+                CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
                 catchAssertionHandler.handleUnexpectedExceptionNotThrown(); \
             } \
             catch( exceptionType const& ex ) { \


### PR DESCRIPTION
Suppress warning from GCC about useless cast in the CHECK_THROWS_MATCHES macro the same way it is already being done for the similar CHECK macros.

