### PR TITLE
Use isatty() when using GNU libc

### DIFF
--- a/src/catch2/internal/catch_console_colour.cpp
+++ b/src/catch2/internal/catch_console_colour.cpp
@@ -161,7 +161,7 @@ namespace {
 #endif // Windows/ ANSI/ None
 
 
-#if defined( CATCH_PLATFORM_LINUX ) || defined( CATCH_PLATFORM_MAC )
+#if defined( CATCH_PLATFORM_LINUX ) || defined( CATCH_PLATFORM_MAC ) || defined( __GLIBC__ )
 #    define CATCH_INTERNAL_HAS_ISATTY
 #    include <unistd.h>
 #endif


### PR DESCRIPTION
## Description

While `isatty()` is a POSIX interface and theoretically could be used more broadly than on Linux and macOS, use a conservative approach and use it on any platform that uses GNU libc.

This fixes `#1670 regression check` on GNU/Hurd (which uses GNU libc).