### PR TITLE
Fix using from_range with std::vector<>::const_iterator

### DIFF
--- a/src/catch2/generators/catch_generators_range.hpp
+++ b/src/catch2/generators/catch_generators_range.hpp
@@ -91,7 +91,7 @@ public:
 
 template <typename InputIterator,
           typename InputSentinel,
-          typename ResultType = typename std::iterator_traits<InputIterator>::value_type>
+          typename ResultType = std::remove_const_t<typename std::iterator_traits<InputIterator>::value_type>>
 GeneratorWrapper<ResultType> from_range(InputIterator from, InputSentinel to) {
     return GeneratorWrapper<ResultType>(Catch::Detail::make_unique<IteratorGenerator<ResultType>>(from, to));
 }


### PR DESCRIPTION
This pull request addresses a compile error occurring when attempting to instantiate `std::vector` with a constant value type.

The issue arose in `catch_generators_range.hpp`, where `ResultType` was defined as a `value_type` of `const_iterator` within `GeneratorWrapper<ResultType>` which is usually `const`. This caused a conflict with `std::vector`, which requires its `value_type` to be non-const.