### PR TITLE
Remove unnecessary `friend` keywords

### DIFF
--- a/src/catch2/catch_approx.hpp
+++ b/src/catch2/catch_approx.hpp
@@ -50,21 +50,6 @@ namespace Catch {
         }
 
         template <typename T, typename = std::enable_if_t<std::is_constructible<double, T>::value>>
-        friend bool operator == ( Approx const& lhs, const T& rhs ) {
-            return operator==( rhs, lhs );
-        }
-
-        template <typename T, typename = std::enable_if_t<std::is_constructible<double, T>::value>>
-        friend bool operator != ( T const& lhs, Approx const& rhs ) {
-            return !operator==( lhs, rhs );
-        }
-
-        template <typename T, typename = std::enable_if_t<std::is_constructible<double, T>::value>>
-        friend bool operator != ( Approx const& lhs, T const& rhs ) {
-            return !operator==( rhs, lhs );
-        }
-
-        template <typename T, typename = std::enable_if_t<std::is_constructible<double, T>::value>>
         friend bool operator <= ( T const& lhs, Approx const& rhs ) {
             return static_cast<double>(lhs) < rhs.m_value || lhs == rhs;
         }
@@ -112,6 +97,27 @@ namespace Catch {
         double m_scale;
         double m_value;
     };
+
+    template <
+        typename T,
+        typename = std::enable_if_t<std::is_constructible<double, T>::value>>
+    bool operator==( Approx const& lhs, const T& rhs ) {
+        return operator==( rhs, lhs );
+    }
+
+    template <
+        typename T,
+        typename = std::enable_if_t<std::is_constructible<double, T>::value>>
+    bool operator!=( T const& lhs, Approx const& rhs ) {
+        return !operator==( lhs, rhs );
+    }
+
+    template <
+        typename T,
+        typename = std::enable_if_t<std::is_constructible<double, T>::value>>
+    bool operator!=( Approx const& lhs, T const& rhs ) {
+        return !operator==( rhs, lhs );
+    }
 
 namespace literals {
     Approx operator ""_a(long double val);

--- a/src/catch2/catch_config.hpp
+++ b/src/catch2/catch_config.hpp
@@ -35,13 +35,14 @@ namespace Catch {
         std::string outputFilename;
         ColourMode colourMode;
         std::map<std::string, std::string> customOptions;
-        friend bool operator==( ProcessedReporterSpec const& lhs,
-                                ProcessedReporterSpec const& rhs );
-        friend bool operator!=( ProcessedReporterSpec const& lhs,
-                                ProcessedReporterSpec const& rhs ) {
-            return !( lhs == rhs );
-        }
     };
+
+    bool operator==( ProcessedReporterSpec const& lhs,
+                     ProcessedReporterSpec const& rhs );
+    inline bool operator!=( ProcessedReporterSpec const& lhs,
+                     ProcessedReporterSpec const& rhs ) {
+        return !( lhs == rhs );
+    }
 
     struct ConfigData {
 

--- a/src/catch2/internal/catch_clara.hpp
+++ b/src/catch2/internal/catch_clara.hpp
@@ -671,28 +671,11 @@ namespace Catch {
 
             Parser& operator|=(Parser const& other);
 
-            template <typename T>
-            friend Parser operator|( Parser const& p, T&& rhs ) {
-                Parser temp( p );
-                temp |= rhs;
-                return temp;
-            }
-
-            template <typename T>
-            friend Parser operator|( Parser&& p, T&& rhs ) {
-                p |= CATCH_FORWARD(rhs);
-                return CATCH_MOVE(p);
-            }
+            
 
             std::vector<Detail::HelpColumns> getHelpColumns() const;
 
             void writeToStream(std::ostream& os) const;
-
-            friend auto operator<<(std::ostream& os, Parser const& parser)
-                -> std::ostream& {
-                parser.writeToStream(os);
-                return os;
-            }
 
             Detail::Result validate() const override;
 
@@ -701,6 +684,25 @@ namespace Catch {
                 parse(std::string const& exeName,
                       Detail::TokenStream tokens) const override;
         };
+
+        template <typename T>
+        Parser operator|( Parser const& p, T&& rhs ) {
+            Parser temp( p );
+            temp |= rhs;
+            return temp;
+        }
+
+        template<typename T>
+        Parser operator|( Parser&& p, T&& rhs ) {
+            p |= CATCH_FORWARD( rhs );
+            return CATCH_MOVE( p );
+        }
+
+        inline auto operator<<( std::ostream& os, Parser const& parser )
+            -> std::ostream& {
+            parser.writeToStream( os );
+            return os;
+        }
 
         /**
          * Wrapper over argc + argv, assumes that the inputs outlive it

--- a/src/catch2/internal/catch_decomposer.hpp
+++ b/src/catch2/internal/catch_decomposer.hpp
@@ -174,12 +174,14 @@ namespace Catch {
         constexpr ITransientExpression( ITransientExpression const& ) = default;
         constexpr ITransientExpression& operator=( ITransientExpression const& ) = default;
 
-        friend std::ostream& operator<<(std::ostream& out, ITransientExpression const& expr) {
-            expr.streamReconstructedExpression(out);
-            return out;
-        }
     };
 
+    inline std::ostream& operator<<( std::ostream& out,
+                                     ITransientExpression const& expr ) {
+        expr.streamReconstructedExpression( out );
+        return out;
+    }
+    
     void formatReconstructedExpression( std::ostream &os, std::string const& lhs, StringRef op, std::string const& rhs );
 
     template<typename LhsT, typename RhsT>

--- a/src/catch2/internal/catch_stringref.hpp
+++ b/src/catch2/internal/catch_stringref.hpp
@@ -97,10 +97,6 @@ namespace Catch {
         constexpr const_iterator end() const { return m_start + m_size; }
 
 
-        friend std::string& operator += (std::string& lhs, StringRef rhs);
-        friend std::ostream& operator << (std::ostream& os, StringRef str);
-        friend std::string operator+(StringRef lhs, StringRef rhs);
-
         /**
          * Provides a three-way comparison with rhs
          *
@@ -110,6 +106,9 @@ namespace Catch {
         int compare( StringRef rhs ) const;
     };
 
+    std::string& operator+=( std::string& lhs, StringRef rhs );
+    std::ostream& operator<<( std::ostream& os, StringRef str );
+    std::string operator+( StringRef lhs, StringRef rhs );
 
     constexpr auto operator ""_sr( char const* rawChars, std::size_t size ) noexcept -> StringRef {
         return StringRef( rawChars, size );

--- a/src/catch2/internal/catch_xmlwriter.hpp
+++ b/src/catch2/internal/catch_xmlwriter.hpp
@@ -49,13 +49,14 @@ namespace Catch {
 
         void encodeTo( std::ostream& os ) const;
 
-        friend std::ostream& operator << ( std::ostream& os, XmlEncode const& xmlEncode );
 
     private:
         StringRef m_str;
         ForWhat m_forWhat;
     };
 
+    std::ostream& operator << ( std::ostream& os, XmlEncode const& xmlEncode );
+    
     class XmlWriter {
     public:
 


### PR DESCRIPTION
Note that I didn't remove it for `internal\catch_optional.hpp` for ` friend bool operator==(Optional<T>,Optional<T>)` and `operator!=` since the friend function will allow for implicit conversions which allows comparing against a `T` like `Catch::Optional<int>() == int(1)` nor did I make inline functions not inline like `operator<<` for `ITransientExpression`.

This change removes several friend declarations that are no longer necessary. Overuse of friend can lead to tighter coupling between classes, reduced encapsulation and thinking it relies on implementation details.
in general avoid granting excessive access unless explicitly required.