### PR TITLE
Silence -Weffc++ compiler warnings from gcc 11.4

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,6 +188,7 @@ set(IMPL_SOURCES
   ${SOURCES_DIR}/internal/catch_leak_detector.cpp
   ${SOURCES_DIR}/internal/catch_list.cpp
   ${SOURCES_DIR}/internal/catch_message_info.cpp
+  ${SOURCES_DIR}/internal/catch_noncopyable.cpp
   ${SOURCES_DIR}/internal/catch_output_redirect.cpp
   ${SOURCES_DIR}/internal/catch_parse_numbers.cpp
   ${SOURCES_DIR}/internal/catch_polyfills.cpp

--- a/src/catch2/catch_assertion_result.hpp
+++ b/src/catch2/catch_assertion_result.hpp
@@ -24,8 +24,8 @@ namespace Catch {
 
         AssertionResultData( ResultWas::OfType _resultType, LazyExpression const& _lazyExpression );
 
-        std::string message;
-        mutable std::string reconstructedExpression;
+        std::string message {};
+        mutable std::string reconstructedExpression {};
         LazyExpression lazyExpression;
         ResultWas::OfType resultType;
 

--- a/src/catch2/catch_config.hpp
+++ b/src/catch2/catch_config.hpp
@@ -80,13 +80,13 @@ namespace Catch {
         ColourMode defaultColourMode = ColourMode::PlatformDefault;
         WaitForKeypress::When waitForKeypress = WaitForKeypress::Never;
 
-        std::string defaultOutputFilename;
-        std::string name;
-        std::string processName;
-        std::vector<ReporterSpec> reporterSpecifications;
+        std::string defaultOutputFilename {};
+        std::string name {};
+        std::string processName {};
+        std::vector<ReporterSpec> reporterSpecifications {};
 
-        std::vector<std::string> testsOrTags;
-        std::vector<std::string> sectionsToRun;
+        std::vector<std::string> testsOrTags {};
+        std::vector<std::string> sectionsToRun {};
     };
 
 
@@ -144,8 +144,8 @@ namespace Catch {
         void readBazelEnvVars();
 
         ConfigData m_data;
-        std::vector<ProcessedReporterSpec> m_processedReporterSpecs;
-        TestSpec m_testSpec;
+        std::vector<ProcessedReporterSpec> m_processedReporterSpecs {};
+        TestSpec m_testSpec {};
         bool m_hasTestFilters = false;
     };
 } // end namespace Catch

--- a/src/catch2/catch_message.hpp
+++ b/src/catch2/catch_message.hpp
@@ -32,7 +32,7 @@ namespace Catch {
             return *this;
         }
 
-        ReusableStringStream m_stream;
+        ReusableStringStream m_stream {};
     };
 
     struct MessageBuilder : MessageStream {
@@ -62,7 +62,7 @@ namespace Catch {
     };
 
     class Capturer {
-        std::vector<MessageInfo> m_messages;
+        std::vector<MessageInfo> m_messages {};
         IResultCapture& m_resultCapture;
         size_t m_captured = 0;
     public:

--- a/src/catch2/catch_registry_hub.cpp
+++ b/src/catch2/catch_registry_hub.cpp
@@ -77,12 +77,12 @@ namespace Catch {
             }
 
         private:
-            TestRegistry m_testCaseRegistry;
-            ReporterRegistry m_reporterRegistry;
-            ExceptionTranslatorRegistry m_exceptionTranslatorRegistry;
-            TagAliasRegistry m_tagAliasRegistry;
-            StartupExceptionRegistry m_exceptionRegistry;
-            Detail::EnumValuesRegistry m_enumValuesRegistry;
+            TestRegistry m_testCaseRegistry {};
+            ReporterRegistry m_reporterRegistry {};
+            ExceptionTranslatorRegistry m_exceptionTranslatorRegistry {};
+            TagAliasRegistry m_tagAliasRegistry {};
+            StartupExceptionRegistry m_exceptionRegistry {};
+            Detail::EnumValuesRegistry m_enumValuesRegistry {};
         };
     }
 

--- a/src/catch2/catch_session.cpp
+++ b/src/catch2/catch_session.cpp
@@ -109,6 +109,8 @@ namespace Catch {
 
                 m_tests = createShard(m_tests, m_config->shardCount(), m_config->shardIndex());
             }
+            TestGroup( TestGroup const& ) = delete;
+            TestGroup& operator=( TestGroup const& ) = delete;
 
             Totals execute() {
                 Totals totals;
@@ -138,8 +140,8 @@ namespace Catch {
             IEventListener* m_reporter;
             Config const* m_config;
             RunContext m_context;
-            std::set<TestCaseHandle const*> m_tests;
-            TestSpec::Matches m_matches;
+            std::set<TestCaseHandle const*> m_tests {};
+            TestSpec::Matches m_matches {};
             bool m_unmatchedTestSpecs = false;
         };
 

--- a/src/catch2/catch_session.hpp
+++ b/src/catch2/catch_session.hpp
@@ -20,7 +20,7 @@ namespace Catch {
     public:
 
         Session();
-        ~Session();
+        ~Session() override;
 
         void showHelp() const;
         void libIdentify();
@@ -51,9 +51,9 @@ namespace Catch {
     private:
         int runInternal();
 
-        Clara::Parser m_cli;
-        ConfigData m_configData;
-        Detail::unique_ptr<Config> m_config;
+        Clara::Parser m_cli {};
+        ConfigData m_configData {};
+        Detail::unique_ptr<Config> m_config {};
         bool m_startupExceptions = false;
     };
 

--- a/src/catch2/catch_test_case_info.hpp
+++ b/src/catch2/catch_test_case_info.hpp
@@ -89,12 +89,12 @@ namespace Catch {
         std::string name;
         StringRef className;
     private:
-        std::string backingTags;
+        std::string backingTags {};
         // Internally we copy tags to the backing storage and then add
         // refs to this storage to the tags vector.
         void internalAppendTag(StringRef tagString);
     public:
-        std::vector<Tag> tags;
+        std::vector<Tag> tags {};
         SourceLineInfo lineInfo;
         TestCaseProperties properties = TestCaseProperties::None;
     };

--- a/src/catch2/catch_test_spec.hpp
+++ b/src/catch2/catch_test_spec.hpp
@@ -67,8 +67,8 @@ namespace Catch {
         };
 
         struct Filter {
-            std::vector<Detail::unique_ptr<Pattern>> m_required;
-            std::vector<Detail::unique_ptr<Pattern>> m_forbidden;
+            std::vector<Detail::unique_ptr<Pattern>> m_required {};
+            std::vector<Detail::unique_ptr<Pattern>> m_forbidden {};
 
             //! Serializes this filter into a string that would be parsed into
             //! an equivalent filter
@@ -97,8 +97,8 @@ namespace Catch {
         const vectorStrings & getInvalidSpecs() const;
 
     private:
-        std::vector<Filter> m_filters;
-        std::vector<std::string> m_invalidSpecs;
+        std::vector<Filter> m_filters {};
+        std::vector<std::string> m_invalidSpecs {};
 
         friend class TestSpecParser;
         //! Serializes this test spec into a string that would be parsed into

--- a/src/catch2/catch_totals.hpp
+++ b/src/catch2/catch_totals.hpp
@@ -33,8 +33,8 @@ namespace Catch {
 
         Totals delta( Totals const& prevTotals ) const;
 
-        Counts assertions;
-        Counts testCases;
+        Counts assertions {};
+        Counts testCases {};
     };
 }
 

--- a/src/catch2/generators/catch_generator_exception.cpp
+++ b/src/catch2/generators/catch_generator_exception.cpp
@@ -10,6 +10,10 @@
 
 namespace Catch {
 
+    GeneratorException::GeneratorException( GeneratorException const& other):
+        m_msg(other.m_msg)
+    {}
+
     const char* GeneratorException::what() const noexcept {
         return m_msg;
     }

--- a/src/catch2/generators/catch_generator_exception.hpp
+++ b/src/catch2/generators/catch_generator_exception.hpp
@@ -22,6 +22,8 @@ namespace Catch {
         GeneratorException(const char* msg):
             m_msg(msg)
         {}
+        GeneratorException( GeneratorException const& other );
+        GeneratorException& operator=( GeneratorException const& ) = delete;
 
         const char* what() const noexcept override final;
     };

--- a/src/catch2/generators/catch_generators_random.hpp
+++ b/src/catch2/generators/catch_generators_random.hpp
@@ -50,7 +50,7 @@ class RandomFloatingGenerator<long double> final : public IGenerator<long double
     // want to drag it into the header.
     struct PImpl;
     Catch::Detail::unique_ptr<PImpl> m_pimpl;
-    long double m_current_number;
+    long double m_current_number {};
 
 public:
     RandomFloatingGenerator( long double a, long double b, std::uint32_t seed );

--- a/src/catch2/interfaces/catch_interfaces_enum_values_registry.hpp
+++ b/src/catch2/interfaces/catch_interfaces_enum_values_registry.hpp
@@ -16,8 +16,8 @@ namespace Catch {
 
     namespace Detail {
         struct EnumInfo {
-            StringRef m_name;
-            std::vector<std::pair<int, StringRef>> m_values;
+            StringRef m_name {};
+            std::vector<std::pair<int, StringRef>> m_values {};
 
             ~EnumInfo();
 
@@ -27,7 +27,7 @@ namespace Catch {
 
     class IMutableEnumValuesRegistry {
     public:
-        virtual ~IMutableEnumValuesRegistry(); // = default;
+        virtual ~IMutableEnumValuesRegistry();
 
         virtual Detail::EnumInfo const& registerEnum( StringRef enumName, StringRef allEnums, std::vector<int> const& values ) = 0;
 

--- a/src/catch2/interfaces/catch_interfaces_generatortracker.hpp
+++ b/src/catch2/interfaces/catch_interfaces_generatortracker.hpp
@@ -19,7 +19,7 @@ namespace Catch {
         class GeneratorUntypedBase {
             // Caches result from `toStringImpl`, assume that when it is an
             // empty string, the cache is invalidated.
-            mutable std::string m_stringReprCache;
+            mutable std::string m_stringReprCache {};
 
             // Counts based on `next` returning true
             std::size_t m_currentElementIndex = 0;
@@ -42,7 +42,7 @@ namespace Catch {
             GeneratorUntypedBase(GeneratorUntypedBase const&) = default;
             GeneratorUntypedBase& operator=(GeneratorUntypedBase const&) = default;
 
-            virtual ~GeneratorUntypedBase(); // = default;
+            virtual ~GeneratorUntypedBase();
 
             /**
              * Attempts to move the generator to the next element
@@ -79,7 +79,7 @@ namespace Catch {
 
     class IGeneratorTracker {
     public:
-        virtual ~IGeneratorTracker(); // = default;
+        virtual ~IGeneratorTracker();
         virtual auto hasGenerator() const -> bool = 0;
         virtual auto getGenerator() const -> Generators::GeneratorBasePtr const& = 0;
         virtual void setGenerator( Generators::GeneratorBasePtr&& generator ) = 0;

--- a/src/catch2/interfaces/catch_interfaces_reporter.hpp
+++ b/src/catch2/interfaces/catch_interfaces_reporter.hpp
@@ -40,7 +40,9 @@ namespace Catch {
                         std::map<std::string, std::string> customOptions );
 
         ReporterConfig( ReporterConfig&& ) = default;
+        ReporterConfig( ReporterConfig const& ) = delete;
         ReporterConfig& operator=( ReporterConfig&& ) = default;
+        ReporterConfig& operator=( ReporterConfig const& ) = delete;
         ~ReporterConfig(); // = default
 
         Detail::unique_ptr<IStream> takeStream() &&;
@@ -75,6 +77,8 @@ namespace Catch {
                         Counts const& _assertions,
                         double _durationInSeconds,
                         bool _missingAssertions );
+        SectionStats( SectionStats const& ) = default;
+        SectionStats& operator=( SectionStats const& ) = default;
 
         SectionInfo sectionInfo;
         Counts assertions;
@@ -88,6 +92,8 @@ namespace Catch {
                         std::string&& _stdOut,
                         std::string&& _stdErr,
                         bool _aborting );
+        TestCaseStats( TestCaseStats const& ) = default;
+        TestCaseStats& operator=( TestCaseStats const& ) = default;
 
         TestCaseInfo const * testInfo;
         Totals totals;
@@ -100,6 +106,8 @@ namespace Catch {
         TestRunStats(   TestRunInfo const& _runInfo,
                         Totals const& _totals,
                         bool _aborting );
+        TestRunStats( TestRunStats const& ) = default;
+        TestRunStats& operator=( TestRunStats const& ) = default;
 
         TestRunInfo runInfo;
         Totals totals;
@@ -133,12 +141,14 @@ namespace Catch {
     class IEventListener {
     protected:
         //! Derived classes can set up their preferences here
-        ReporterPreferences m_preferences;
+        ReporterPreferences m_preferences {};
         //! The test run's config as filled in from CLI and defaults
         IConfig const* m_config;
 
     public:
         IEventListener( IConfig const* config ): m_config( config ) {}
+        IEventListener( IEventListener const& ) = delete;
+        IEventListener& operator=( IEventListener const& ) = delete;
 
         virtual ~IEventListener(); // = default;
 

--- a/src/catch2/internal/catch_assertion_handler.hpp
+++ b/src/catch2/internal/catch_assertion_handler.hpp
@@ -24,7 +24,7 @@ namespace Catch {
 
     class AssertionHandler {
         AssertionInfo m_assertionInfo;
-        AssertionReaction m_reaction;
+        AssertionReaction m_reaction {};
         bool m_completed = false;
         IResultCapture& m_resultCapture;
 

--- a/src/catch2/internal/catch_clara.hpp
+++ b/src/catch2/internal/catch_clara.hpp
@@ -111,7 +111,7 @@ namespace Catch {
                 using Iterator = std::vector<StringRef>::const_iterator;
                 Iterator it;
                 Iterator itEnd;
-                std::vector<Token> m_tokenBuffer;
+                std::vector<Token> m_tokenBuffer {};
                 void loadBuffer();
 
             public:
@@ -275,7 +275,7 @@ namespace Catch {
                 }
 
                 std::string
-                    m_errorMessage; // Only populated if resultType is an error
+                    m_errorMessage {}; // Only populated if resultType is an error
 
                 BasicResult( ResultType type,
                              std::string&& message ):
@@ -491,8 +491,8 @@ namespace Catch {
             protected:
                 Optionality m_optionality = Optionality::Optional;
                 std::shared_ptr<BoundRef> m_ref;
-                StringRef m_hint;
-                StringRef m_description;
+                StringRef m_hint {};
+                StringRef m_description {};
 
                 explicit ParserRefImpl( std::shared_ptr<BoundRef> const& ref ):
                     m_ref( ref ) {}
@@ -569,7 +569,7 @@ namespace Catch {
         // A parser for options
         class Opt : public Detail::ParserRefImpl<Opt> {
         protected:
-            std::vector<StringRef> m_optNames;
+            std::vector<StringRef> m_optNames {};
 
         public:
             template <typename LambdaT>
@@ -620,7 +620,7 @@ namespace Catch {
         // Specifies the name of the executable
         class ExeName : public Detail::ComposableParserImpl<ExeName> {
             std::shared_ptr<std::string> m_name;
-            std::shared_ptr<Detail::BoundValueRefBase> m_ref;
+            std::shared_ptr<Detail::BoundValueRefBase> m_ref {};
 
         public:
             ExeName();
@@ -644,9 +644,9 @@ namespace Catch {
 
         // A Combined parser
         class Parser : Detail::ParserBase {
-            mutable ExeName m_exeName;
-            std::vector<Opt> m_options;
-            std::vector<Arg> m_args;
+            mutable ExeName m_exeName {};
+            std::vector<Opt> m_options {};
+            std::vector<Arg> m_args {};
 
         public:
 

--- a/src/catch2/internal/catch_console_colour.hpp
+++ b/src/catch2/internal/catch_console_colour.hpp
@@ -63,6 +63,8 @@ namespace Catch {
         IStream* m_stream;
     public:
         ColourImpl( IStream* stream ): m_stream( stream ) {}
+        ColourImpl( ColourImpl const& ) = delete;
+        ColourImpl& operator=( ColourImpl const& ) = delete;
 
         //! RAII wrapper around writing specific colour of text using specific
         //! colour impl into a stream.

--- a/src/catch2/internal/catch_decomposer.hpp
+++ b/src/catch2/internal/catch_decomposer.hpp
@@ -115,6 +115,7 @@
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wsign-compare"
 #  pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#  pragma GCC diagnostic ignored "-Weffc++"
 #endif
 
 #if defined(CATCH_CPP20_OR_GREATER) && __has_include(<compare>)

--- a/src/catch2/internal/catch_enum_values_registry.hpp
+++ b/src/catch2/internal/catch_enum_values_registry.hpp
@@ -22,7 +22,7 @@ namespace Catch {
 
         class EnumValuesRegistry : public IMutableEnumValuesRegistry {
 
-            std::vector<Catch::Detail::unique_ptr<EnumInfo>> m_enumInfos;
+            std::vector<Catch::Detail::unique_ptr<EnumInfo>> m_enumInfos {};
 
             EnumInfo const& registerEnum( StringRef enumName, StringRef allValueNames, std::vector<int> const& values) override;
         };

--- a/src/catch2/internal/catch_exception_translator_registry.hpp
+++ b/src/catch2/internal/catch_exception_translator_registry.hpp
@@ -23,7 +23,7 @@ namespace Catch {
         std::string translateActiveException() const override;
 
     private:
-        ExceptionTranslators m_translators;
+        ExceptionTranslators m_translators {};
     };
 }
 

--- a/src/catch2/internal/catch_fatal_condition_handler.hpp
+++ b/src/catch2/internal/catch_fatal_condition_handler.hpp
@@ -56,6 +56,8 @@ namespace Catch {
             m_handler(handler) {
             m_handler->engage();
         }
+        FatalConditionHandlerGuard( FatalConditionHandlerGuard const& ) = delete;
+        FatalConditionHandlerGuard& operator=( FatalConditionHandlerGuard const& ) = delete;
         ~FatalConditionHandlerGuard() {
             m_handler->disengage();
         }

--- a/src/catch2/internal/catch_istream.cpp
+++ b/src/catch2/internal/catch_istream.cpp
@@ -26,7 +26,7 @@ namespace Detail {
         template<typename WriterF, std::size_t bufferSize=256>
         class StreamBufImpl final : public std::streambuf {
             char data[bufferSize];
-            WriterF m_writer;
+            WriterF m_writer {};
 
         public:
             StreamBufImpl() {
@@ -73,7 +73,7 @@ namespace Detail {
         ///////////////////////////////////////////////////////////////////////////
 
         class FileStream final : public IStream {
-            std::ofstream m_ofs;
+            std::ofstream m_ofs {};
         public:
             FileStream( std::string const& filename ) {
                 m_ofs.open( filename.c_str() );

--- a/src/catch2/internal/catch_jsonwriter.hpp
+++ b/src/catch2/internal/catch_jsonwriter.hpp
@@ -56,7 +56,7 @@ namespace Catch {
         }
 
         std::ostream& m_os;
-        std::stringstream m_sstream;
+        std::stringstream m_sstream {};
         std::uint64_t m_indent_level;
     };
 

--- a/src/catch2/internal/catch_list.hpp
+++ b/src/catch2/internal/catch_list.hpp
@@ -21,7 +21,8 @@ namespace Catch {
 
 
     struct ReporterDescription {
-        std::string name, description;
+        std::string description;
+        std::string name;
     };
     struct ListenerDescription {
         StringRef name;
@@ -32,7 +33,7 @@ namespace Catch {
         void add(StringRef spelling);
         std::string all() const;
 
-        std::set<StringRef> spellings;
+        std::set<StringRef> spellings {};
         std::size_t count = 0;
     };
 

--- a/src/catch2/internal/catch_message_info.hpp
+++ b/src/catch2/internal/catch_message_info.hpp
@@ -22,7 +22,7 @@ namespace Catch {
                         ResultWas::OfType _type );
 
         StringRef macroName;
-        std::string message;
+        std::string message {};
         SourceLineInfo lineInfo;
         ResultWas::OfType type;
         unsigned int sequence;

--- a/src/catch2/internal/catch_noncopyable.cpp
+++ b/src/catch2/internal/catch_noncopyable.cpp
@@ -1,0 +1,16 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+#include <catch2/internal/catch_noncopyable.hpp>
+
+namespace Catch {
+    namespace Detail {
+        NonCopyable::~NonCopyable() noexcept {}
+    } // namespace Detail
+} // namespace Catch
+

--- a/src/catch2/internal/catch_noncopyable.hpp
+++ b/src/catch2/internal/catch_noncopyable.hpp
@@ -13,6 +13,7 @@ namespace Catch {
 
         //! Deriving classes become noncopyable and nonmovable
         class NonCopyable {
+        public:
             NonCopyable( NonCopyable const& ) = delete;
             NonCopyable( NonCopyable&& ) = delete;
             NonCopyable& operator=( NonCopyable const& ) = delete;
@@ -20,6 +21,8 @@ namespace Catch {
 
         protected:
             NonCopyable() noexcept = default;
+        public:
+            virtual ~NonCopyable() noexcept;
         };
 
     } // namespace Detail

--- a/src/catch2/internal/catch_output_redirect.cpp
+++ b/src/catch2/internal/catch_output_redirect.cpp
@@ -12,9 +12,6 @@
 #include <catch2/internal/catch_reusable_string_stream.hpp>
 #include <catch2/internal/catch_stdstreams.hpp>
 
-#include <cstdio>
-#include <cstring>
-#include <iosfwd>
 #include <sstream>
 
 #if defined( CATCH_CONFIG_NEW_CAPTURE )
@@ -71,7 +68,8 @@ namespace Catch {
          * but does not touch the actual `stdout`/`stderr` file descriptors.
          */
         class StreamRedirect : public OutputRedirect {
-            ReusableStringStream m_redirectedOut, m_redirectedErr;
+            ReusableStringStream m_redirectedOut {};
+            ReusableStringStream m_redirectedErr {};
             RedirectedStreamNew m_cout, m_cerr, m_clog;
 
         public:

--- a/src/catch2/internal/catch_random_number_generator.hpp
+++ b/src/catch2/internal/catch_random_number_generator.hpp
@@ -46,7 +46,7 @@ namespace Catch {
         // In practice we do not use them, so we will skip them for now
 
 
-        std::uint64_t m_state;
+        std::uint64_t m_state {};
         // This part of the state determines which "stream" of the numbers
         // is chosen -- we take it as a constant for Catch2, so we only
         // need to deal with seeding the main state.

--- a/src/catch2/internal/catch_reporter_registry.cpp
+++ b/src/catch2/internal/catch_reporter_registry.cpp
@@ -23,9 +23,9 @@
 
 namespace Catch {
     struct ReporterRegistry::ReporterRegistryImpl {
-        std::vector<Detail::unique_ptr<EventListenerFactory>> listeners;
+        std::vector<Detail::unique_ptr<EventListenerFactory>> listeners {};
         std::map<std::string, IReporterFactoryPtr, Detail::CaseInsensitiveLess>
-            factories;
+            factories {};
     };
 
     ReporterRegistry::ReporterRegistry():

--- a/src/catch2/internal/catch_reusable_string_stream.cpp
+++ b/src/catch2/internal/catch_reusable_string_stream.cpp
@@ -9,7 +9,6 @@
 #include <catch2/internal/catch_singletons.hpp>
 #include <catch2/internal/catch_unique_ptr.hpp>
 
-#include <cstdio>
 #include <sstream>
 #include <vector>
 
@@ -17,9 +16,9 @@ namespace Catch {
 
     // This class encapsulates the idea of a pool of ostringstreams that can be reused.
     struct StringStreams {
-        std::vector<Detail::unique_ptr<std::ostringstream>> m_streams;
-        std::vector<std::size_t> m_unused;
-        std::ostringstream m_referenceStream; // Used for copy state/ flags from
+        std::vector<Detail::unique_ptr<std::ostringstream>> m_streams {};
+        std::vector<std::size_t> m_unused {};
+        std::ostringstream m_referenceStream {}; // Used for copy state/ flags from
 
         auto add() -> std::size_t {
             if( m_unused.empty() ) {

--- a/src/catch2/internal/catch_reusable_string_stream.hpp
+++ b/src/catch2/internal/catch_reusable_string_stream.hpp
@@ -17,12 +17,14 @@
 
 namespace Catch {
 
-    class ReusableStringStream : Detail::NonCopyable {
+    class ReusableStringStream : public Detail::NonCopyable {
         std::size_t m_index;
         std::ostream* m_oss;
     public:
         ReusableStringStream();
-        ~ReusableStringStream();
+        ~ReusableStringStream() override;
+        ReusableStringStream( ReusableStringStream const& ) = delete;
+        ReusableStringStream& operator=( ReusableStringStream const& ) = delete;
 
         //! Returns the serialized state
         std::string str() const;

--- a/src/catch2/internal/catch_run_context.cpp
+++ b/src/catch2/internal/catch_run_context.cpp
@@ -31,7 +31,7 @@ namespace Catch {
         namespace {
             struct GeneratorTracker final : TestCaseTracking::TrackerBase,
                                       IGeneratorTracker {
-                GeneratorBasePtr m_generator;
+                GeneratorBasePtr m_generator {};
 
                 GeneratorTracker(
                     TestCaseTracking::NameAndLocation&& nameAndLocation,

--- a/src/catch2/internal/catch_run_context.hpp
+++ b/src/catch2/internal/catch_run_context.hpp
@@ -138,19 +138,19 @@ namespace Catch {
         TestRunInfo m_runInfo;
         TestCaseHandle const* m_activeTestCase = nullptr;
         ITracker* m_testCaseTracker = nullptr;
-        Optional<AssertionResult> m_lastResult;
+        Optional<AssertionResult> m_lastResult {};
 
         IConfig const* m_config;
-        Totals m_totals;
+        Totals m_totals {};
         IEventListenerPtr m_reporter;
-        std::vector<MessageInfo> m_messages;
-        std::vector<ScopedMessage> m_messageScopes; /* Keeps owners of so-called unscoped messages. */
+        std::vector<MessageInfo> m_messages {};
+        std::vector<ScopedMessage> m_messageScopes {}; /* Keeps owners of so-called unscoped messages. */
         AssertionInfo m_lastAssertionInfo;
-        std::vector<SectionEndInfo> m_unfinishedSections;
-        std::vector<ITracker*> m_activeSections;
-        TrackerContext m_trackerContext;
+        std::vector<SectionEndInfo> m_unfinishedSections {};
+        std::vector<ITracker*> m_activeSections {};
+        TrackerContext m_trackerContext {};
         Detail::unique_ptr<OutputRedirect> m_outputRedirect;
-        FatalConditionHandler m_fatalConditionhandler;
+        FatalConditionHandler m_fatalConditionhandler {};
         bool m_lastAssertionPassed = false;
         bool m_shouldReportUnexpected = true;
         bool m_includeSuccessfulResults;

--- a/src/catch2/internal/catch_section.hpp
+++ b/src/catch2/internal/catch_section.hpp
@@ -24,7 +24,7 @@ namespace Catch {
         Section( SourceLineInfo const& _lineInfo,
                  StringRef _name,
                  const char* const = nullptr );
-        ~Section();
+        ~Section() override;
 
         // This indicates whether the section should be executed or not
         explicit operator bool() const;
@@ -32,9 +32,9 @@ namespace Catch {
     private:
         SectionInfo m_info;
 
-        Counts m_assertions;
+        Counts m_assertions {};
         bool m_sectionIncluded;
-        Timer m_timer;
+        Timer m_timer {};
     };
 
 } // end namespace Catch

--- a/src/catch2/internal/catch_startup_exception_registry.hpp
+++ b/src/catch2/internal/catch_startup_exception_registry.hpp
@@ -20,7 +20,7 @@ namespace Catch {
         void add(std::exception_ptr const& exception) noexcept;
         std::vector<std::exception_ptr> const& getExceptions() const noexcept;
     private:
-        std::vector<std::exception_ptr> m_exceptions;
+        std::vector<std::exception_ptr> m_exceptions {};
 #endif
     };
 

--- a/src/catch2/internal/catch_stream_end_stop.hpp
+++ b/src/catch2/internal/catch_stream_end_stop.hpp
@@ -19,10 +19,17 @@ namespace Catch {
     struct StreamEndStop {
         constexpr StringRef operator+() const { return StringRef(); }
 
+#if defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Weffc++"
+#endif
         template <typename T>
         constexpr friend T const& operator+( T const& value, StreamEndStop ) {
             return value;
         }
+#if defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
     };
 
 } // namespace Catch

--- a/src/catch2/internal/catch_tag_alias_registry.hpp
+++ b/src/catch2/internal/catch_tag_alias_registry.hpp
@@ -25,7 +25,7 @@ namespace Catch {
         void add( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo );
 
     private:
-        std::map<std::string, TagAlias> m_registry;
+        std::map<std::string, TagAlias> m_registry {};
     };
 
 } // end namespace Catch

--- a/src/catch2/internal/catch_test_case_registry_impl.hpp
+++ b/src/catch2/internal/catch_test_case_registry_impl.hpp
@@ -39,15 +39,15 @@ namespace Catch {
         ~TestRegistry() override; // = default
 
     private:
-        std::vector<Detail::unique_ptr<TestCaseInfo>> m_owned_test_infos;
+        std::vector<Detail::unique_ptr<TestCaseInfo>> m_owned_test_infos {};
         // Keeps a materialized vector for `getAllInfos`.
         // We should get rid of that eventually (see interface note)
-        std::vector<TestCaseInfo*> m_viewed_test_infos;
+        std::vector<TestCaseInfo*> m_viewed_test_infos {};
 
-        std::vector<Detail::unique_ptr<ITestInvoker>> m_invokers;
-        std::vector<TestCaseHandle> m_handles;
+        std::vector<Detail::unique_ptr<ITestInvoker>> m_invokers {};
+        std::vector<TestCaseHandle> m_handles {};
         mutable TestRunOrder m_currentSortOrder = TestRunOrder::Declared;
-        mutable std::vector<TestCaseHandle> m_sortedFunctions;
+        mutable std::vector<TestCaseHandle> m_sortedFunctions {};
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/catch2/internal/catch_test_case_tracker.hpp
+++ b/src/catch2/internal/catch_test_case_tracker.hpp
@@ -88,7 +88,7 @@ namespace TestCaseTracking {
         };
 
         ITracker* m_parent = nullptr;
-        Children m_children;
+        Children m_children {};
         CycleState m_runState = NotStarted;
 
     public:
@@ -96,6 +96,8 @@ namespace TestCaseTracking {
             m_nameAndLocation( CATCH_MOVE(nameAndLoc) ),
             m_parent( parent )
         {}
+        ITracker( ITracker const& ) = delete;
+        ITracker& operator=( ITracker const& ) = delete;
 
 
         // static queries
@@ -168,7 +170,7 @@ namespace TestCaseTracking {
             CompletedCycle
         };
 
-        ITrackerPtr m_rootTracker;
+        ITrackerPtr m_rootTracker {};
         ITracker* m_currentTracker = nullptr;
         RunState m_runState = NotStarted;
 
@@ -208,7 +210,7 @@ namespace TestCaseTracking {
     };
 
     class SectionTracker : public TrackerBase {
-        std::vector<StringRef> m_filters;
+        std::vector<StringRef> m_filters {};
         // Note that lifetime-wise we piggy back off the name stored in the `ITracker` parent`.
         // Currently it allocates owns the name, so this is safe. If it is later refactored
         // to not own the name, the name still has to outlive the `ITracker` parent, so

--- a/src/catch2/internal/catch_test_spec_parser.hpp
+++ b/src/catch2/internal/catch_test_spec_parser.hpp
@@ -29,16 +29,18 @@ namespace Catch {
         bool m_exclusion = false;
         std::size_t m_pos = 0;
         std::size_t m_realPatternPos = 0;
-        std::string m_arg;
-        std::string m_substring;
-        std::string m_patternName;
-        std::vector<std::size_t> m_escapeChars;
-        TestSpec::Filter m_currentFilter;
-        TestSpec m_testSpec;
+        std::string m_arg {};
+        std::string m_substring {};
+        std::string m_patternName {};
+        std::vector<std::size_t> m_escapeChars {};
+        TestSpec::Filter m_currentFilter {};
+        TestSpec m_testSpec {};
         ITagAliasRegistry const* m_tagAliases = nullptr;
 
     public:
         TestSpecParser( ITagAliasRegistry const& tagAliases );
+        TestSpecParser( TestSpecParser const& ) = delete;
+        TestSpecParser& operator=( TestSpecParser const& ) = delete;
 
         TestSpecParser& parse( std::string const& arg );
         TestSpec testSpec();

--- a/src/catch2/internal/catch_textflow.hpp
+++ b/src/catch2/internal/catch_textflow.hpp
@@ -247,7 +247,7 @@ namespace Catch {
         Column Spacer( size_t spaceWidth );
 
         class Columns {
-            std::vector<Column> m_columns;
+            std::vector<Column> m_columns {};
 
         public:
             class iterator {
@@ -255,7 +255,7 @@ namespace Catch {
                 struct EndTag {};
 
                 std::vector<Column> const& m_columns;
-                std::vector<Column::const_iterator> m_iterators;
+                std::vector<Column::const_iterator> m_iterators {};
                 size_t m_activeIterators;
 
                 iterator( Columns const& columns, EndTag );

--- a/src/catch2/internal/catch_xmlwriter.hpp
+++ b/src/catch2/internal/catch_xmlwriter.hpp
@@ -45,6 +45,8 @@ namespace Catch {
 
         constexpr XmlEncode( StringRef str, ForWhat forWhat = ForTextNodes ):
             m_str( str ), m_forWhat( forWhat ) {}
+        XmlEncode( XmlEncode const& ) = delete;
+        XmlEncode& operator=( XmlEncode const& ) = delete;
 
 
         void encodeTo( std::ostream& os ) const;
@@ -64,7 +66,9 @@ namespace Catch {
             ScopedElement( XmlWriter* writer, XmlFormatting fmt );
 
             ScopedElement( ScopedElement&& other ) noexcept;
+            ScopedElement( ScopedElement const& ) = delete;
             ScopedElement& operator=( ScopedElement&& other ) noexcept;
+            ScopedElement& operator=( ScopedElement const& ) = delete;
 
             ~ScopedElement();
 
@@ -153,8 +157,8 @@ namespace Catch {
 
         bool m_tagIsOpen = false;
         bool m_needsNewline = false;
-        std::vector<std::string> m_tags;
-        std::string m_indent;
+        std::vector<std::string> m_tags {};
+        std::string m_indent {};
         std::ostream& m_os;
     };
 

--- a/src/catch2/matchers/catch_matchers.hpp
+++ b/src/catch2/matchers/catch_matchers.hpp
@@ -14,6 +14,11 @@
 #include <string>
 #include <vector>
 
+#if defined __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Weffc++"
+#endif
+
 namespace Catch {
 namespace Matchers {
 
@@ -233,5 +238,9 @@ namespace Matchers {
   #define REQUIRE_THAT( arg, matcher )                           (void)(0)
 
 #endif // end of user facing macro declarations
+
+#if defined __GNUC__
+#  pragma GCC diagnostic pop
+#endif
 
 #endif // CATCH_MATCHERS_HPP_INCLUDED

--- a/src/catch2/matchers/catch_matchers_templated.hpp
+++ b/src/catch2/matchers/catch_matchers_templated.hpp
@@ -18,12 +18,17 @@
 #include <string>
 #include <type_traits>
 
+#if defined __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Weffc++"
+#endif
+
 namespace Catch {
 namespace Matchers {
     class MatcherGenericBase : public MatcherUntypedBase {
     public:
         MatcherGenericBase() = default;
-        ~MatcherGenericBase() override; // = default;
+        ~MatcherGenericBase() override;
 
         MatcherGenericBase(MatcherGenericBase const&) = default;
         MatcherGenericBase(MatcherGenericBase&&) = default;
@@ -292,5 +297,9 @@ namespace Matchers {
 
 } // namespace Matchers
 } // namespace Catch
+
+#if defined __GNUC__
+#  pragma GCC diagnostic pop
+#endif
 
 #endif // CATCH_MATCHERS_TEMPLATED_HPP_INCLUDED

--- a/src/catch2/meson.build
+++ b/src/catch2/meson.build
@@ -228,6 +228,7 @@ internal_sources = files(
   'internal/catch_leak_detector.cpp',
   'internal/catch_list.cpp',
   'internal/catch_message_info.cpp',
+  'internal/catch_noncopyable.cpp',
   'internal/catch_output_redirect.cpp',
   'internal/catch_parse_numbers.cpp',
   'internal/catch_polyfills.cpp',

--- a/src/catch2/reporters/catch_reporter_console.cpp
+++ b/src/catch2/reporters/catch_reporter_console.cpp
@@ -21,8 +21,6 @@
 #include <catch2/internal/catch_move_and_forward.hpp>
 #include <catch2/catch_get_random_seed.hpp>
 
-#include <cstdio>
-
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable:4061) // Not all labels are EXPLICITLY handled in switch
@@ -185,8 +183,8 @@ private:
     AssertionStats const& stats;
     AssertionResult const& result;
     Colour::Code colour;
-    StringRef passOrFail;
-    StringRef messageLabel;
+    StringRef passOrFail {};
+    StringRef messageLabel {};
     std::vector<MessageInfo> const& messages;
     ColourImpl* colourImpl;
     bool printInfoMessages;
@@ -300,7 +298,7 @@ struct ColumnInfo {
 class TablePrinter {
     std::ostream& m_os;
     std::vector<ColumnInfo> m_columnInfos;
-    ReusableStringStream m_oss;
+    ReusableStringStream m_oss {};
     int m_currentColumn = -1;
     bool m_isOpen = false;
 

--- a/src/catch2/reporters/catch_reporter_cumulative_base.hpp
+++ b/src/catch2/reporters/catch_reporter_cumulative_base.hpp
@@ -25,8 +25,8 @@ namespace Catch {
             // This should really be a variant, but this is much faster
             // to write and the data layout here is already terrible
             // enough that we do not have to care about the object size.
-            Optional<AssertionStats> m_assertion;
-            Optional<BenchmarkStats<>> m_benchmark;
+            Optional<AssertionStats> m_assertion {};
+            Optional<BenchmarkStats<>> m_benchmark {};
         public:
             AssertionOrBenchmarkResult(AssertionStats const& assertion);
             AssertionOrBenchmarkResult(BenchmarkStats<> const& benchmark);
@@ -67,7 +67,7 @@ namespace Catch {
 
             using ChildNodes = std::vector<Detail::unique_ptr<ChildNodeT>>;
             T value;
-            ChildNodes children;
+            ChildNodes children {};
         };
         struct SectionNode {
             explicit SectionNode(SectionStats const& _stats) : stats(_stats) {}
@@ -79,10 +79,10 @@ namespace Catch {
             bool hasAnyAssertions() const;
 
             SectionStats stats;
-            std::vector<Detail::unique_ptr<SectionNode>> childSections;
-            std::vector<Detail::AssertionOrBenchmarkResult> assertionsAndBenchmarks;
-            std::string stdOut;
-            std::string stdErr;
+            std::vector<Detail::unique_ptr<SectionNode>> childSections {};
+            std::vector<Detail::AssertionOrBenchmarkResult> assertionsAndBenchmarks {};
+            std::string stdOut {};
+            std::string stdErr {};
         };
 
 
@@ -94,6 +94,8 @@ namespace Catch {
         CumulativeReporterBase(ReporterConfig&& _config):
             ReporterBase(CATCH_MOVE(_config))
         {}
+        CumulativeReporterBase( CumulativeReporterBase const& other ) = default;
+        CumulativeReporterBase& operator=( CumulativeReporterBase const& ) = delete;
         ~CumulativeReporterBase() override;
 
         void benchmarkPreparing( StringRef ) override {}
@@ -132,18 +134,18 @@ namespace Catch {
         // We need lazy construction here. We should probably refactor it
         // later, after the events are redone.
         //! The root node of the test run tree.
-        Detail::unique_ptr<TestRunNode> m_testRun;
+        Detail::unique_ptr<TestRunNode> m_testRun {};
 
     private:
         // Note: We rely on pointer identity being stable, which is why
         //       we store pointers to the nodes rather than the values.
-        std::vector<Detail::unique_ptr<TestCaseNode>> m_testCases;
+        std::vector<Detail::unique_ptr<TestCaseNode>> m_testCases {};
         // Root section of the _current_ test case
-        Detail::unique_ptr<SectionNode> m_rootSection;
+        Detail::unique_ptr<SectionNode> m_rootSection {};
         // Deepest section of the _current_ test case
         SectionNode* m_deepestSection = nullptr;
         // Stack of _active_ sections in the _current_ test case
-        std::vector<SectionNode*> m_sectionStack;
+        std::vector<SectionNode*> m_sectionStack {};
     };
 
 } // end namespace Catch

--- a/src/catch2/reporters/catch_reporter_helpers.cpp
+++ b/src/catch2/reporters/catch_reporter_helpers.cpp
@@ -266,7 +266,7 @@ namespace Catch {
             std::string m_suffix;
             Colour::Code m_colour;
             std::size_t m_width = 0;
-            std::vector<std::string> m_rows;
+            std::vector<std::string> m_rows {};
         };
 
         void printSummaryRow( std::ostream& stream,

--- a/src/catch2/reporters/catch_reporter_json.hpp
+++ b/src/catch2/reporters/catch_reporter_json.hpp
@@ -57,7 +57,7 @@ namespace Catch {
         void listTags( std::vector<TagInfo> const& tags ) override;
 
     private:
-        Timer m_testCaseTimer;
+        Timer m_testCaseTimer {};
         enum class Writer {
             Object,
             Array

--- a/src/catch2/reporters/catch_reporter_junit.hpp
+++ b/src/catch2/reporters/catch_reporter_junit.hpp
@@ -44,9 +44,9 @@ namespace Catch {
         void writeAssertion(AssertionStats const& stats);
 
         XmlWriter xml;
-        Timer suiteTimer;
-        std::string stdOutForSuite;
-        std::string stdErrForSuite;
+        Timer suiteTimer {};
+        std::string stdOutForSuite {};
+        std::string stdErrForSuite {};
         unsigned int unexpectedExceptions = 0;
         bool m_okToFail = false;
     };

--- a/src/catch2/reporters/catch_reporter_multi.hpp
+++ b/src/catch2/reporters/catch_reporter_multi.hpp
@@ -19,7 +19,7 @@ namespace Catch {
          * All Listeners are stored before all reporters, and individual
          * listeners/reporters are stored in order of insertion.
          */
-        std::vector<IEventListenerPtr> m_reporterLikes;
+        std::vector<IEventListenerPtr> m_reporterLikes {};
         bool m_haveNoncapturingReporters = false;
 
         // Keep track of how many listeners we have already inserted,

--- a/src/catch2/reporters/catch_reporter_streaming_base.hpp
+++ b/src/catch2/reporters/catch_reporter_streaming_base.hpp
@@ -23,6 +23,8 @@ namespace Catch {
             ReporterBase(CATCH_MOVE(_config))
         {}
         ~StreamingReporterBase() override;
+        StreamingReporterBase( StreamingReporterBase const& ) = delete;
+        StreamingReporterBase& operator=( StreamingReporterBase const& ) = delete;
 
         void benchmarkPreparing( StringRef ) override {}
         void benchmarkStarting( BenchmarkInfo const& ) override {}
@@ -65,7 +67,7 @@ namespace Catch {
         TestCaseInfo const* currentTestCaseInfo = nullptr;
 
         //! Stack of all _active_ sections in the _current_ test case
-        std::vector<SectionInfo> m_sectionStack;
+        std::vector<SectionInfo> m_sectionStack {};
     };
 
 } // end namespace Catch

--- a/src/catch2/reporters/catch_reporter_teamcity.hpp
+++ b/src/catch2/reporters/catch_reporter_teamcity.hpp
@@ -54,7 +54,7 @@ namespace Catch {
         void printSectionHeader(std::ostream& os);
 
         bool m_headerPrintedForThisSection = false;
-        Timer m_testTimer;
+        Timer m_testTimer {};
     };
 
 } // end namespace Catch

--- a/src/catch2/reporters/catch_reporter_xml.hpp
+++ b/src/catch2/reporters/catch_reporter_xml.hpp
@@ -56,7 +56,7 @@ namespace Catch {
         void listTags(std::vector<TagInfo> const& tags) override;
 
     private:
-        Timer m_testCaseTimer;
+        Timer m_testCaseTimer {};
         XmlWriter m_xml;
         int m_sectionDepth = 0;
     };


### PR DESCRIPTION
## Description
These changes either address or silence the warnings that come from using -Weffc++ with gcc. This code has to be compiled in other projects, and it's easier to use this option if Catch isn't filling the compilation logs with warnings in its code, especially the headers. This compiler option has helped me in the past to find a subtle bug, and I'd like to continue doing that. Using this compiler option can also help highlight what does need to be tested.

The warnings about the operators were silenced with these changes because they seem like basic functionality. The rest were addressed as best that I can address them.

## GitHub Issues
This addresses the `-Weffc++` part of #2927.
