### PR TITLE
Add TupleGenerator for heterogeneous parametrized-tests

### DIFF
--- a/src/catch2/generators/catch_generators_tuple.hpp
+++ b/src/catch2/generators/catch_generators_tuple.hpp
@@ -21,10 +21,10 @@ namespace Catch {
             struct is_tuple_like : std::false_type {};
 
             template <typename T>
-            struct is_tuple_like<
-                T,
-                std::void_t<decltype( std::tuple_size<T>::value ),
-                            decltype( std::get<0>( std::declval<T>() ) )>>
+            struct is_tuple_like<T,
+                                 decltype( void( std::tuple_size<T>::value ),
+                                           void( std::get<0>(
+                                               std::declval<T>() ) ) )>
                 : std::true_type {};
 
             template <typename Ret,

--- a/src/catch2/generators/catch_generators_tuple.hpp
+++ b/src/catch2/generators/catch_generators_tuple.hpp
@@ -1,0 +1,124 @@
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+#ifndef CATCH_GENERATORS_TUPLE_HPINCLUDED
+#define CATCH_GENERATORS_TUPLE_HPINCLUDED
+
+#include <catch2/generators/catch_generators.hpp>
+
+#include <array>
+#include <tuple>
+#include <type_traits>
+
+namespace Catch {
+    namespace Generators {
+        namespace Detail {
+
+            template <typename Ret,
+                      typename Tup,
+                      typename Fun,
+                      std::size_t... Idxs>
+            struct TupleRuntimeAccessTable {
+                template <std::size_t N>
+                static constexpr Ret access_tuple( Tup& tuple, Fun& fun ) {
+                    return fun( std::get<N>( tuple ) );
+                }
+
+                using AccessorFunPtr = Ret ( * )( Tup&, Fun& );
+                static constexpr std::size_t table_size{ sizeof...( Idxs ) };
+
+                static constexpr std::array<AccessorFunPtr, table_size>
+                    lookup_table{ { access_tuple<Idxs>... } };
+            };
+
+            template <typename Tup, typename Fun, std::size_t... Idxs>
+            constexpr auto
+            call_access_function( Tup& tuple,
+                                  std::size_t index,
+                                  Fun fun,
+                                  std::index_sequence<Idxs...> ) {
+                using FirstTupleIndexType = decltype( std::get<0>( tuple ) );
+                using FunReturnType =
+                    std::invoke_result_t<Fun, FirstTupleIndexType>;
+
+                constexpr auto& table{
+                    TupleRuntimeAccessTable<FunReturnType, Tup, Fun, Idxs...>::
+                        lookup_table };
+                return table[index]( tuple, fun );
+            }
+
+            template <typename Tup, typename Fun>
+            constexpr auto
+            runtime_get( Tup& tuple, std::size_t index, Fun fun ) {
+                return call_access_function(
+                    tuple,
+                    index,
+                    CATCH_FORWARD( fun ),
+                    std::make_index_sequence<std::tuple_size_v<Tup>>{} );
+            }
+
+            template <typename Tup>
+            class TupleAccessor {
+                Tup m_tuple;
+                std::size_t m_current_index;
+
+            public:
+                template <typename... Args>
+                constexpr TupleAccessor( Args&&... args ):
+                    m_tuple{ CATCH_FORWARD( args )... }, m_current_index{ 0 } {}
+
+                constexpr TupleAccessor& operator++() {
+                    ++m_current_index;
+                    return *this;
+                }
+
+                constexpr operator bool() const {
+                    return m_current_index < std::tuple_size_v<Tup>;
+                }
+
+                template <typename Fun>
+                constexpr auto perform( Fun fun ) const {
+                    return runtime_get(
+                        m_tuple, m_current_index, CATCH_FORWARD( fun ) );
+                }
+            };
+
+        } // namespace Detail
+
+        template <typename Tup>
+        class TupleGenerator final
+            : public IGenerator<Detail::TupleAccessor<Tup>> {
+            Detail::TupleAccessor<Tup> m_iterator;
+
+        public:
+            template <typename... Args>
+            TupleGenerator( Args&&... args ):
+                m_iterator{ CATCH_FORWARD( args )... } {}
+
+            const Detail::TupleAccessor<Tup>& get() const override {
+                return m_iterator;
+            }
+
+            bool next() override { return ++m_iterator; }
+        };
+
+        template <typename Tup, typename... Args>
+        auto tuple_as_range( Args&&... args ) {
+            return GeneratorWrapper<Detail::TupleAccessor<Tup>>(
+                Catch::Detail::make_unique<TupleGenerator<Tup>>(
+                    CATCH_FORWARD( args )... ) );
+        }
+
+        template <typename... Args>
+        auto tuple_as_range( Args&&... args ) {
+            return tuple_as_range<std::tuple<Args...>>(
+                CATCH_FORWARD( args )... );
+        }
+
+    } // namespace Generators
+} // namespace Catch
+
+#endif // CATCH_GENERATORS_TUPLE_HPINCLUDED

--- a/src/catch2/generators/catch_generators_tuple.hpp
+++ b/src/catch2/generators/catch_generators_tuple.hpp
@@ -16,25 +16,39 @@
 namespace Catch {
     namespace Generators {
         namespace Detail {
-            template <typename Ret, typename Tup, typename Fun, std::size_t N>
-            constexpr Ret access_tuple( Tup& tuple, Fun& fun ) {
+
+            template <typename T, typename = void>
+            struct is_tuple_like : std::false_type {};
+
+            template <typename T>
+            struct is_tuple_like<
+                T,
+                std::void_t<decltype( std::tuple_size<T>::value ),
+                            decltype( std::get<0>( std::declval<T>() ) )>>
+                : std::true_type {};
+
+            template <typename Ret,
+                      typename TupleType,
+                      typename Fun,
+                      std::size_t N>
+            constexpr Ret access_tuple( TupleType& tuple, Fun& fun ) {
                 return fun( std::get<N>( tuple ) );
             }
 
             template <typename Ret,
-                      typename Tup,
+                      typename TupleType,
                       typename Fun,
                       std::size_t... Idxs>
             constexpr auto tuple_runtime_access_table() {
-                using AccessorFunPtr = Ret ( * )( Tup&, Fun& );
+                using AccessorFunPtr = Ret ( * )( TupleType&, Fun& );
                 constexpr std::size_t table_size{ sizeof...( Idxs ) };
                 return std::array<AccessorFunPtr, table_size>{
-                    { access_tuple<Ret, Tup, Fun, Idxs>... } };
+                    { access_tuple<Ret, TupleType, Fun, Idxs>... } };
             }
 
-            template <typename Tup, typename Fun, std::size_t... Idxs>
+            template <typename TupleType, typename Fun, std::size_t... Idxs>
             constexpr auto
-            call_access_function( Tup& tuple,
+            call_access_function( TupleType& tuple,
                                   std::size_t index,
                                   Fun fun,
                                   std::index_sequence<Idxs...> ) {
@@ -47,39 +61,40 @@ namespace Catch {
 #endif
 
                 constexpr auto table{ tuple_runtime_access_table<FunReturnType,
-                                                                 Tup,
+                                                                 TupleType,
                                                                  Fun,
                                                                  Idxs...>() };
                 return table[index]( tuple, fun );
             }
 
-            template <typename Tup, typename Fun>
+            template <typename TupleType, typename Fun>
             constexpr auto
-            runtime_get( Tup& tuple, std::size_t index, Fun fun ) {
+            runtime_get( TupleType& tuple, std::size_t index, Fun fun ) {
                 return call_access_function(
                     tuple,
                     index,
                     CATCH_FORWARD( fun ),
-                    std::make_index_sequence<std::tuple_size<Tup>::value>{} );
+                    std::make_index_sequence<
+                        std::tuple_size<TupleType>::value>{} );
             }
 
-            template <typename Tup>
+            template <typename TupleType>
             class TupleAccessor {
-                Tup m_tuple;
+                TupleType m_tuple;
                 std::size_t m_current_index;
 
             public:
+                template <typename TupleLike>
+                constexpr TupleAccessor( TupleLike&& tuple ):
+                    m_tuple{ CATCH_FORWARD( tuple ) }, m_current_index{ 0 } {}
+
                 template <typename... Args>
                 constexpr TupleAccessor( Args&&... args ):
                     m_tuple{ CATCH_FORWARD( args )... }, m_current_index{ 0 } {}
 
-                constexpr TupleAccessor& operator++() {
+                constexpr bool next() {
                     ++m_current_index;
-                    return *this;
-                }
-
-                constexpr operator bool() const {
-                    return m_current_index < std::tuple_size<Tup>::value;
+                    return m_current_index < std::tuple_size<TupleType>::value;
                 }
 
                 template <typename Fun>
@@ -91,28 +106,44 @@ namespace Catch {
 
         } // namespace Detail
 
-        template <typename Tup>
+        template <typename TupleType>
         class TupleGenerator final
-            : public IGenerator<Detail::TupleAccessor<Tup>> {
-            Detail::TupleAccessor<Tup> m_iterator;
+            : public IGenerator<Detail::TupleAccessor<TupleType>> {
+            Detail::TupleAccessor<TupleType> m_iterator;
 
         public:
+            template <typename TupleLike>
+            TupleGenerator( TupleLike&& tuple ):
+                m_iterator{ CATCH_FORWARD( tuple ) } {}
+
             template <typename... Args>
             TupleGenerator( Args&&... args ):
                 m_iterator{ CATCH_FORWARD( args )... } {}
 
-            const Detail::TupleAccessor<Tup>& get() const override {
+            const Detail::TupleAccessor<TupleType>& get() const override {
                 return m_iterator;
             }
 
-            bool next() override { return ++m_iterator; }
+            bool next() override { return m_iterator.next(); }
         };
 
-        template <typename Tup, typename... Args>
+        template <typename TupleType,
+                  typename... Args,
+                  typename =
+                      std::enable_if_t<Detail::is_tuple_like<TupleType>::value>>
         auto tuple_as_range( Args&&... args ) {
-            return GeneratorWrapper<Detail::TupleAccessor<Tup>>(
-                Catch::Detail::make_unique<TupleGenerator<Tup>>(
+            return GeneratorWrapper<Detail::TupleAccessor<TupleType>>(
+                Catch::Detail::make_unique<TupleGenerator<TupleType>>(
                     CATCH_FORWARD( args )... ) );
+        }
+
+        template <typename TupleLike,
+                  typename TupleType =
+                      std::remove_cv_t<std::remove_reference_t<TupleLike>>,
+                  typename =
+                      std::enable_if_t<Detail::is_tuple_like<TupleType>::value>>
+        auto tuple_as_range( TupleLike&& tuple ) {
+            return tuple_as_range<TupleType>( CATCH_FORWARD( tuple ) );
         }
 
         template <typename... Args>

--- a/src/catch2/generators/catch_generators_tuple.hpp
+++ b/src/catch2/generators/catch_generators_tuple.hpp
@@ -16,23 +16,21 @@
 namespace Catch {
     namespace Generators {
         namespace Detail {
+            template <typename Ret, typename Tup, typename Fun, std::size_t N>
+            constexpr Ret access_tuple( Tup& tuple, Fun& fun ) {
+                return fun( std::get<N>( tuple ) );
+            }
 
             template <typename Ret,
                       typename Tup,
                       typename Fun,
                       std::size_t... Idxs>
-            struct TupleRuntimeAccessTable {
-                template <std::size_t N>
-                static constexpr Ret access_tuple( Tup& tuple, Fun& fun ) {
-                    return fun( std::get<N>( tuple ) );
-                }
-
+            constexpr auto tuple_runtime_access_table() {
                 using AccessorFunPtr = Ret ( * )( Tup&, Fun& );
-                static constexpr std::size_t table_size{ sizeof...( Idxs ) };
-
-                static constexpr std::array<AccessorFunPtr, table_size>
-                    lookup_table{ { access_tuple<Idxs>... } };
-            };
+                constexpr std::size_t table_size{ sizeof...( Idxs ) };
+                return std::array<AccessorFunPtr, table_size>{
+                    { access_tuple<Ret, Tup, Fun, Idxs>... } };
+            }
 
             template <typename Tup, typename Fun, std::size_t... Idxs>
             constexpr auto
@@ -42,11 +40,16 @@ namespace Catch {
                                   std::index_sequence<Idxs...> ) {
                 using FirstTupleIndexType = decltype( std::get<0>( tuple ) );
                 using FunReturnType =
+#ifdef __cpp_lib_is_invocable // C++ >= 17
                     std::invoke_result_t<Fun, FirstTupleIndexType>;
+#else
+                    std::result_of_t<Fun( FirstTupleIndexType )>;
+#endif
 
-                constexpr auto& table{
-                    TupleRuntimeAccessTable<FunReturnType, Tup, Fun, Idxs...>::
-                        lookup_table };
+                constexpr auto table{ tuple_runtime_access_table<FunReturnType,
+                                                                 Tup,
+                                                                 Fun,
+                                                                 Idxs...>() };
                 return table[index]( tuple, fun );
             }
 
@@ -57,7 +60,7 @@ namespace Catch {
                     tuple,
                     index,
                     CATCH_FORWARD( fun ),
-                    std::make_index_sequence<std::tuple_size_v<Tup>>{} );
+                    std::make_index_sequence<std::tuple_size<Tup>::value>{} );
             }
 
             template <typename Tup>
@@ -76,7 +79,7 @@ namespace Catch {
                 }
 
                 constexpr operator bool() const {
-                    return m_current_index < std::tuple_size_v<Tup>;
+                    return m_current_index < std::tuple_size<Tup>::value;
                 }
 
                 template <typename Fun>

--- a/src/catch2/generators/catch_generators_tuple.hpp
+++ b/src/catch2/generators/catch_generators_tuple.hpp
@@ -83,6 +83,22 @@ namespace Catch {
                 TupleType m_tuple;
                 std::size_t m_current_index;
 
+                template <typename TupleLike>
+                struct in_place_tuple {
+                    template <typename... Args>
+                    static constexpr TupleType make( Args&&... args ) {
+                        return TupleType{ CATCH_FORWARD( args )... };
+                    }
+                };
+
+                template <typename T, std::size_t N>
+                struct in_place_tuple<std::array<T, N>> {
+                    template <typename... Args>
+                    static constexpr TupleType make( Args&&... args ) {
+                        return TupleType{ { CATCH_FORWARD( args )... } };
+                    }
+                };
+
             public:
                 template <typename TupleLike>
                 constexpr TupleAccessor( TupleLike&& tuple ):
@@ -90,7 +106,9 @@ namespace Catch {
 
                 template <typename... Args>
                 constexpr TupleAccessor( Args&&... args ):
-                    m_tuple{ CATCH_FORWARD( args )... }, m_current_index{ 0 } {}
+                    m_tuple{ in_place_tuple<TupleType>::make(
+                        CATCH_FORWARD( args )... ) },
+                    m_current_index{ 0 } {}
 
                 constexpr bool next() {
                     ++m_current_index;

--- a/tests/SelfTest/UsageTests/Generators.tests.cpp
+++ b/tests/SelfTest/UsageTests/Generators.tests.cpp
@@ -7,12 +7,15 @@
 // SPDX-License-Identifier: BSL-1.0
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_tostring.hpp>
 #include <catch2/generators/catch_generator_exception.hpp>
 #include <catch2/generators/catch_generators_adapters.hpp>
 #include <catch2/generators/catch_generators_random.hpp>
 #include <catch2/generators/catch_generators_range.hpp>
+#include <catch2/generators/catch_generators_tuple.hpp>
 
 #include <cstring>
+#include <sstream>
 
 
 // Generators and sections can be nested freely
@@ -320,4 +323,37 @@ TEST_CASE( "GENERATE can combine literals and generators", "[generators]" ) {
                              filter( []( int val ) { return val % 2 == 0; },
                                      random( -100, 100 ) ) ) );
     REQUIRE( i % 2 == 0 );
+}
+
+TEST_CASE( "Tuple", "[generators]" ) {
+    // imagine two different serialization to test
+    // once a serialization is tested, the second must be identical
+    static const auto std_serialization{ []( const auto& element ) {
+        std::stringstream ss;
+        ss << element;
+        return ss.str();
+    } };
+    static const auto catch2_serialization{ []( const auto& element ) {
+        return Catch::StringMaker<decltype( element )>::convert( element );
+    } };
+
+    int counter{ 0 };
+
+    const auto accessor = GENERATE( tuple_as_range( 42, "foo", 3.14 ) );
+    accessor.perform( [&]( const auto& element ) {
+        REQUIRE( std_serialization( element ) ==
+                 catch2_serialization( element ) );
+        ++counter;
+    } );
+
+    // also work with std::pair or a tuple-like
+    const auto accessor_pair =
+        GENERATE( tuple_as_range<std::pair<int, std::string>>( 42, "foo" ) );
+    accessor_pair.perform( [&]( const auto& element ) {
+        REQUIRE( std_serialization( element ) ==
+                 catch2_serialization( element ) );
+        ++counter;
+    } );
+    
+    REQUIRE( counter == 2 );
 }

--- a/tests/SelfTest/UsageTests/Generators.tests.cpp
+++ b/tests/SelfTest/UsageTests/Generators.tests.cpp
@@ -326,34 +326,74 @@ TEST_CASE( "GENERATE can combine literals and generators", "[generators]" ) {
 }
 
 TEST_CASE( "Tuple", "[generators]" ) {
-    // imagine two different serialization to test
-    // once a serialization is tested, the second must be identical
-    static const auto std_serialization{ []( const auto& element ) {
-        std::stringstream ss;
-        ss << element;
-        return ss.str();
-    } };
-    static const auto catch2_serialization{ []( const auto& element ) {
-        return Catch::StringMaker<decltype( element )>::convert( element );
-    } };
+    SECTION( "Basic Use Case" ) {
+        // imagine two different serialization to test
+        // once a serialization is tested, the second must be identical
+        static const auto std_serialization{ []( const auto& element ) {
+            std::stringstream ss;
+            ss << element;
+            return ss.str();
+        } };
+        static const auto catch2_serialization{ []( const auto& element ) {
+            return Catch::StringMaker<decltype( element )>::convert( element );
+        } };
 
-    int counter{ 0 };
+        int counter{ 0 };
 
-    const auto accessor = GENERATE( tuple_as_range( 42, "foo", 3.14 ) );
-    accessor.perform( [&]( const auto& element ) {
-        REQUIRE( std_serialization( element ) ==
-                 catch2_serialization( element ) );
-        ++counter;
-    } );
+        SECTION( "Tuple Implicit" ) {
+            const auto accessor = GENERATE( tuple_as_range( 42, "foo", 3.14 ) );
+            accessor.perform( [&]( const auto& element ) {
+                REQUIRE( std_serialization( element ) ==
+                         catch2_serialization( element ) );
+                ++counter;
+            } );
+        }
 
-    // also work with std::pair or a tuple-like
-    const auto accessor_pair =
-        GENERATE( tuple_as_range<std::pair<int, std::string>>( 42, "foo" ) );
-    accessor_pair.perform( [&]( const auto& element ) {
-        REQUIRE( std_serialization( element ) ==
-                 catch2_serialization( element ) );
-        ++counter;
-    } );
-    
-    REQUIRE( counter == 2 );
+        SECTION( "Tuple Explicit" ) {
+            const auto accessor =
+                GENERATE( tuple_as_range<std::tuple<int, std::string, double>>(
+                    42, "foo", 3.14 ) );
+            accessor.perform( [&]( const auto& element ) {
+                REQUIRE( std_serialization( element ) ==
+                         catch2_serialization( element ) );
+                ++counter;
+            } );
+        }
+
+        // also work with std::pair or a tuple-like
+
+        SECTION( "Pair" ) {
+            const auto accessor_pair = GENERATE(
+                tuple_as_range<std::pair<int, std::string>>( 42, "foo" ) );
+            accessor_pair.perform( [&]( const auto& element ) {
+                REQUIRE( std_serialization( element ) ==
+                         catch2_serialization( element ) );
+                ++counter;
+            } );
+        }
+
+        REQUIRE( counter == 1 );
+    }
+
+    SECTION( "Single Parameter" ) {
+        SECTION( "Tuple" ) {
+            auto test = std::tuple<int, double, float>( 1, 2.0, 3.0f );
+            const auto accessor = GENERATE_REF( tuple_as_range( test ) );
+            SUCCEED();
+            std::ignore = accessor;
+        }
+
+        SECTION( "Pair" ) {
+            auto test = std::pair<int, std::string>( 42, "foo" );
+            const auto accessor = GENERATE_REF( tuple_as_range( test ) );
+            SUCCEED();
+            std::ignore = accessor;
+        }
+
+        SECTION( "Any" ) {
+            const auto accessor = GENERATE( tuple_as_range( 1 ) );
+            SUCCEED();
+            std::ignore = accessor;
+        }
+    }
 }

--- a/tests/SelfTest/UsageTests/Generators.tests.cpp
+++ b/tests/SelfTest/UsageTests/Generators.tests.cpp
@@ -372,6 +372,16 @@ TEST_CASE( "Tuple", "[generators]" ) {
             } );
         }
 
+        SECTION( "Array" ) {
+            const auto accessor_array =
+                GENERATE( tuple_as_range<std::array<int, 3>>( 1, 2, 3 ) );
+            accessor_array.perform( [&]( const auto& element ) {
+                REQUIRE( std_serialization( element ) ==
+                         catch2_serialization( element ) );
+                ++counter;
+            } );
+        }
+
         REQUIRE( counter == 1 );
     }
 
@@ -385,6 +395,13 @@ TEST_CASE( "Tuple", "[generators]" ) {
 
         SECTION( "Pair" ) {
             auto test = std::pair<int, std::string>( 42, "foo" );
+            const auto accessor = GENERATE_REF( tuple_as_range( test ) );
+            SUCCEED();
+            std::ignore = accessor;
+        }
+
+        SECTION( "Array" ) {
+            auto test = std::array<int, 3>{ { 1, 2, 3 } };
             const auto accessor = GENERATE_REF( tuple_as_range( test ) );
             SUCCEED();
             std::ignore = accessor;


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

Currently, Catch2's `GENERATE` macro supports individual values, ranges, and containers, but lacks native support for tuple-like generation in a single call.
This PR introduces an utility (`tuple_as_range`) to seamlessly generate tuples of heterogeneous types, enabling cleaner test cases with mixed-type inputs.

It is more or less like `TEMPLATE_TEST_CASE_SIG` but with the powerful of Catch2's generators.

Usage will be:

```cpp
TEST_CASE("Heterogeneous Generation", "[generators]") {
    auto accessor = GENERATE(tuple_as_range(42, "foo", 3.14));
    accessor.perform([](const auto& element) {
        // element is sequentially: 42, "foo", 3.14
    });
}
```

I will complete the PR with documentation, example and `_all` headers if you think it is a good add.

Both blogs inspired me:
https://www.fluentcpp.com/2019/03/08/stl-algorithms-on-tuples/
https://www.foonathan.net/2017/03/tuple-iterator/

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
None.