### PR TITLE
Add shared library support when building with meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@
 project(
   'catch2',
   'cpp',
+  default_options: ['default_library=static'],
   version: '3.7.1', # CML version placeholder, don't delete
   license: 'BSL-1.0',
   meson_version: '>=0.54.1',

--- a/src/catch2/meson.build
+++ b/src/catch2/meson.build
@@ -351,7 +351,7 @@ if ((host_machine.system() == 'android') or
   catch2_dependencies += log_dep
 endif
 
-catch2 = static_library(
+catch2 = library(
   'Catch2',
   sources,
   dependencies: catch2_dependencies,
@@ -371,7 +371,7 @@ pkg.generate(
   url: 'https://github.com/catchorg/Catch2',
 )
 
-catch2_with_main = static_library(
+catch2_with_main = library(
   'Catch2Main',
   'internal/catch_main.cpp',
   link_with: catch2,


### PR DESCRIPTION
## Description
Building shared libraries is currently not supported, when building with meson.
This PR enables building shared libraries, by passing `-Ddefault_library=shared`.
When this option is not passed, a static library is built.
