### PR TITLE
Add test case stats functionality and test case name priority output

### DIFF
--- a/src/catch2/catch_config.cpp
+++ b/src/catch2/catch_config.cpp
@@ -205,6 +205,8 @@ namespace Catch {
     int Config::abortAfter() const                     { return m_data.abortAfter; }
     bool Config::showInvisibles() const                { return m_data.showInvisibles; }
     Verbosity Config::verbosity() const                { return m_data.verbosity; }
+    bool Config::outputTestCaseNameFirst() const       { return m_data.outputTestCaseNameFirst; }
+    bool Config::outputTestCaseStats() const           { return m_data.outputTestCaseStats; }
 
     bool Config::skipBenchmarks() const                           { return m_data.skipBenchmarks; }
     bool Config::benchmarkNoAnalysis() const                      { return m_data.benchmarkNoAnalysis; }

--- a/src/catch2/catch_config.hpp
+++ b/src/catch2/catch_config.hpp
@@ -58,6 +58,8 @@ namespace Catch {
         bool filenamesAsTags = false;
         bool libIdentify = false;
         bool allowZeroTests = false;
+        bool outputTestCaseNameFirst = false;
+        bool outputTestCaseStats = false;
 
         int abortAfter = -1;
         uint32_t rngSeed = generateRandomSeed(GenerateFrom::Default);
@@ -132,6 +134,8 @@ namespace Catch {
         int abortAfter() const override;
         bool showInvisibles() const override;
         Verbosity verbosity() const override;
+        bool outputTestCaseNameFirst() const override;
+        bool outputTestCaseStats() const override;
         bool skipBenchmarks() const override;
         bool benchmarkNoAnalysis() const override;
         unsigned int benchmarkSamples() const override;

--- a/src/catch2/interfaces/catch_interfaces_config.hpp
+++ b/src/catch2/interfaces/catch_interfaces_config.hpp
@@ -87,6 +87,8 @@ namespace Catch {
         virtual ColourMode defaultColourMode() const = 0;
         virtual std::vector<std::string> const& getSectionsToRun() const = 0;
         virtual Verbosity verbosity() const = 0;
+        virtual bool outputTestCaseNameFirst() const = 0;
+        virtual bool outputTestCaseStats() const = 0;
 
         virtual bool skipBenchmarks() const = 0;
         virtual bool benchmarkNoAnalysis() const = 0;

--- a/src/catch2/internal/catch_commandline.cpp
+++ b/src/catch2/internal/catch_commandline.cpp
@@ -251,6 +251,12 @@ namespace Catch {
             | Opt( setVerbosity, "quiet|normal|high" )
                 ["-v"]["--verbosity"]
                 ( "set output verbosity" )
+            | Opt( config.outputTestCaseNameFirst)
+                ["--output-test-case-name-first"]
+                ( "test case name will be printed before the test is run" )
+            | Opt( config.outputTestCaseStats)
+                ["--output-test-case-stats"]
+                ( "prints assertion stat data of the test case run" )
             | Opt( config.listTests )
                 ["--list-tests"]
                 ( "list all/matching test cases" )

--- a/src/catch2/reporters/catch_reporter_console.cpp
+++ b/src/catch2/reporters/catch_reporter_console.cpp
@@ -512,11 +512,31 @@ void ConsoleReporter::benchmarkFailed( StringRef error ) {
         << ColumnBreak() << RowBreak();
 }
 
+void ConsoleReporter::testCaseStarting( TestCaseInfo const& testInfo ) {
+    StreamingReporterBase::testCaseStarting( testInfo );
+
+    if ( m_config->outputTestCaseNameFirst() ) {
+        m_stream << testInfo.name << ":\n";
+    }
+}
+
 void ConsoleReporter::testCaseEnded(TestCaseStats const& _testCaseStats) {
     m_tablePrinter->close();
     StreamingReporterBase::testCaseEnded(_testCaseStats);
     m_headerPrinted = false;
+
+    if ( !_testCaseStats.aborting && m_config->outputTestCaseStats() ) {
+        if (!m_config->outputTestCaseNameFirst())
+        {
+            m_stream << _testCaseStats.testInfo->name << ": ";
+        }
+
+        m_stream << _testCaseStats.totals.assertions.passed << " passed "
+            << _testCaseStats.totals.assertions.failed << " failed "
+            << _testCaseStats.totals.assertions.skipped << " skipped\n";
+    }
 }
+
 void ConsoleReporter::testRunEnded(TestRunStats const& _testRunStats) {
     printTotalsDivider(_testRunStats.totals);
     printTestRunTotals( m_stream, *m_colour, _testRunStats.totals );

--- a/src/catch2/reporters/catch_reporter_console.hpp
+++ b/src/catch2/reporters/catch_reporter_console.hpp
@@ -38,6 +38,7 @@ namespace Catch {
         void benchmarkEnded(BenchmarkStats<> const& stats) override;
         void benchmarkFailed( StringRef error ) override;
 
+        void testCaseStarting( TestCaseInfo const& testInfo ) override;
         void testCaseEnded(TestCaseStats const& _testCaseStats) override;
         void testRunEnded(TestRunStats const& _testRunStats) override;
         void testRunStarting(TestRunInfo const& _testRunInfo) override;


### PR DESCRIPTION
## Description
Add 2 new flags `--output-test-case-name-first` and `--output-test-case-stats`. Former will print name of the test case before it is run (as was requested [here](https://github.com/catchorg/Catch2/issues/1579#issuecomment-983815709)) and the latter will print regular `TestCaseName: **stats**`. I've seen https://github.com/catchorg/Catch2/pull/2343 so this is a bit more lightweight and hopefully not too much against the grain with the argument namespace polution. idklmk

As is mentioned in refed issue, I was missing this feature as well and as much as I want to understand why it's not yet implemented I don't, but I understand why it's not the default.

This is more of a proposal as I'm not really confident with the naming and even worse, I'm using catch for like 3 days now, so I know very little about its internals and overall design.

With that said, I'd be glad to get some feedback. If this feature will be considered, I'll try to polish this PR more with tests and everything, but for that I'll need to look a bit deeper into docs.

I would split these "features" into two, but because of non-buffered output, there are some interdependencies because of newlines already (as with `-s` and `-d yes` would be and idk how many more flags that configure output) between these two, so I wanted to keep them together.

Also atm. I have no idea what table printer does so all I've really done is just ran it, saw it working and here we are.

Also, since everything was so easily accessible, this was pretty much low hanging fruit, I'm even a bit concerned if there isn't such functionality already, but I haven't found it. Would be pretty bad if I've implemented something that's already there. 🤞 

## GitHub Issues
https://github.com/catchorg/Catch2/issues/1579
