### PR TITLE
Fix color mode detection on FreeBSD by adding platform macro

### DIFF
--- a/src/catch2/internal/catch_console_colour.cpp
+++ b/src/catch2/internal/catch_console_colour.cpp
@@ -161,7 +161,7 @@ namespace {
 #endif // Windows/ ANSI/ None
 
 
-#if defined( CATCH_PLATFORM_LINUX ) || defined( CATCH_PLATFORM_MAC ) || defined( __GLIBC__ )
+#if defined( CATCH_PLATFORM_LINUX ) || defined( CATCH_PLATFORM_MAC ) || defined( __GLIBC__ ) || defined(__FreeBSD__)
 #    define CATCH_INTERNAL_HAS_ISATTY
 #    include <unistd.h>
 #endif


### PR DESCRIPTION
## Description
Fixed the color mode detection on FreeBSD by adding defined(__FreeBSD__) to the platform check in catch_console_colour.cpp. This enables the use of isatty() on FreeBSD systems to correctly detect when output is redirected to a file. As a result, it prevents ANSI color codes from being printed when they shouldn’t be, making FreeBSD behave consistently with Linux and macOS in terms of console color output.

## GitHub Issues
Closes #2449