### PR TITLE
fix: make deleted member function public

### DIFF
--- a/src/catch2/internal/catch_noncopyable.hpp
+++ b/src/catch2/internal/catch_noncopyable.hpp
@@ -13,6 +13,7 @@ namespace Catch {
 
         //! Deriving classes become noncopyable and nonmovable
         class NonCopyable {
+        public:
             NonCopyable( NonCopyable const& ) = delete;
             NonCopyable( NonCopyable&& ) = delete;
             NonCopyable& operator=( NonCopyable const& ) = delete;


### PR DESCRIPTION
## Description

https://github.com/catchorg/Catch2/blob/3013cb897b5706e8532507cb2b6ac33e1fc35d93/.clang-tidy#L21

modernize-use-equals-delete is enabled and the code complies with it, but clang-tidy issues warning: "deleted member function should be public."