### PR TITLE
Suppress __COUNTER__ pedantic warning on Clang

### DIFF
--- a/src/catch2/internal/catch_unique_name.hpp
+++ b/src/catch2/internal/catch_unique_name.hpp
@@ -11,8 +11,16 @@
 #include <catch2/internal/catch_config_counter.hpp>
 #define INTERNAL_CATCH_UNIQUE_NAME_LINE2( name, line ) name##line
 #define INTERNAL_CATCH_UNIQUE_NAME_LINE( name, line ) INTERNAL_CATCH_UNIQUE_NAME_LINE2( name, line )
+
 #ifdef CATCH_CONFIG_COUNTER
+#  ifdef __clang__
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wc2y-extensions"
+#  endif
 #  define INTERNAL_CATCH_UNIQUE_NAME( name ) INTERNAL_CATCH_UNIQUE_NAME_LINE( name, __COUNTER__ )
+#  ifdef __clang__
+#    pragma clang diagnostic pop
+#  endif
 #else
 #  define INTERNAL_CATCH_UNIQUE_NAME( name ) INTERNAL_CATCH_UNIQUE_NAME_LINE( name, __LINE__ )
 #endif

--- a/src/catch2/internal/catch_unique_name.hpp
+++ b/src/catch2/internal/catch_unique_name.hpp
@@ -15,6 +15,7 @@
 #ifdef CATCH_CONFIG_COUNTER
 #  ifdef __clang__
 #    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wunknown-warning-option"
 #    pragma clang diagnostic ignored "-Wc2y-extensions"
 #  endif
 #  define INTERNAL_CATCH_UNIQUE_NAME( name ) INTERNAL_CATCH_UNIQUE_NAME_LINE( name, __COUNTER__ )


### PR DESCRIPTION
## Description

Clang 22 with `-pedantic-errors` treats `__COUNTER__` as a C2y
extension and emits a hard error on every `TEST_CASE()` usage.

This fix wraps the `__COUNTER__` usage in `catch_unique_name.hpp`
with Clang-specific diagnostic pragmas to suppress `-Wc2y-extensions`
locally, without affecting any other compiler or warning.

## GitHub Issues

Closes #3076