### PR TITLE
fix(python): fix invalid escape sequences

### DIFF
--- a/tests/TestScripts/DiscoverTests/VerifyRegistration.py
+++ b/tests/TestScripts/DiscoverTests/VerifyRegistration.py
@@ -17,7 +17,7 @@ from typing import List
 
 TestInfo = namedtuple('TestInfo', ['name', 'tags'])
 
-cmake_version_regex = re.compile('cmake version (\d+)\.(\d+)\.(\d+)')
+cmake_version_regex = re.compile(r'cmake version (\d+)\.(\d+)\.(\d+)')
 
 def get_cmake_version():
     result = subprocess.run(['cmake', '--version'],

--- a/tools/scripts/approvalTests.py
+++ b/tools/scripts/approvalTests.py
@@ -121,7 +121,7 @@ def filterLine(line, isCompact):
     # strip source line numbers
     # Note that this parser assumes an already normalized filepath from above,
     # and might break terribly if it is moved around before the normalization.
-    line = filelocParser.sub('\g<filename>:<line number>', line)
+    line = filelocParser.sub(r'\g<filename>:<line number>', line)
 
     line = lineNumberParser.sub(" ", line)
 
@@ -130,7 +130,7 @@ def filterLine(line, isCompact):
         line = line.replace(': PASSED', ': passed')
 
     # strip out the test order number in TAP to avoid massive diffs for every change
-    line = tapTestNumParser.sub("\g<1> {test-number} -", line)
+    line = tapTestNumParser.sub(r"\g<1> {test-number} -", line)
 
     # strip Catch2 version number
     line = versionParser.sub("<version>", line)
@@ -148,7 +148,7 @@ def filterLine(line, isCompact):
     line = junitDurationsParser.sub(' time="{duration}"', line)
     line = durationParser.sub(' duration="{duration}"', line)
     line = timestampsParser.sub('{iso8601-timestamp}', line)
-    line = specialCaseParser.sub('file:\g<1>', line)
+    line = specialCaseParser.sub(r'file:\g<1>', line)
     line = sinceEpochParser.sub('{since-epoch-report}', line)
     return line
 

--- a/tools/scripts/checkConvenienceHeaders.py
+++ b/tools/scripts/checkConvenienceHeaders.py
@@ -21,11 +21,11 @@ import os
 import re
 
 def normalized_path(path):
-    """Replaces \ in paths on Windows with /"""
+    r"""Replaces \ in paths on Windows with /"""
     return path.replace('\\', '/')
 
 def normalized_paths(paths):
-    """Replaces \ with / in every path"""
+    r"""Replaces \ with / in every path"""
     return [normalized_path(path) for path in paths]
 
 source_path = catchPath + '/src/catch2'


### PR DESCRIPTION
## Description

Regex such as `'\d'` is invalid, which must be `r'\d'` or `'\\d'`.