### PR TITLE
Suppress static analysis warning 26426 for Windows/MSVC builds

### DIFF
--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -220,7 +220,7 @@
 #    endif
 
 // Suppress MSVC C++ Core Guidelines checker warning 26426:
-// "Global initializer calls a non-constexpr function 'Catch::makeTestInvoker' (i.22)"
+// "Global initializer calls a non-constexpr function (i.22)"
 #    define CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
          __pragma( warning( disable : 26426 ) )
 

--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -219,6 +219,11 @@
             __pragma( warning( pop ) )
 #    endif
 
+// Suppress MSVC C++ Core Guidelines checker warning 26426:
+// "Global initializer calls a non-constexpr function 'Catch::makeTestInvoker' (i.22)"
+#    define CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
+         __pragma( warning( disable : 26426 ) )
+
 // Universal Windows platform does not support SEH
 #  if !defined(CATCH_PLATFORM_WINDOWS_UWP)
 #    define CATCH_INTERNAL_CONFIG_WINDOWS_SEH


### PR DESCRIPTION
Suppress `Global initializer calls a non-constexpr function 'Catch::makeTestInvoker' (i.22).`, which is issued when using macro `TEST_CASE` for windows/MSVC builds.

## Description
After switching from Catch v2 to v3, we received the following warning when using the “TEST_CASE” macro under Windows with VS 2022:
`Global initializer calls a non-constexpr function ‘Catch::makeTestInvoker’ (i.22).`

This is a static analysis that implements the C++ Core Guidelines rule `I.22: Avoid complex initialization of global objects.`

With my limited knowledge of Catch2, I don't feel confident making a change to `Catch::makeTestInvoker`, so I suggest using the existing mechanism of `CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS`. This will disable the warning in a more targeted manner.