### PR TITLE
clang: do not issue bogus warnings about integer manipulation in hash functions with fsanitize=undefined/integer

### DIFF
--- a/src/catch2/internal/catch_random_number_generator.cpp
+++ b/src/catch2/internal/catch_random_number_generator.cpp
@@ -9,7 +9,7 @@
 
 #if defined( __clang__ )
 #    define CATCH2_CLANG_NO_SANITIZE_INTEGER \
-        __attribute__( ( no_sanitize( "undefined", "integer" ) ) )
+        __attribute__( ( no_sanitize( "unsigned-integer-overflow" ) ) )
 #else
 #    define CATCH2_CLANG_NO_SANITIZE_INTEGER
 #endif

--- a/src/catch2/internal/catch_random_number_generator.cpp
+++ b/src/catch2/internal/catch_random_number_generator.cpp
@@ -7,6 +7,12 @@
 // SPDX-License-Identifier: BSL-1.0
 #include <catch2/internal/catch_random_number_generator.hpp>
 
+#if defined( __clang__ )
+#    define CATCH2_CLANG_NO_SANITIZE_INTEGER \
+        __attribute__( ( no_sanitize( "undefined", "integer" ) ) )
+#else
+#    define CATCH2_CLANG_NO_SANITIZE_INTEGER
+#endif
 namespace Catch {
 
 namespace {
@@ -16,6 +22,7 @@ namespace {
 #pragma warning(disable:4146) // we negate uint32 during the rotate
 #endif
         // Safe rotr implementation thanks to John Regehr
+        CATCH2_CLANG_NO_SANITIZE_INTEGER
         uint32_t rotate_right(uint32_t val, uint32_t count) {
             const uint32_t mask = 31;
             count &= mask;
@@ -49,6 +56,7 @@ namespace {
         }
     }
 
+    CATCH2_CLANG_NO_SANITIZE_INTEGER
     SimplePcg32::result_type SimplePcg32::operator()() {
         // prepare the output value
         const uint32_t xorshifted = static_cast<uint32_t>(((m_state >> 18u) ^ m_state) >> 27u);


### PR DESCRIPTION
With -fsanitize=integer every over/under-flowing integer manipulation triggers a warning.
This is extremely useful as it allows to find some non-obvious bugs such as

    for(size_t i = 0; i < N - 1; i++) { ... }

But it comes with a lot of false positives, for instance with every hash function
doing shifting on unsigned integer. Random number generators are also often detected
with this sanitizer.

This marks a few of these functions as safe in this case.

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
