### PR TITLE
Optin to VT100 style terminal codes on Windows

### DIFF
--- a/src/catch2/internal/catch_console_colour.cpp
+++ b/src/catch2/internal/catch_console_colour.cpp
@@ -178,10 +178,7 @@ namespace {
         void use( Colour::Code _colourCode ) const override {
             auto setColour = [&out =
                                   m_stream->stream()]( char const* escapeCode ) {
-                // The escape sequence must be flushed to console, otherwise
-                // if stdin and stderr are intermixed, we'd get accidentally
-                // coloured output.
-                out << '\033' << escapeCode << std::flush;
+                out << '\033' << escapeCode;
             };
             switch( _colourCode ) {
                 case Colour::None:

--- a/src/catch2/internal/catch_console_colour.cpp
+++ b/src/catch2/internal/catch_console_colour.cpp
@@ -97,34 +97,6 @@ namespace Catch {
 
 } // namespace Catch
 
-#if defined ( CATCH_PLATFORM_WINDOWS )
-namespace Catch {
-namespace {
-
-    bool enableVirtualTerminalSupport(bool restore)
-    {
-        HANDLE outputHandle = GetStdHandle( STD_OUTPUT_HANDLE );
-        DWORD mode = 0;
-        if ( GetConsoleMode( outputHandle, &mode ) ) {
-            // VT100 style sequence processing has to be enabled by explicit
-            // opt-in.
-            DWORD newMode = mode | ENABLE_PROCESSED_OUTPUT |
-                            ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-            bool virtualTerminalSupported = SetConsoleMode( outputHandle, newMode );
-            if(restore)
-            {
-                SetConsoleMode( outputHandle, mode );
-            }
-            return virtualTerminalSupported;
-        } else {
-            return false;
-        }
-    }
-
-}
-}
-#endif
-
 #if defined ( CATCH_CONFIG_COLOUR_WIN32 ) /////////////////////////////////////////
 
 namespace Catch {
@@ -142,13 +114,13 @@ namespace {
         }
 
         static bool useImplementationForStream(IStream const& stream) {
-            // Win32 text colour APIs can only be used on console streams
-            // We cannot check that the output hasn't been redirected,
-            // so we just check that the original stream is console stream.
-            bool useColour = stream.isConsole();
-            // If available, prefer VT100 style escape sequences.
-            useColour = useColour && !enableVirtualTerminalSupport( true );
-            return useColour;
+            OSVERSIONINFOA versionInfo;
+            // Use as fallback for Windows versions <10.0 only.
+            // Newer Windows versions have full support for ANSI color codes.
+            if ( GetVersionExA( &versionInfo ) && versionInfo.dwMajorVersion < 10 ) {
+                return stream.isConsole();
+            }
+            return false;
         }
 
     private:
@@ -196,17 +168,10 @@ namespace {
     class ANSIColourImpl final : public ColourImpl {
     public:
         ANSIColourImpl( IStream* stream ): ColourImpl( stream ) {
-#if defined( CATCH_PLATFORM_WINDOWS )
-            enableVirtualTerminalSupport(false);
-#endif
         }
 
         static bool useImplementationForStream(IStream const& stream) {
-            bool useColour = stream.isConsole();
-#    if defined( CATCH_PLATFORM_WINDOWS )
-            useColour = useColour && enableVirtualTerminalSupport(true);
-#    endif
-            return useColour;
+            return stream.isConsole();
         }
 
     private:

--- a/src/catch2/internal/catch_console_colour.cpp
+++ b/src/catch2/internal/catch_console_colour.cpp
@@ -97,6 +97,42 @@ namespace Catch {
 
 } // namespace Catch
 
+#if defined( CATCH_PLATFORM_LINUX ) || defined( CATCH_PLATFORM_MAC ) || \
+    defined( __GLIBC__ )
+#    define CATCH_INTERNAL_HAS_ISATTY
+#    include <unistd.h>
+#elif defined( CATCH_PLATFORM_WINDOWS )
+#    define CATCH_INTERNAL_HAS_ISATTY
+#    include <io.h>
+#endif
+
+#if defined ( CATCH_PLATFORM_WINDOWS )
+namespace Catch {
+namespace {
+
+    bool enableVirtualTerminalSupport(bool restore)
+    {
+        HANDLE outputHandle = GetStdHandle( STD_OUTPUT_HANDLE );
+        DWORD mode = 0;
+        if ( GetConsoleMode( outputHandle, &mode ) ) {
+            // VT100 style sequence processing has to be enabled by explicit
+            // opt-in.
+            DWORD newMode = mode | ENABLE_PROCESSED_OUTPUT |
+                            ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+            bool virtualTerminalSupported = SetConsoleMode( outputHandle, newMode );
+            if(restore)
+            {
+                SetConsoleMode( outputHandle, mode );
+            }
+            return virtualTerminalSupported;
+        } else {
+            return false;
+        }
+    }
+
+}
+}
+#endif
 
 #if defined ( CATCH_CONFIG_COLOUR_WIN32 ) /////////////////////////////////////////
 
@@ -118,7 +154,11 @@ namespace {
             // Win32 text colour APIs can only be used on console streams
             // We cannot check that the output hasn't been redirected,
             // so we just check that the original stream is console stream.
-            return stream.isConsole();
+            bool useColour = stream.isConsole();
+            useColour = useColour && _isatty( _fileno( stdout ) );
+            // If available, prefer VT100 style escape sequences.
+            useColour = useColour && !enableVirtualTerminalSupport( true );
+            return useColour;
         }
 
     private:
@@ -160,18 +200,16 @@ namespace {
 
 #endif // Windows/ ANSI/ None
 
-
-#if defined( CATCH_PLATFORM_LINUX ) || defined( CATCH_PLATFORM_MAC ) || defined( __GLIBC__ )
-#    define CATCH_INTERNAL_HAS_ISATTY
-#    include <unistd.h>
-#endif
-
 namespace Catch {
 namespace {
 
     class ANSIColourImpl final : public ColourImpl {
     public:
-        ANSIColourImpl( IStream* stream ): ColourImpl( stream ) {}
+        ANSIColourImpl( IStream* stream ): ColourImpl( stream ) {
+#if defined( CATCH_PLATFORM_WINDOWS )
+            enableVirtualTerminalSupport(false);
+#endif
+        }
 
         static bool useImplementationForStream(IStream const& stream) {
             // This is kinda messy due to trying to support a bunch of
@@ -185,7 +223,10 @@ namespace {
 #if defined( CATCH_INTERNAL_HAS_ISATTY ) && \
     !( defined( __DJGPP__ ) && defined( __STRICT_ANSI__ ) )
             ErrnoGuard _; // for isatty
-            useColour = useColour && isatty( STDOUT_FILENO );
+            useColour = useColour && _isatty( _fileno( stdout ) );
+#    endif
+#    if defined( CATCH_PLATFORM_WINDOWS )
+            useColour = useColour && enableVirtualTerminalSupport(true);
 #    endif
 #    if defined( CATCH_PLATFORM_MAC ) || defined( CATCH_PLATFORM_IPHONE )
             useColour = useColour && !isDebuggerActive();

--- a/src/catch2/internal/catch_console_colour.cpp
+++ b/src/catch2/internal/catch_console_colour.cpp
@@ -97,15 +97,6 @@ namespace Catch {
 
 } // namespace Catch
 
-#if defined( CATCH_PLATFORM_LINUX ) || defined( CATCH_PLATFORM_MAC ) || \
-    defined( __GLIBC__ )
-#    define CATCH_INTERNAL_HAS_ISATTY
-#    include <unistd.h>
-#elif defined( CATCH_PLATFORM_WINDOWS )
-#    define CATCH_INTERNAL_HAS_ISATTY
-#    include <io.h>
-#endif
-
 #if defined ( CATCH_PLATFORM_WINDOWS )
 namespace Catch {
 namespace {
@@ -155,7 +146,6 @@ namespace {
             // We cannot check that the output hasn't been redirected,
             // so we just check that the original stream is console stream.
             bool useColour = stream.isConsole();
-            useColour = useColour && _isatty( _fileno( stdout ) );
             // If available, prefer VT100 style escape sequences.
             useColour = useColour && !enableVirtualTerminalSupport( true );
             return useColour;
@@ -212,26 +202,10 @@ namespace {
         }
 
         static bool useImplementationForStream(IStream const& stream) {
-            // This is kinda messy due to trying to support a bunch of
-            // different platforms at once.
-            // The basic idea is that if we are asked to do autodetection (as
-            // opposed to being told to use posixy colours outright), then we
-            // only want to use the colours if we are writing to console.
-            // However, console might be redirected, so we make an attempt at
-            // checking for that on platforms where we know how to do that.
             bool useColour = stream.isConsole();
-#if defined( CATCH_INTERNAL_HAS_ISATTY ) && \
-    !( defined( __DJGPP__ ) && defined( __STRICT_ANSI__ ) )
-            ErrnoGuard _; // for isatty
-            useColour = useColour && _isatty( _fileno( stdout ) );
-#    endif
 #    if defined( CATCH_PLATFORM_WINDOWS )
             useColour = useColour && enableVirtualTerminalSupport(true);
 #    endif
-#    if defined( CATCH_PLATFORM_MAC ) || defined( CATCH_PLATFORM_IPHONE )
-            useColour = useColour && !isDebuggerActive();
-#    endif
-
             return useColour;
         }
 

--- a/src/catch2/internal/catch_istream.cpp
+++ b/src/catch2/internal/catch_istream.cpp
@@ -11,9 +11,18 @@
 #include <catch2/internal/catch_debug_console.hpp>
 #include <catch2/internal/catch_unique_ptr.hpp>
 #include <catch2/internal/catch_stdstreams.hpp>
+#include <catch2/internal/catch_errno_guard.hpp>
 
 #include <cstdio>
 #include <fstream>
+
+#if defined( CATCH_PLATFORM_LINUX ) || defined( CATCH_PLATFORM_MAC ) || \
+    defined( __GLIBC__ )
+#    define CATCH_INTERNAL_HAS_ISATTY
+#    include <unistd.h>
+#elif defined( CATCH_PLATFORM_WINDOWS )
+#    include <io.h>
+#endif
 
 namespace Catch {
 
@@ -88,27 +97,52 @@ namespace Detail {
 
         class CoutStream final : public IStream {
             std::ostream m_os;
+            bool m_isatty;
         public:
             // Store the streambuf from cout up-front because
             // cout may get redirected when running tests
-            CoutStream() : m_os( Catch::cout().rdbuf() ) {}
+            CoutStream() : m_os( Catch::cout().rdbuf() ) {
+                m_isatty = true;
+#if defined( CATCH_INTERNAL_HAS_ISATTY ) && \
+    !( defined( __DJGPP__ ) && defined( __STRICT_ANSI__ ) )
+                ErrnoGuard _; // for isatty
+                m_isatty = m_isatty && isatty( STDOUT_FILENO );
+#elif defined( CATCH_PLATFORM_WINDOWS )
+                m_isatty = m_isatty && _isatty( _fileno( stdout ) );
+#endif
+#if defined( CATCH_PLATFORM_MAC ) || defined( CATCH_PLATFORM_IPHONE )
+                    m_isatty = m_isatty && !isDebuggerActive();
+#endif
+            }
 
         public: // IStream
             std::ostream& stream() override { return m_os; }
-            bool isConsole() const override { return true; }
+            bool isConsole() const override { return m_isatty; }
         };
 
         class CerrStream : public IStream {
             std::ostream m_os;
-
+            bool m_isatty;
         public:
             // Store the streambuf from cerr up-front because
             // cout may get redirected when running tests
-            CerrStream(): m_os( Catch::cerr().rdbuf() ) {}
+            CerrStream(): m_os( Catch::cerr().rdbuf() ) {
+                m_isatty = true;
+#if defined( CATCH_INTERNAL_HAS_ISATTY ) && \
+    !( defined( __DJGPP__ ) && defined( __STRICT_ANSI__ ) )
+                ErrnoGuard _; // for isatty
+                m_isatty = m_isatty && isatty( STDERR_FILENO );
+#elif defined( CATCH_PLATFORM_WINDOWS )
+                m_isatty = m_isatty && _isatty( _fileno( stderr ) );
+#endif
+#if defined( CATCH_PLATFORM_MAC ) || defined( CATCH_PLATFORM_IPHONE )
+                m_isatty = m_isatty && !isDebuggerActive();
+#endif
+            }
 
         public: // IStream
             std::ostream& stream() override { return m_os; }
-            bool isConsole() const override { return true; }
+            bool isConsole() const override { return m_isatty; }
         };
 
         ///////////////////////////////////////////////////////////////////////////

--- a/src/catch2/internal/catch_istream.cpp
+++ b/src/catch2/internal/catch_istream.cpp
@@ -131,10 +131,11 @@ namespace Detail {
                 ErrnoGuard _; // for isatty
                 m_isatty = m_isatty && isatty( STDOUT_FILENO );
 #elif defined( CATCH_PLATFORM_WINDOWS )
+                m_isatty = m_isatty && _isatty( _fileno( stdout ) );
                 m_isatty = m_isatty && enableVirtualTerminalSupport( STD_OUTPUT_HANDLE );
 #endif
 #if defined( CATCH_PLATFORM_MAC ) || defined( CATCH_PLATFORM_IPHONE )
-                    m_isatty = m_isatty && !isDebuggerActive();
+                m_isatty = m_isatty && !isDebuggerActive();
 #endif
             }
 
@@ -156,6 +157,7 @@ namespace Detail {
                 ErrnoGuard _; // for isatty
                 m_isatty = m_isatty && isatty( STDERR_FILENO );
 #elif defined( CATCH_PLATFORM_WINDOWS )
+                m_isatty = m_isatty && _isatty( _fileno( stderr ) );
                 m_isatty = m_isatty && enableVirtualTerminalSupport( STD_ERROR_HANDLE );
 #endif
 #if defined( CATCH_PLATFORM_MAC ) || defined( CATCH_PLATFORM_IPHONE )

--- a/src/catch2/internal/catch_istream.cpp
+++ b/src/catch2/internal/catch_istream.cpp
@@ -6,12 +6,13 @@
 
 // SPDX-License-Identifier: BSL-1.0
 
-#include <catch2/internal/catch_istream.hpp>
-#include <catch2/internal/catch_enforce.hpp>
 #include <catch2/internal/catch_debug_console.hpp>
-#include <catch2/internal/catch_unique_ptr.hpp>
-#include <catch2/internal/catch_stdstreams.hpp>
+#include <catch2/internal/catch_enforce.hpp>
 #include <catch2/internal/catch_errno_guard.hpp>
+#include <catch2/internal/catch_istream.hpp>
+#include <catch2/internal/catch_stdstreams.hpp>
+#include <catch2/internal/catch_unique_ptr.hpp>
+#include <catch2/internal/catch_windows_h_proxy.hpp>
 
 #include <cstdio>
 #include <fstream>
@@ -95,6 +96,28 @@ namespace Detail {
 
         ///////////////////////////////////////////////////////////////////////////
 
+#if defined( CATCH_PLATFORM_WINDOWS )
+        bool enableVirtualTerminalSupport( DWORD stdHandle ) {
+            HANDLE outputHandle = GetStdHandle( stdHandle );
+            DWORD mode = 0;
+            const DWORD requiredMode = ENABLE_PROCESSED_OUTPUT |
+                                ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+            if ( GetConsoleMode( outputHandle, &mode ) &&
+                    ( mode & requiredMode ) == requiredMode ) {
+                // VT100 style sequence processing has to be enabled by
+                // explicit opt-in.
+                const DWORD newMode = mode | requiredMode;
+                if( SetConsoleMode( outputHandle, newMode ) )
+                {
+                    return true;
+                }
+                // Restore fail-safe state.
+                SetConsoleMode( outputHandle, mode );
+            }
+            return false;
+        }
+#endif
+
         class CoutStream final : public IStream {
             std::ostream m_os;
             bool m_isatty;
@@ -108,7 +131,7 @@ namespace Detail {
                 ErrnoGuard _; // for isatty
                 m_isatty = m_isatty && isatty( STDOUT_FILENO );
 #elif defined( CATCH_PLATFORM_WINDOWS )
-                m_isatty = m_isatty && _isatty( _fileno( stdout ) );
+                m_isatty = m_isatty && enableVirtualTerminalSupport( STD_OUTPUT_HANDLE );
 #endif
 #if defined( CATCH_PLATFORM_MAC ) || defined( CATCH_PLATFORM_IPHONE )
                     m_isatty = m_isatty && !isDebuggerActive();
@@ -133,7 +156,7 @@ namespace Detail {
                 ErrnoGuard _; // for isatty
                 m_isatty = m_isatty && isatty( STDERR_FILENO );
 #elif defined( CATCH_PLATFORM_WINDOWS )
-                m_isatty = m_isatty && _isatty( _fileno( stderr ) );
+                m_isatty = m_isatty && enableVirtualTerminalSupport( STD_ERROR_HANDLE );
 #endif
 #if defined( CATCH_PLATFORM_MAC ) || defined( CATCH_PLATFORM_IPHONE )
                 m_isatty = m_isatty && !isDebuggerActive();


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
Enable VT100 terminal color codes on Windows too (if available) and use them by default.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
Closes https://github.com/catchorg/Catch2/issues/3003
