### PR TITLE
style: remove redundant `override` specifier from functions that are declared `final`

### DIFF
--- a/fuzzing/NullOStream.h
+++ b/fuzzing/NullOStream.h
@@ -16,7 +16,7 @@ class NullStreambuf : public std::streambuf {
   char dummyBuffer[64];
 
 protected:
-  virtual int overflow(int c) override final;
+  virtual int overflow(int c) final;
 };
 
 class NullOStream final : private NullStreambuf, public std::ostream {

--- a/src/catch2/generators/catch_generator_exception.hpp
+++ b/src/catch2/generators/catch_generator_exception.hpp
@@ -23,7 +23,7 @@ namespace Catch {
             m_msg(msg)
         {}
 
-        const char* what() const noexcept override final;
+        const char* what() const noexcept final;
     };
 
 } // end namespace Catch


### PR DESCRIPTION

## Description

clang-tidy complains about unnecessary `override` as per modernize-use-override.

