### PR TITLE
Fix _NullFile for MinGW

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -483,7 +483,7 @@ set_tests_properties("ErrorHandling::InvalidTestSpecExitsEarly"
     FAIL_REGULAR_EXPRESSION "No tests ran"
 )
 
-if(MSVC)
+if(WIN32)
   set(_NullFile "NUL")
 else()
   set(_NullFile "/dev/null")

--- a/tests/ExtraTests/CMakeLists.txt
+++ b/tests/ExtraTests/CMakeLists.txt
@@ -273,7 +273,7 @@ set_tests_properties(Reporters::CapturedStdOutInEvents
     FAIL_REGULAR_EXPRESSION "X27 ERROR"
 )
 
-if(MSVC)
+if(WIN32)
   set(_NullFile "NUL")
 else()
   set(_NullFile "/dev/null")


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

Using `/dev/null` on MSys2/MinGW will cause 2 tests to fail, while `NUL` is ok.

```
49/74 Test #49: MultiReporter::CapturingReportersDontPropagateStdOut .........***Failed  Error regular expression found in output. Regex=[.+]  0.02 sec
Unable to open file: '/dev/null'

      Start 50: MultiReporter::NonCapturingReportersPropagateStdout
50/74 Test #50: MultiReporter::NonCapturingReportersPropagateStdout ..........***Failed  Required regular expression not found. Regex=[A string sent to stderr via clog
]  0.02 sec
Unable to open file: '/dev/null'
```

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
