### PR TITLE
Fix Clang 19 `-Wc++20-extensions` warning

### DIFF
--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -103,8 +103,16 @@
 #    define CATCH_INTERNAL_SUPPRESS_UNUSED_VARIABLE_WARNINGS \
          _Pragma( "clang diagnostic ignored \"-Wunused-variable\"" )
 
-#    define CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS \
-         _Pragma( "clang diagnostic ignored \"-Wgnu-zero-variadic-macro-arguments\"" )
+#    if (__clang_major__ >= 20)
+#        define CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS \
+             _Pragma( "clang diagnostic ignored \"-Wvariadic-macro-arguments-omitted\"" )
+#    elif (__clang_major__ == 19)
+#        define CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS \
+	         _Pragma( "clang diagnostic ignored \"-Wc++20-extensions\"" )
+#    else
+#        define CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS
+             _Pragma( "clang diagnostic ignored \"-Wgnu-zero-variadic-macro-arguments\"" )
+#    endif
 
 #    define CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS \
          _Pragma( "clang diagnostic ignored \"-Wunused-template\"" )


### PR DESCRIPTION
## Description
1) IInitial work (commit 5) removes WS/unrelated changes from PR #2934 meant to address issue #2910. 
2) commit 6 discards changes from PR #2934 in favor of correct clang-version specific warning suppression pragmas for CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS

## GitHub Issues
#2910 

## Minimal reproduction

Tested with:

```c++ 
// test.cpp
#include <catch2/catch_template_test_macros.hpp>
#include <catch2/catch_test_macros.hpp>

#include <vector>

TEMPLATE_TEST_CASE( "one-arg", "[bar]", int)
{
	std::vector<TestType> vec;
	vec.push_back(2);
}
```
```bash
> clang-${VERSION} -I Catch2/src -I ${GENERATED_INCLUDES} -Wall -Wextra -Wpedantic -Werror -c test.cpp 
```

## Patch Results

|Catch2       | Ubuntu clang-19 | Ubuntu clang-20 | OSX clang-19 |
|-------------|-----------------|-----------------|--------------|
| **devel**   |      fail       |     success     |     fail     |
| **patch**   |     success     |     success     |    success   |

Error seen (clang-19 only):
test.cpp:6:1: error: passing no argument for the '...' parameter of a variadic macro is a C++20 extension [-Werror,-Wc++20-extensions]

