### PR TITLE
Changing Clang-Tidy's CheckOptions to use a Sequence

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -78,5 +78,5 @@ WarningsAsErrors: >-
   readability-duplicate-include,
 HeaderFilterRegex: '.*\.(c|cxx|cpp)$'
 FormatStyle:     none
-CheckOptions: {}
+CheckOptions: []
 ...


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

Updated the `.clang-tidy` `CheckOptions` field to use an empty sequence instead of an empty mapping to prevent Clang Tidy warnings. 

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->

Closes #3030