### PR TITLE
Fix bug where `catch_discover_tests` fails when no `TEST_CASE`s are present

### DIFF
--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -143,6 +143,12 @@ function(catch_discover_tests_impl)
   # Speed-up reparsing by cutting away unneeded parts of JSON.
   string(JSON test_listing GET "${listing_output}" "listings" "tests")
   string(JSON num_tests LENGTH "${test_listing}")
+
+  # Exit early if no tests are detected
+  if(num_tests STREQUAL "0")
+    return()
+  endif()
+
   # CMake's foreach-RANGE is inclusive, so we have to subtract 1
   math(EXPR num_tests "${num_tests} - 1")
 


### PR DESCRIPTION
## Description

Closes https://github.com/catchorg/Catch2/issues/2961

This bug was introduced in https://github.com/catchorg/Catch2/commit/7d7b2f89f24cbd277f6eb6912705e5e13c68a3c7

