### PR TITLE
🐛 Clang on Windows will define _MSC_VER and do a redefined-`#define`

### DIFF
--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -208,7 +208,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 // Visual C++
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 
 // We want to defer to nvcc-specific warning suppression if we are compiled
 // with nvcc masquerading for MSVC.


### PR DESCRIPTION
This double-define triggers warnings (and warnings-as-errors) and, unfortunately, halts some of my builds and CI ([like so](https://github.com/soasis/idk/actions/runs/20977171376/job/60531058530#step:6:1456)). It's certainly not a big problem, but the fix is simple and it would be nice.

## Description

When building on Windows with Clang or Clang-cl, the combination of `__clang__` and `_MSC_VER` being defined at the same time trips up a multi-definition error in the configuration of catch's internals for warning suppression.

This PR fixes that by being specifically for MSVC OR Clang, but not both.

## GitHub Issues

None (at least none I could find).