### PR TITLE
refactor: replace deprecated FindPythonInterp with FindPython3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,8 @@ add_subdirectory(src)
 
 # Build tests only if requested
 if(BUILD_TESTING AND CATCH_BUILD_TESTING AND NOT_SUBPROJECT)
-  find_package(PythonInterp 3 REQUIRED)
-  if(NOT PYTHONINTERP_FOUND)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  if(NOT TARGET Python3::Interpreter)
     message(FATAL_ERROR "Python not found, but required for tests")
   endif()
   set(CMAKE_FOLDER "tests")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -342,10 +342,9 @@ set_tests_properties(FilteredSection::GeneratorsDontCauseInfiniteLoop-2
     PASS_REGULAR_EXPRESSION "All tests passed \\(4 assertions in 1 test case\\)"
 )
 
-# AppVeyor has a Python 2.7 in path, but doesn't have .py files as autorunnable
 add_test(NAME ApprovalTests
   COMMAND
-    ${PYTHON_EXECUTABLE}
+    Python3::Interpreter
     ${CATCH_DIR}/tools/scripts/approvalTests.py
     $<TARGET_FILE:SelfTest>
     "${CMAKE_CURRENT_BINARY_DIR}"
@@ -408,7 +407,7 @@ set_tests_properties(TagAlias PROPERTIES
   FAIL_REGULAR_EXPRESSION "0 matching test cases"
 )
 
-add_test(NAME RandomTestOrdering COMMAND ${PYTHON_EXECUTABLE}
+add_test(NAME RandomTestOrdering COMMAND Python3::Interpreter
   ${CATCH_DIR}/tests/TestScripts/testRandomOrder.py $<TARGET_FILE:SelfTest>)
 set_tests_properties(RandomTestOrdering
   PROPERTIES
@@ -417,7 +416,7 @@ set_tests_properties(RandomTestOrdering
 
 add_test(NAME CheckConvenienceHeaders
   COMMAND
-    ${PYTHON_EXECUTABLE} ${CATCH_DIR}/tools/scripts/checkConvenienceHeaders.py
+    Python3::Interpreter ${CATCH_DIR}/tools/scripts/checkConvenienceHeaders.py
 )
 set_tests_properties(CheckConvenienceHeaders
   PROPERTIES
@@ -602,7 +601,7 @@ if(CATCH_ENABLE_CONFIGURE_TESTS)
                     "ExperimentalRedirect")
     add_test(NAME "CMakeConfig::${testName}"
       COMMAND
-        "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/TestScripts/testConfigure${testName}.py" "${CATCH_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
+        Python3::Interpreter "${CMAKE_CURRENT_LIST_DIR}/TestScripts/testConfigure${testName}.py" "${CATCH_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
     )
     set_tests_properties("CMakeConfig::${testName}"
       PROPERTIES
@@ -615,7 +614,7 @@ endif()
 if(CATCH_ENABLE_CMAKE_HELPER_TESTS)
   add_test(NAME "CMakeHelper::DiscoverTests"
     COMMAND
-      "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/TestScripts/DiscoverTests/VerifyRegistration.py" "${CATCH_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
+      Python3::Interpreter "${CMAKE_CURRENT_LIST_DIR}/TestScripts/DiscoverTests/VerifyRegistration.py" "${CATCH_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
   )
   set_tests_properties("CMakeHelper::DiscoverTests"
     PROPERTIES

--- a/tests/ExtraTests/CMakeLists.txt
+++ b/tests/ExtraTests/CMakeLists.txt
@@ -5,7 +5,7 @@ message(STATUS "Extra tests included")
 
 add_test(
   NAME TestShardingIntegration
-  COMMAND ${PYTHON_EXECUTABLE} ${CATCH_DIR}/tests/TestScripts/testSharding.py $<TARGET_FILE:SelfTest>
+  COMMAND Python3::Interpreter ${CATCH_DIR}/tests/TestScripts/testSharding.py $<TARGET_FILE:SelfTest>
 )
 set_tests_properties(TestShardingIntegration
   PROPERTIES
@@ -114,7 +114,7 @@ target_compile_definitions(BazelReporter PRIVATE CATCH_CONFIG_BAZEL_SUPPORT)
 target_link_libraries(BazelReporter Catch2_buildall_interface)
 add_test(NAME CATCH_CONFIG_BAZEL_REPORTER-1
   COMMAND
-  "${PYTHON_EXECUTABLE}" "${CATCH_DIR}/tests/TestScripts/testBazelReporter.py" $<TARGET_FILE:BazelReporter> "${CMAKE_CURRENT_BINARY_DIR}"
+  Python3::Interpreter "${CATCH_DIR}/tests/TestScripts/testBazelReporter.py" $<TARGET_FILE:BazelReporter> "${CMAKE_CURRENT_BINARY_DIR}"
 )
 set_tests_properties(CATCH_CONFIG_BAZEL_REPORTER-1
   PROPERTIES
@@ -126,7 +126,7 @@ add_executable(BazelReporterNoCatchConfig ${TESTS_DIR}/X30-BazelReporter.cpp)
 target_link_libraries(BazelReporterNoCatchConfig Catch2WithMain)
 add_test(NAME NO_CATCH_CONFIG_BAZEL_REPORTER-1
   COMMAND
-  "${PYTHON_EXECUTABLE}" "${CATCH_DIR}/tests/TestScripts/testBazelReporter.py" $<TARGET_FILE:BazelReporterNoCatchConfig> "${CMAKE_CURRENT_BINARY_DIR}"
+  Python3::Interpreter "${CATCH_DIR}/tests/TestScripts/testBazelReporter.py" $<TARGET_FILE:BazelReporterNoCatchConfig> "${CMAKE_CURRENT_BINARY_DIR}"
 )
 set_tests_properties(NO_CATCH_CONFIG_BAZEL_REPORTER-1
   PROPERTIES
@@ -146,7 +146,7 @@ set_tests_properties(BazelEnv::TESTBRIDGE_TEST_ONLY
 
 add_test(NAME BazelEnv::Sharding
   COMMAND
-    "${PYTHON_EXECUTABLE}" "${CATCH_DIR}/tests/TestScripts/testBazelSharding.py"
+    Python3::Interpreter "${CATCH_DIR}/tests/TestScripts/testBazelSharding.py"
       $<TARGET_FILE:BazelReporterNoCatchConfig>
       "${CMAKE_CURRENT_BINARY_DIR}"
 )
@@ -222,7 +222,7 @@ add_executable(PartialTestCaseEvents ${TESTS_DIR}/X21-PartialTestCaseEvents.cpp)
 target_link_libraries(PartialTestCaseEvents PRIVATE Catch2WithMain)
 add_test(
   NAME PartialTestCaseEvents
-  COMMAND ${PYTHON_EXECUTABLE} ${CATCH_DIR}/tests/TestScripts/testPartialTestCaseEvent.py $<TARGET_FILE:PartialTestCaseEvents>
+  COMMAND Python3::Interpreter ${CATCH_DIR}/tests/TestScripts/testPartialTestCaseEvent.py $<TARGET_FILE:PartialTestCaseEvents>
 )
 set_tests_properties(PartialTestCaseEvents
   PROPERTIES


### PR DESCRIPTION
## Description

[FindPythonInterp](https://cmake.org/cmake/help/v3.16/module/FindPythonInterp.html) is deprecated in CMake 3.12.

Now the project requires CMake 3.16+
https://github.com/catchorg/Catch2/blob/3013cb897b5706e8532507cb2b6ac33e1fc35d93/CMakeLists.txt#L1
hence FindPython3 module is usable.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->

fix #2755