### PR TITLE
Make ConsoleReporter non-final

### DIFF
--- a/src/catch2/reporters/catch_reporter_console.hpp
+++ b/src/catch2/reporters/catch_reporter_console.hpp
@@ -15,7 +15,7 @@ namespace Catch {
     // Fwd decls
     class TablePrinter;
 
-    class ConsoleReporter final : public StreamingReporterBase {
+    class ConsoleReporter : public StreamingReporterBase {
         Detail::unique_ptr<TablePrinter> m_tablePrinter;
 
     public:


### PR DESCRIPTION

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
Many functions here can be customized without issue.

My primary motivation was to print test cases (without printing each individual test) as they're being executed in a long-running test suite. Custom reporters can't be used for this since the console reporter can't be combined with other reporters. Making ConsoleReporter non-final makes it trivial since I can simply implement `testCaseStarting` myself now.
