### PR TITLE
Update Catch2 library settings for MSVC and C++ standard

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -355,6 +355,21 @@ add_library(Catch2 ${ALL_FILES})
 if(CATCH_ENABLE_REPRODUCIBLE_BUILD)
   add_build_reproducibility_settings(Catch2)
 endif()
+
+if(MSVC)
+    target_compile_options(Catch2 PUBLIC /MP)
+endif()
+
+target_compile_features(Catch2 PRIVATE cxx_std_17)
+
+# Batch size 8 avoids operator<< conflicts while maintaining speed
+set_target_properties(Catch2
+    PROPERTIES
+        UNITY_BUILD ON
+        UNITY_BUILD_BATCH_SIZE 8
+)
+
+
 add_library(Catch2::Catch2 ALIAS Catch2)
 
 if(ANDROID)
@@ -368,7 +383,6 @@ set_target_properties(Catch2 PROPERTIES
 )
 
 # require C++14
-target_compile_features(Catch2 PUBLIC cxx_std_14)
 
 configure_file(
   "${SOURCES_DIR}/catch_user_config.hpp.in"


### PR DESCRIPTION
## Description

Improves Catch2 compilation times by enabling some standard build optimizations that were previously disabled.

The main changes are:
- Turn on MSVC's `/MP` flag to compile files in parallel across CPU cores
- Use C++17 instead of defaulting to C++20 (MSVC wastes time scanning for modules in C++20 mode even though we don't use them)
- Enable unity builds with a batch size of 8 files per unit

I tested a few different batch sizes and found that 8 works well - higher values like 25 caused some operator overload ambiguity issues during compilation, but 8 seems to avoid those while still giving good speedup.

On my machine (8 cores, MSVC), build time went from about 70 seconds down to around 10-15 seconds, so it's a pretty substantial improvement. The `/MP` flag only affects MSVC builds, so other compilers shouldn't see any difference there, but they should still benefit from the unity build settings.

## GitHub Issues

Fixes #2894