### PR TITLE
Add validation for --benchmark-samples to prevent crash with zero value

### DIFF
--- a/src/catch2/internal/catch_commandline.cpp
+++ b/src/catch2/internal/catch_commandline.cpp
@@ -189,6 +189,19 @@ namespace Catch {
             config.shardCount = *parsedCount;
             return ParserResult::ok( ParseResultType::Matched );
         };
+        auto const setBenchmarkSamples = [&]( std::string const& samples ) {
+        auto parsedSamples = parseUInt( samples );
+        if ( !parsedSamples ) {
+            return ParserResult::runtimeError(
+                "Could not parse '" + samples + "' as benchmark samples" );
+        }
+        if ( *parsedSamples == 0 ) {
+            return ParserResult::runtimeError(
+                "Benchmark samples must be greater than 0" );
+        }
+        config.benchmarkSamples = *parsedSamples;
+        return ParserResult::ok( ParseResultType::Matched );
+    };
 
         auto const setShardIndex = [&](std::string const& shardIndex) {
             auto parsedIndex = parseUInt( shardIndex );
@@ -281,7 +294,7 @@ namespace Catch {
             | Opt( config.skipBenchmarks)
                 ["--skip-benchmarks"]
                 ( "disable running benchmarks")
-            | Opt( config.benchmarkSamples, "samples" )
+            | Opt( setBenchmarkSamples, "samples"  )
                 ["--benchmark-samples"]
                 ( "number of samples to collect (default: 100)" )
             | Opt( config.benchmarkResamples, "resamples" )

--- a/tests/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/CmdLine.tests.cpp
@@ -301,6 +301,14 @@ TEST_CASE( "Process can be configured on command line", "[config][command-line]"
 
             REQUIRE(config.benchmarkSamples == 200);
         }
+        SECTION("samples must be greater than zero"){
+            auto result = cli.parse({"test", "--benchmark-samples=0"});
+
+            CHECK_FALSE(result);
+            REQUIRE_THAT(
+                result.errorMessage(),
+                ContainsSubstring("Benchmark samples must be greater than 0"));
+        }
 
         SECTION("resamples") {
             CHECK(cli.parse({ "test", "--benchmark-resamples=20000" }));


### PR DESCRIPTION
Fixes #3040 

Summary
Added validation to reject `--benchmark-samples 0` which was causing a segmentation fault.

Changes
- Added 'setBenchmarkSamples' validation function in 'src/catch2/internal/catch_commandline.cpp'
- Function checks if the value is 0 and returns an error message instead of allowing the crash
- Follows the same pattern as existing validators like 'setShardCount'

Testing
Tested with a benchmark test case - now shows error message "Benchmark samples must be greater than 0" instead of crashing with SIGSEGV.
