### PR TITLE
Silence warning -Wconversion in GCC 15.2 and -Wsign-conversion in Clang 21.1.8

### DIFF
--- a/src/catch2/catch_timer.cpp
+++ b/src/catch2/catch_timer.cpp
@@ -13,7 +13,10 @@ namespace Catch {
 
     namespace {
         static auto getCurrentNanosecondsSinceEpoch() -> uint64_t {
-            return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+            return static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::steady_clock::now().time_since_epoch() )
+                    .count() );
         }
     } // end unnamed namespace
 

--- a/src/catch2/internal/catch_run_context.cpp
+++ b/src/catch2/internal/catch_run_context.cpp
@@ -278,7 +278,7 @@ namespace Catch {
         m_config(_config),
         m_reporter(CATCH_MOVE(reporter)),
         m_outputRedirect( makeOutputRedirect( m_reporter->getPreferences().shouldRedirectStdOut ) ),
-        m_abortAfterXFailedAssertions( m_config->abortAfter() ),
+        m_abortAfterXFailedAssertions( static_cast<size_t>(m_config->abortAfter()) ),
         m_reportAssertionStarting( m_reporter->getPreferences().shouldReportAllAssertionStarts ),
         m_includeSuccessfulResults( m_config->includeSuccessfulResults() || m_reporter->getPreferences().shouldReportAllAssertions ),
         m_shouldDebugBreak( m_config->shouldDebugBreak() )

--- a/src/catch2/internal/catch_test_case_info_hasher.cpp
+++ b/src/catch2/internal/catch_test_case_info_hasher.cpp
@@ -17,16 +17,16 @@ namespace Catch {
         const hash_t prime = 1099511628211u;
         hash_t hash = 14695981039346656037u;
         for ( const char c : t.name ) {
-            hash ^= c;
+            hash ^= static_cast<unsigned char>( c );
             hash *= prime;
         }
         for ( const char c : t.className ) {
-            hash ^= c;
+            hash ^= static_cast<unsigned char>( c );
             hash *= prime;
         }
         for ( const Tag& tag : t.tags ) {
             for ( const char c : tag.original ) {
-                hash ^= c;
+                hash ^= static_cast<unsigned char>( c );
                 hash *= prime;
             }
         }

--- a/src/catch2/reporters/catch_reporter_console.cpp
+++ b/src/catch2/reporters/catch_reporter_console.cpp
@@ -354,7 +354,8 @@ public:
         }
         tp.m_currentColumn++;
 
-        auto colInfo = tp.m_columnInfos[tp.m_currentColumn];
+        auto colInfo =
+            tp.m_columnInfos[static_cast<size_t>( tp.m_currentColumn )];
         auto padding = (strSize + 1 < colInfo.width)
             ? std::string(colInfo.width - (strSize + 1), ' ')
             : std::string();

--- a/src/catch2/reporters/catch_reporter_helpers.cpp
+++ b/src/catch2/reporters/catch_reporter_helpers.cpp
@@ -205,7 +205,8 @@ namespace Catch {
 
         for ( auto const& tagCount : tags ) {
             ReusableStringStream rss;
-            rss << "  " << std::setw( maxTagCountLen ) << tagCount.count << "  ";
+            rss << "  " << std::setw( static_cast<int>( maxTagCountLen ) )
+                << tagCount.count << "  ";
             auto str = rss.str();
             auto wrapper = TextFlow::Column( tagCount.all() )
                                .initialIndent( 0 )

--- a/src/catch2/reporters/catch_reporter_multi.cpp
+++ b/src/catch2/reporters/catch_reporter_multi.cpp
@@ -25,7 +25,9 @@ namespace Catch {
 
     void MultiReporter::addListener( IEventListenerPtr&& listener ) {
         updatePreferences(*listener);
-        m_reporterLikes.insert(m_reporterLikes.begin() + m_insertedListeners, CATCH_MOVE(listener) );
+        m_reporterLikes.insert( m_reporterLikes.begin() +
+                                    static_cast<long>( m_insertedListeners ),
+                                CATCH_MOVE( listener ) );
         ++m_insertedListeners;
     }
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
This small PR add explicit cast from `size_t` to `int` when calling `std::setw(...)` to silence warning produced by GCC 15.2.

This also fixes conversions between sign types in Clang 21.1.8.
