### PR TITLE
Fix warning in `catch_unique_ptr::bool()` (fixes #3011)

### DIFF
--- a/src/catch2/internal/catch_unique_ptr.hpp
+++ b/src/catch2/internal/catch_unique_ptr.hpp
@@ -92,7 +92,7 @@ namespace Detail {
         }
 
         explicit operator bool() const {
-            return m_ptr;
+            return m_ptr != nullptr;
         }
 
         friend void swap(unique_ptr& lhs, unique_ptr& rhs) {


### PR DESCRIPTION
## Description
Return boolean value instead of implicit conversion (as, for example, is done [here](https://github.com/catchorg/Catch2/blob/devel/src/catch2/internal/catch_lazy_expr.hpp#L32))

## GitHub Issues
Closes #3011
