### PR TITLE
Fix compiling on non-desktop GDK platforms

### DIFF
--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -220,11 +220,15 @@
 #    endif
 
 // Universal Windows platform does not support SEH
-// Or console colours (or console at all...)
-#  if defined(CATCH_PLATFORM_WINDOWS_UWP)
-#    define CATCH_INTERNAL_CONFIG_NO_COLOUR_WIN32
-#  else
+#  if !defined(CATCH_PLATFORM_WINDOWS_UWP)
 #    define CATCH_INTERNAL_CONFIG_WINDOWS_SEH
+#  endif
+
+// Only some Windows platform families support the console
+#  if defined(WINAPI_FAMILY_PARTITION)
+#    if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_SYSTEM)
+#      define CATCH_INTERNAL_CONFIG_NO_COLOUR_WIN32
+#    endif
 #  endif
 
 // MSVC traditional preprocessor needs some workaround for __VA_ARGS__


### PR DESCRIPTION
## Description

When building on non-desktop GDK platforms, I'd encounter compile failures regarding `CONSOLE_SCREEN_BUFFER_INFO` and other console-related WinAPI symbols. Those are defined only for some family partitions, and they were not correctly covered by the current `CATCH_PLATFORM_WINDOWS_UWP` gate-off.

In this PR, I modified the code defining `CATCH_INTERNAL_CONFIG_NO_COLOUR_WIN32` to use the correct Windows family partition checks (when applicable), identical to the checks performed inside `ConsoleApi2.h`. With this change, I can build Catch2 on all platforms supported by GDK.

## GitHub Issues

N/A, stumbled upon this issue in production.