### PR TITLE
Fix catch_discover_tests PRE_TEST failure with zero discoverable tests

### DIFF
--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -146,6 +146,7 @@ function(catch_discover_tests_impl)
 
   # Exit early if no tests are detected
   if(num_tests STREQUAL "0")
+    file(WRITE "${_CTEST_FILE}" "")
     return()
   endif()
 


### PR DESCRIPTION
## Summary

When using `catch_discover_tests()` with `DISCOVERY_MODE PRE_TEST` and a multi-config generator (e.g., Ninja Multi-Config), if a test target has zero discoverable tests (e.g., all tests tagged with `[.]`), `ctest` fails with:

```
CMake Error at .../test-hidden-b12d07c_include-Release.cmake:26 (include):
  include could not find requested file:
    .../test-hidden-b12d07c_tests-Release.cmake
```

This error aborts all test discovery, preventing any tests from running — even from other targets that have tests.

## Root Cause

The early return added in #2962 (76f70b14) correctly prevented a JSON parsing crash for zero tests, but skipped `file(WRITE "${_CTEST_FILE}" ...)`. The `PRE_TEST` code path in `Catch.cmake` unconditionally `include()`s this file (line 282), so the missing file causes a hard error.

The `POST_BUILD` code path is unaffected because it wraps the include in `if(EXISTS ...)`.

## Fix

Write an empty file before the early return so the `include()` always succeeds.

## Reproduction

Minimal project with two test targets — one normal, one with only hidden (`[.]`) tests:

<details>
<summary>CMakeLists.txt</summary>

```cmake
cmake_minimum_required(VERSION 3.22)
project(catch2-pretest-bug LANGUAGES CXX)

include(FetchContent)
FetchContent_Declare(
    Catch2
    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
    GIT_TAG v3.13.0
)
FetchContent_MakeAvailable(Catch2)
list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
include(Catch)

enable_testing()
set(CMAKE_CATCH_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST)

add_executable(test-normal test-normal.cpp)
target_link_libraries(test-normal PRIVATE Catch2::Catch2WithMain)
catch_discover_tests(test-normal)

add_executable(test-hidden test-hidden.cpp)
target_link_libraries(test-hidden PRIVATE Catch2::Catch2WithMain)
catch_discover_tests(test-hidden)
```

</details>

<details>
<summary>test-normal.cpp</summary>

```cpp
#include <catch2/catch_test_macros.hpp>

TEST_CASE("Normal test") {
    REQUIRE(1 + 1 == 2);
}
```

</details>

<details>
<summary>test-hidden.cpp</summary>

```cpp
#include <catch2/catch_test_macros.hpp>

// All tests are hidden (tagged with [.]), so --list-tests returns zero results.
TEST_CASE("Hardware-dependent test", "[.DUT]") {
    REQUIRE(true);
}
```

</details>

<details>
<summary>CMakePresets.json</summary>

```json
{
    "version": 6,
    "configurePresets": [
        {
            "name": "default",
            "generator": "Ninja Multi-Config",
            "binaryDir": "${sourceDir}/build"
        }
    ],
    "buildPresets": [
        {
            "name": "release",
            "configurePreset": "default",
            "configuration": "Release"
        }
    ]
}
```

</details>

```
cmake --preset default
cmake --build --preset release
ctest --test-dir build --build-config Release
# Error: include could not find requested file: .../test-hidden-b12d07c_tests-Release.cmake
```

After this fix, `test-normal` runs and passes; `test-hidden` is gracefully skipped.