### PR TITLE
Fix the help text for the --order command line argument

### DIFF
--- a/src/catch2/internal/catch_commandline.cpp
+++ b/src/catch2/internal/catch_commandline.cpp
@@ -265,7 +265,7 @@ namespace Catch {
                 ( "list all listeners" )
             | Opt( setTestOrder, "decl|lex|rand" )
                 ["--order"]
-                ( "test case order (defaults to decl)" )
+                ( "test case order (defaults to rand)" )
             | Opt( setRngSeed, "'time'|'random-device'|number" )
                 ["--rng-seed"]
                 ( "set a specific seed for random numbers" )


### PR DESCRIPTION
This fixes the `--help` output for the `--order` argument; it was changed to rand in v3.9.0.
