### PR TITLE
Fix bug in TokenStream parser

### DIFF
--- a/src/catch2/internal/catch_clara.cpp
+++ b/src/catch2/internal/catch_clara.cpp
@@ -76,7 +76,7 @@ namespace Catch {
                                 { TokenType::Argument,
                                   next.substr( delimiterPos + 1, next.size() ) } );
                         } else {
-                            if ( next[1] != '-' && next.size() > 2 ) {
+                            if ( next.size() > 1 && next[1] != '-' && next.size() > 2 ) {
                                 // Combined short args, e.g. "-ab" for "-a -b"
                                 for ( size_t i = 1; i < next.size(); ++i ) {
                                     m_tokenBuffer.push_back(

--- a/tests/SelfTest/Baselines/automake.sw.approved.txt
+++ b/tests/SelfTest/Baselines/automake.sw.approved.txt
@@ -105,6 +105,7 @@ Nor would this
 :test-result: PASS CaseInsensitiveEqualsTo is case insensitive
 :test-result: PASS CaseInsensitiveLess is case insensitive
 :test-result: PASS Character pretty printing
+:test-result: PASS Clara::Arg does not crash on incomplete input
 :test-result: PASS Clara::Arg supports single-arg parse the way Opt does
 :test-result: PASS Clara::Opt supports accept-many lambdas
 :test-result: PASS ColourGuard behaviour

--- a/tests/SelfTest/Baselines/automake.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/automake.sw.multi.approved.txt
@@ -103,6 +103,7 @@
 :test-result: PASS CaseInsensitiveEqualsTo is case insensitive
 :test-result: PASS CaseInsensitiveLess is case insensitive
 :test-result: PASS Character pretty printing
+:test-result: PASS Clara::Arg does not crash on incomplete input
 :test-result: PASS Clara::Arg supports single-arg parse the way Opt does
 :test-result: PASS Clara::Opt supports accept-many lambdas
 :test-result: PASS ColourGuard behaviour

--- a/tests/SelfTest/Baselines/compact.sw.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.approved.txt
@@ -389,6 +389,12 @@ ToStringGeneral.tests.cpp:<line number>: passed: ::Catch::Detail::stringify( '\0
 ToStringGeneral.tests.cpp:<line number>: passed: ::Catch::Detail::stringify( static_cast<char>(2) ) == "2" for: "2" == "2"
 ToStringGeneral.tests.cpp:<line number>: passed: ::Catch::Detail::stringify( static_cast<char>(5) ) == "5" for: "5" == "5"
 Clara.tests.cpp:<line number>: passed: name.empty() for: true
+Clara.tests.cpp:<line number>: passed: result for: {?}
+Clara.tests.cpp:<line number>: passed: result.type() == Catch::Clara::Detail::ResultType::Ok for: 0 == 0
+Clara.tests.cpp:<line number>: passed: parsed.type() == Catch::Clara::ParseResultType::NoMatch for: 1 == 1
+Clara.tests.cpp:<line number>: passed: parsed.remainingTokens().count() == 2 for: 2 == 2
+Clara.tests.cpp:<line number>: passed: name.empty() for: true
+Clara.tests.cpp:<line number>: passed: name.empty() for: true
 Clara.tests.cpp:<line number>: passed: name == "foo" for: "foo" == "foo"
 Clara.tests.cpp:<line number>: passed: !(parse_result) for: !{?}
 Clara.tests.cpp:<line number>: passed: parse_result for: {?}
@@ -2844,7 +2850,7 @@ InternalBenchmark.tests.cpp:<line number>: passed: med == 18. for: 18.0 == 18.0
 InternalBenchmark.tests.cpp:<line number>: passed: q3 == 23. for: 23.0 == 23.0
 Misc.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: passed:
-test cases:  418 |  312 passed |  86 failed | 6 skipped | 14 failed as expected
-assertions: 2259 | 2077 passed | 147 failed | 35 failed as expected
+test cases:  419 |  313 passed |  86 failed | 6 skipped | 14 failed as expected
+assertions: 2265 | 2083 passed | 147 failed | 35 failed as expected
 
 

--- a/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
@@ -387,6 +387,12 @@ ToStringGeneral.tests.cpp:<line number>: passed: ::Catch::Detail::stringify( '\0
 ToStringGeneral.tests.cpp:<line number>: passed: ::Catch::Detail::stringify( static_cast<char>(2) ) == "2" for: "2" == "2"
 ToStringGeneral.tests.cpp:<line number>: passed: ::Catch::Detail::stringify( static_cast<char>(5) ) == "5" for: "5" == "5"
 Clara.tests.cpp:<line number>: passed: name.empty() for: true
+Clara.tests.cpp:<line number>: passed: result for: {?}
+Clara.tests.cpp:<line number>: passed: result.type() == Catch::Clara::Detail::ResultType::Ok for: 0 == 0
+Clara.tests.cpp:<line number>: passed: parsed.type() == Catch::Clara::ParseResultType::NoMatch for: 1 == 1
+Clara.tests.cpp:<line number>: passed: parsed.remainingTokens().count() == 2 for: 2 == 2
+Clara.tests.cpp:<line number>: passed: name.empty() for: true
+Clara.tests.cpp:<line number>: passed: name.empty() for: true
 Clara.tests.cpp:<line number>: passed: name == "foo" for: "foo" == "foo"
 Clara.tests.cpp:<line number>: passed: !(parse_result) for: !{?}
 Clara.tests.cpp:<line number>: passed: parse_result for: {?}
@@ -2833,7 +2839,7 @@ InternalBenchmark.tests.cpp:<line number>: passed: med == 18. for: 18.0 == 18.0
 InternalBenchmark.tests.cpp:<line number>: passed: q3 == 23. for: 23.0 == 23.0
 Misc.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: passed:
-test cases:  418 |  312 passed |  86 failed | 6 skipped | 14 failed as expected
-assertions: 2259 | 2077 passed | 147 failed | 35 failed as expected
+test cases:  419 |  313 passed |  86 failed | 6 skipped | 14 failed as expected
+assertions: 2265 | 2083 passed | 147 failed | 35 failed as expected
 
 

--- a/tests/SelfTest/Baselines/console.std.approved.txt
+++ b/tests/SelfTest/Baselines/console.std.approved.txt
@@ -1610,6 +1610,6 @@ due to unexpected exception with message:
   Why would you throw a std::string?
 
 ===============================================================================
-test cases:  418 |  326 passed |  71 failed | 7 skipped | 14 failed as expected
-assertions: 2242 | 2077 passed | 130 failed | 35 failed as expected
+test cases:  419 |  327 passed |  71 failed | 7 skipped | 14 failed as expected
+assertions: 2248 | 2083 passed | 130 failed | 35 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.approved.txt
@@ -3040,6 +3040,42 @@ with expansion:
   "5" == "5"
 
 -------------------------------------------------------------------------------
+Clara::Arg does not crash on incomplete input
+-------------------------------------------------------------------------------
+Clara.tests.cpp:<line number>
+...............................................................................
+
+Clara.tests.cpp:<line number>: PASSED:
+  CHECK( name.empty() )
+with expansion:
+  true
+
+Clara.tests.cpp:<line number>: PASSED:
+  CHECK( result )
+with expansion:
+  {?}
+
+Clara.tests.cpp:<line number>: PASSED:
+  CHECK( result.type() == Catch::Clara::Detail::ResultType::Ok )
+with expansion:
+  0 == 0
+
+Clara.tests.cpp:<line number>: PASSED:
+  CHECK( parsed.type() == Catch::Clara::ParseResultType::NoMatch )
+with expansion:
+  1 == 1
+
+Clara.tests.cpp:<line number>: PASSED:
+  CHECK( parsed.remainingTokens().count() == 2 )
+with expansion:
+  2 == 2
+
+Clara.tests.cpp:<line number>: PASSED:
+  CHECK( name.empty() )
+with expansion:
+  true
+
+-------------------------------------------------------------------------------
 Clara::Arg supports single-arg parse the way Opt does
 -------------------------------------------------------------------------------
 Clara.tests.cpp:<line number>
@@ -18942,6 +18978,6 @@ Misc.tests.cpp:<line number>
 Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
-test cases:  418 |  312 passed |  86 failed | 6 skipped | 14 failed as expected
-assertions: 2259 | 2077 passed | 147 failed | 35 failed as expected
+test cases:  419 |  313 passed |  86 failed | 6 skipped | 14 failed as expected
+assertions: 2265 | 2083 passed | 147 failed | 35 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.multi.approved.txt
@@ -3038,6 +3038,42 @@ with expansion:
   "5" == "5"
 
 -------------------------------------------------------------------------------
+Clara::Arg does not crash on incomplete input
+-------------------------------------------------------------------------------
+Clara.tests.cpp:<line number>
+...............................................................................
+
+Clara.tests.cpp:<line number>: PASSED:
+  CHECK( name.empty() )
+with expansion:
+  true
+
+Clara.tests.cpp:<line number>: PASSED:
+  CHECK( result )
+with expansion:
+  {?}
+
+Clara.tests.cpp:<line number>: PASSED:
+  CHECK( result.type() == Catch::Clara::Detail::ResultType::Ok )
+with expansion:
+  0 == 0
+
+Clara.tests.cpp:<line number>: PASSED:
+  CHECK( parsed.type() == Catch::Clara::ParseResultType::NoMatch )
+with expansion:
+  1 == 1
+
+Clara.tests.cpp:<line number>: PASSED:
+  CHECK( parsed.remainingTokens().count() == 2 )
+with expansion:
+  2 == 2
+
+Clara.tests.cpp:<line number>: PASSED:
+  CHECK( name.empty() )
+with expansion:
+  true
+
+-------------------------------------------------------------------------------
 Clara::Arg supports single-arg parse the way Opt does
 -------------------------------------------------------------------------------
 Clara.tests.cpp:<line number>
@@ -18931,6 +18967,6 @@ Misc.tests.cpp:<line number>
 Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
-test cases:  418 |  312 passed |  86 failed | 6 skipped | 14 failed as expected
-assertions: 2259 | 2077 passed | 147 failed | 35 failed as expected
+test cases:  419 |  313 passed |  86 failed | 6 skipped | 14 failed as expected
+assertions: 2265 | 2083 passed | 147 failed | 35 failed as expected
 

--- a/tests/SelfTest/Baselines/junit.sw.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="130" skipped="12" tests="2271" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="130" skipped="12" tests="2277" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="random-seed" value="1"/>
       <property name="filters" value="&quot;*&quot; ~[!nonportable] ~[!benchmark] ~[approvals]"/>
@@ -420,6 +420,7 @@ at Exception.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Character pretty printing/Specifically escaped" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Character pretty printing/General chars" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Character pretty printing/Low ASCII" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="Clara::Arg does not crash on incomplete input" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Clara::Arg supports single-arg parse the way Opt does" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Clara::Opt supports accept-many lambdas" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Clara::Opt supports accept-many lambdas/Parsing fails on multiple options without accept_many" time="{duration}" status="run"/>

--- a/tests/SelfTest/Baselines/junit.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.multi.approved.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="<exe-name>" errors="17" failures="130" skipped="12" tests="2271" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="130" skipped="12" tests="2277" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="random-seed" value="1"/>
       <property name="filters" value="&quot;*&quot; ~[!nonportable] ~[!benchmark] ~[approvals]"/>
@@ -419,6 +419,7 @@ at Exception.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Character pretty printing/Specifically escaped" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Character pretty printing/General chars" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Character pretty printing/Low ASCII" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="Clara::Arg does not crash on incomplete input" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Clara::Arg supports single-arg parse the way Opt does" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Clara::Opt supports accept-many lambdas" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Clara::Opt supports accept-many lambdas/Parsing fails on multiple options without accept_many" time="{duration}" status="run"/>

--- a/tests/SelfTest/Baselines/sonarqube.sw.approved.txt
+++ b/tests/SelfTest/Baselines/sonarqube.sw.approved.txt
@@ -13,6 +13,7 @@ at AssertionHandler.tests.cpp:<line number>
     </testCase>
   </file>
   <file path="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp">
+    <testCase name="Clara::Arg does not crash on incomplete input" duration="{duration}"/>
     <testCase name="Clara::Arg supports single-arg parse the way Opt does" duration="{duration}"/>
     <testCase name="Clara::Opt supports accept-many lambdas" duration="{duration}"/>
     <testCase name="Clara::Opt supports accept-many lambdas/Parsing fails on multiple options without accept_many" duration="{duration}"/>

--- a/tests/SelfTest/Baselines/sonarqube.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/sonarqube.sw.multi.approved.txt
@@ -12,6 +12,7 @@ at AssertionHandler.tests.cpp:<line number>
     </testCase>
   </file>
   <file path="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp">
+    <testCase name="Clara::Arg does not crash on incomplete input" duration="{duration}"/>
     <testCase name="Clara::Arg supports single-arg parse the way Opt does" duration="{duration}"/>
     <testCase name="Clara::Opt supports accept-many lambdas" duration="{duration}"/>
     <testCase name="Clara::Opt supports accept-many lambdas/Parsing fails on multiple options without accept_many" duration="{duration}"/>

--- a/tests/SelfTest/Baselines/tap.sw.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.approved.txt
@@ -724,6 +724,18 @@ ok {test-number} - ::Catch::Detail::stringify( '\0' ) == "0" for: "0" == "0"
 ok {test-number} - ::Catch::Detail::stringify( static_cast<char>(2) ) == "2" for: "2" == "2"
 # Character pretty printing
 ok {test-number} - ::Catch::Detail::stringify( static_cast<char>(5) ) == "5" for: "5" == "5"
+# Clara::Arg does not crash on incomplete input
+ok {test-number} - name.empty() for: true
+# Clara::Arg does not crash on incomplete input
+ok {test-number} - result for: {?}
+# Clara::Arg does not crash on incomplete input
+ok {test-number} - result.type() == Catch::Clara::Detail::ResultType::Ok for: 0 == 0
+# Clara::Arg does not crash on incomplete input
+ok {test-number} - parsed.type() == Catch::Clara::ParseResultType::NoMatch for: 1 == 1
+# Clara::Arg does not crash on incomplete input
+ok {test-number} - parsed.remainingTokens().count() == 2 for: 2 == 2
+# Clara::Arg does not crash on incomplete input
+ok {test-number} - name.empty() for: true
 # Clara::Arg supports single-arg parse the way Opt does
 ok {test-number} - name.empty() for: true
 # Clara::Arg supports single-arg parse the way Opt does
@@ -4547,5 +4559,5 @@ ok {test-number} - q3 == 23. for: 23.0 == 23.0
 ok {test-number} -
 # xmlentitycheck
 ok {test-number} -
-1..2271
+1..2277
 

--- a/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
@@ -722,6 +722,18 @@ ok {test-number} - ::Catch::Detail::stringify( '\0' ) == "0" for: "0" == "0"
 ok {test-number} - ::Catch::Detail::stringify( static_cast<char>(2) ) == "2" for: "2" == "2"
 # Character pretty printing
 ok {test-number} - ::Catch::Detail::stringify( static_cast<char>(5) ) == "5" for: "5" == "5"
+# Clara::Arg does not crash on incomplete input
+ok {test-number} - name.empty() for: true
+# Clara::Arg does not crash on incomplete input
+ok {test-number} - result for: {?}
+# Clara::Arg does not crash on incomplete input
+ok {test-number} - result.type() == Catch::Clara::Detail::ResultType::Ok for: 0 == 0
+# Clara::Arg does not crash on incomplete input
+ok {test-number} - parsed.type() == Catch::Clara::ParseResultType::NoMatch for: 1 == 1
+# Clara::Arg does not crash on incomplete input
+ok {test-number} - parsed.remainingTokens().count() == 2 for: 2 == 2
+# Clara::Arg does not crash on incomplete input
+ok {test-number} - name.empty() for: true
 # Clara::Arg supports single-arg parse the way Opt does
 ok {test-number} - name.empty() for: true
 # Clara::Arg supports single-arg parse the way Opt does
@@ -4536,5 +4548,5 @@ ok {test-number} - q3 == 23. for: 23.0 == 23.0
 ok {test-number} -
 # xmlentitycheck
 ok {test-number} -
-1..2271
+1..2277
 

--- a/tests/SelfTest/Baselines/teamcity.sw.approved.txt
+++ b/tests/SelfTest/Baselines/teamcity.sw.approved.txt
@@ -245,6 +245,8 @@
 ##teamcity[testFinished name='CaseInsensitiveLess is case insensitive' duration="{duration}"]
 ##teamcity[testStarted name='Character pretty printing']
 ##teamcity[testFinished name='Character pretty printing' duration="{duration}"]
+##teamcity[testStarted name='Clara::Arg does not crash on incomplete input']
+##teamcity[testFinished name='Clara::Arg does not crash on incomplete input' duration="{duration}"]
 ##teamcity[testStarted name='Clara::Arg supports single-arg parse the way Opt does']
 ##teamcity[testFinished name='Clara::Arg supports single-arg parse the way Opt does' duration="{duration}"]
 ##teamcity[testStarted name='Clara::Opt supports accept-many lambdas']

--- a/tests/SelfTest/Baselines/teamcity.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/teamcity.sw.multi.approved.txt
@@ -245,6 +245,8 @@
 ##teamcity[testFinished name='CaseInsensitiveLess is case insensitive' duration="{duration}"]
 ##teamcity[testStarted name='Character pretty printing']
 ##teamcity[testFinished name='Character pretty printing' duration="{duration}"]
+##teamcity[testStarted name='Clara::Arg does not crash on incomplete input']
+##teamcity[testFinished name='Clara::Arg does not crash on incomplete input' duration="{duration}"]
 ##teamcity[testStarted name='Clara::Arg supports single-arg parse the way Opt does']
 ##teamcity[testFinished name='Clara::Arg supports single-arg parse the way Opt does' duration="{duration}"]
 ##teamcity[testStarted name='Clara::Opt supports accept-many lambdas']

--- a/tests/SelfTest/Baselines/xml.sw.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.approved.txt
@@ -3304,6 +3304,57 @@ Approx( 1.23399996757507324 )
     </Section>
     <OverallResult success="true" skips="0"/>
   </TestCase>
+  <TestCase name="Clara::Arg does not crash on incomplete input" tags="[arg][clara][compilation]" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+    <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+      <Original>
+        name.empty()
+      </Original>
+      <Expanded>
+        true
+      </Expanded>
+    </Expression>
+    <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+      <Original>
+        result
+      </Original>
+      <Expanded>
+        {?}
+      </Expanded>
+    </Expression>
+    <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+      <Original>
+        result.type() == Catch::Clara::Detail::ResultType::Ok
+      </Original>
+      <Expanded>
+        0 == 0
+      </Expanded>
+    </Expression>
+    <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+      <Original>
+        parsed.type() == Catch::Clara::ParseResultType::NoMatch
+      </Original>
+      <Expanded>
+        1 == 1
+      </Expanded>
+    </Expression>
+    <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+      <Original>
+        parsed.remainingTokens().count() == 2
+      </Original>
+      <Expanded>
+        2 == 2
+      </Expanded>
+    </Expression>
+    <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+      <Original>
+        name.empty()
+      </Original>
+      <Expanded>
+        true
+      </Expanded>
+    </Expression>
+    <OverallResult success="true" skips="0"/>
+  </TestCase>
   <TestCase name="Clara::Arg supports single-arg parse the way Opt does" tags="[arg][clara][compilation]" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
     <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
       <Original>
@@ -21882,6 +21933,6 @@ Approx( -1.95996398454005449 )
     </Section>
     <OverallResult success="true" skips="0"/>
   </TestCase>
-  <OverallResults successes="2077" failures="147" expectedFailures="35" skips="12"/>
-  <OverallResultsCases successes="312" failures="86" expectedFailures="14" skips="6"/>
+  <OverallResults successes="2083" failures="147" expectedFailures="35" skips="12"/>
+  <OverallResultsCases successes="313" failures="86" expectedFailures="14" skips="6"/>
 </Catch2TestRun>

--- a/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
@@ -3304,6 +3304,57 @@ Approx( 1.23399996757507324 )
     </Section>
     <OverallResult success="true" skips="0"/>
   </TestCase>
+  <TestCase name="Clara::Arg does not crash on incomplete input" tags="[arg][clara][compilation]" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+    <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+      <Original>
+        name.empty()
+      </Original>
+      <Expanded>
+        true
+      </Expanded>
+    </Expression>
+    <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+      <Original>
+        result
+      </Original>
+      <Expanded>
+        {?}
+      </Expanded>
+    </Expression>
+    <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+      <Original>
+        result.type() == Catch::Clara::Detail::ResultType::Ok
+      </Original>
+      <Expanded>
+        0 == 0
+      </Expanded>
+    </Expression>
+    <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+      <Original>
+        parsed.type() == Catch::Clara::ParseResultType::NoMatch
+      </Original>
+      <Expanded>
+        1 == 1
+      </Expanded>
+    </Expression>
+    <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+      <Original>
+        parsed.remainingTokens().count() == 2
+      </Original>
+      <Expanded>
+        2 == 2
+      </Expanded>
+    </Expression>
+    <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
+      <Original>
+        name.empty()
+      </Original>
+      <Expanded>
+        true
+      </Expanded>
+    </Expression>
+    <OverallResult success="true" skips="0"/>
+  </TestCase>
   <TestCase name="Clara::Arg supports single-arg parse the way Opt does" tags="[arg][clara][compilation]" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
     <Expression success="true" type="CHECK" filename="tests/<exe-name>/IntrospectiveTests/Clara.tests.cpp" >
       <Original>
@@ -21881,6 +21932,6 @@ Approx( -1.95996398454005449 )
     </Section>
     <OverallResult success="true" skips="0"/>
   </TestCase>
-  <OverallResults successes="2077" failures="147" expectedFailures="35" skips="12"/>
-  <OverallResultsCases successes="312" failures="86" expectedFailures="14" skips="6"/>
+  <OverallResults successes="2083" failures="147" expectedFailures="35" skips="12"/>
+  <OverallResultsCases successes="313" failures="86" expectedFailures="14" skips="6"/>
 </Catch2TestRun>

--- a/tests/SelfTest/IntrospectiveTests/Clara.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/Clara.tests.cpp
@@ -51,6 +51,21 @@ TEST_CASE("Clara::Arg supports single-arg parse the way Opt does", "[clara][arg]
     REQUIRE(name == "foo");
 }
 
+TEST_CASE("Clara::Arg does not crash on incomplete input", "[clara][arg][compilation]") {
+    std::string name;
+    auto p = Catch::Clara::Arg(name, "-");
+
+    CHECK(name.empty());
+
+    auto result = p.parse( Catch::Clara::Args{ "UnitTest", "-" } );
+    CHECK( result );
+    CHECK( result.type() == Catch::Clara::Detail::ResultType::Ok );
+    const auto& parsed = result.value();
+    CHECK( parsed.type() == Catch::Clara::ParseResultType::NoMatch );
+    CHECK( parsed.remainingTokens().count() == 2 );
+    CHECK( name.empty() );
+}
+
 TEST_CASE("Clara::Opt supports accept-many lambdas", "[clara][opt]") {
     using namespace Catch::Clara;
     std::vector<std::string> res;


### PR DESCRIPTION
When presented with just '-' it would access the string at position [1]

I discovered this while mistyping the '-?' option, which triggered an assert in my test binary.