### PR TITLE
JUnit reporter: emit only first failure per testcase

### DIFF
--- a/src/catch2/reporters/catch_reporter_junit.cpp
+++ b/src/catch2/reporters/catch_reporter_junit.cpp
@@ -218,12 +218,13 @@ namespace Catch {
             // events and write those out appropriately.
             xml.writeAttribute( "status"_sr, "run"_sr );
 
+            bool resultElementEmitted = false;
             if (sectionNode.stats.assertions.failedButOk) {
                 xml.scopedElement("skipped")
                     .writeAttribute("message", "TEST_CASE tagged with !mayfail");
             }
 
-            writeAssertions( sectionNode );
+            writeAssertions( sectionNode, resultElementEmitted );
 
 
             if( !sectionNode.stdOut.empty() )
@@ -238,18 +239,26 @@ namespace Catch {
                 writeSection( className, name, *childNode, testOkToFail );
     }
 
-    void JunitReporter::writeAssertions( SectionNode const& sectionNode ) {
+    void JunitReporter::writeAssertions( SectionNode const& sectionNode,
+                                           bool& resultElementEmitted ) {
         for (auto const& assertionOrBenchmark : sectionNode.assertionsAndBenchmarks) {
             if (assertionOrBenchmark.isAssertion()) {
-                writeAssertion(assertionOrBenchmark.asAssertion());
+                writeAssertion(assertionOrBenchmark.asAssertion(),
+                               resultElementEmitted);
             }
         }
     }
 
-    void JunitReporter::writeAssertion( AssertionStats const& stats ) {
+    void JunitReporter::writeAssertion( AssertionStats const& stats,
+                                        bool& resultElementEmitted ) {
         AssertionResult const& result = stats.assertionResult;
         if ( !result.isOk() ||
              result.getResultType() == ResultWas::ExplicitSkip ) {
+            // JUnit XML allows at most one of failure/error/skipped per testcase
+            if (resultElementEmitted) {
+                return;
+            }
+            resultElementEmitted = true;
             std::string elementName;
             switch( result.getResultType() ) {
                 case ResultWas::ThrewException:

--- a/src/catch2/reporters/catch_reporter_junit.cpp
+++ b/src/catch2/reporters/catch_reporter_junit.cpp
@@ -218,13 +218,12 @@ namespace Catch {
             // events and write those out appropriately.
             xml.writeAttribute( "status"_sr, "run"_sr );
 
-            bool resultElementEmitted = false;
             if (sectionNode.stats.assertions.failedButOk) {
                 xml.scopedElement("skipped")
                     .writeAttribute("message", "TEST_CASE tagged with !mayfail");
             }
 
-            writeAssertions( sectionNode, resultElementEmitted );
+            writeAssertions( sectionNode );
 
 
             if( !sectionNode.stdOut.empty() )
@@ -239,8 +238,8 @@ namespace Catch {
                 writeSection( className, name, *childNode, testOkToFail );
     }
 
-    void JunitReporter::writeAssertions( SectionNode const& sectionNode,
-                                           bool& resultElementEmitted ) {
+    void JunitReporter::writeAssertions( SectionNode const& sectionNode ) {
+        bool resultElementEmitted = false;
         for (auto const& assertionOrBenchmark : sectionNode.assertionsAndBenchmarks) {
             if (assertionOrBenchmark.isAssertion()) {
                 writeAssertion(assertionOrBenchmark.asAssertion(),

--- a/src/catch2/reporters/catch_reporter_junit.hpp
+++ b/src/catch2/reporters/catch_reporter_junit.hpp
@@ -40,8 +40,7 @@ namespace Catch {
                            SectionNode const& sectionNode,
                            bool testOkToFail );
 
-        void writeAssertions(SectionNode const& sectionNode,
-                             bool& resultElementEmitted);
+        void writeAssertions(SectionNode const& sectionNode);
         void writeAssertion(AssertionStats const& stats, bool& resultElementEmitted);
 
         XmlWriter xml;

--- a/src/catch2/reporters/catch_reporter_junit.hpp
+++ b/src/catch2/reporters/catch_reporter_junit.hpp
@@ -40,8 +40,9 @@ namespace Catch {
                            SectionNode const& sectionNode,
                            bool testOkToFail );
 
-        void writeAssertions(SectionNode const& sectionNode);
-        void writeAssertion(AssertionStats const& stats);
+        void writeAssertions(SectionNode const& sectionNode,
+                             bool& resultElementEmitted);
+        void writeAssertion(AssertionStats const& stats, bool& resultElementEmitted);
 
         XmlWriter xml;
         Timer suiteTimer;

--- a/tests/SelfTest/Baselines/junit.sw.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.approved.txt
@@ -107,51 +107,6 @@ FAILED:
   CHECK( false != false )
 at Condition.tests.cpp:<line number>
       </failure>
-      <failure message="true != true" type="CHECK">
-FAILED:
-  CHECK( true != true )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="!true" type="CHECK">
-FAILED:
-  CHECK( !true )
-with expansion:
-  false
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="!(true)" type="CHECK_FALSE">
-FAILED:
-  CHECK_FALSE( true )
-with expansion:
-  !true
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="!trueValue" type="CHECK">
-FAILED:
-  CHECK( !trueValue )
-with expansion:
-  false
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="!(trueValue)" type="CHECK_FALSE">
-FAILED:
-  CHECK_FALSE( trueValue )
-with expansion:
-  !true
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="!(1 == 1)" type="CHECK">
-FAILED:
-  CHECK( !(1 == 1) )
-with expansion:
-  false
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="!(1 == 1)" type="CHECK_FALSE">
-FAILED:
-  CHECK_FALSE( 1 == 1 )
-at Condition.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="'Not' checks that should succeed" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="(unimplemented) static bools can be evaluated" time="{duration}" status="run"/>
@@ -360,13 +315,6 @@ with expansion:
   0x<hex digits> == 0x<hex digits>
 at Tricky.tests.cpp:<line number>
       </failure>
-      <failure message="o1 == o2" type="CHECK">
-FAILED:
-  CHECK( o1 == o2 )
-with expansion:
-  {?} == {?}
-at Tricky.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Absolute margin" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="An empty test with no assertions" time="{duration}" status="run"/>
@@ -400,12 +348,6 @@ with expansion:
   2 > 10
 at AssertionHandler.tests.cpp:<line number>
       </failure>
-      <error message="foo( 2 ) == 2" type="CHECK">
-FAILED:
-  CHECK( foo( 2 ) == 2 )
-{ nested assertion failed }
-at AssertionHandler.tests.cpp:<line number>
-      </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="Assertions can be nested - REQUIRE" time="{duration}" status="run">
       <skipped message="TEST_CASE tagged with !mayfail"/>
@@ -416,12 +358,6 @@ with expansion:
   2 > 10
 at AssertionHandler.tests.cpp:<line number>
       </failure>
-      <error message="foo( 2 ) == 2" type="REQUIRE">
-FAILED:
-  REQUIRE( foo( 2 ) == 2 )
-{ nested assertion failed }
-at AssertionHandler.tests.cpp:<line number>
-      </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="Assertions then sections" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Assertions then sections/A section" time="{duration}" status="run"/>
@@ -513,13 +449,6 @@ with expansion:
   insensitive)
 at Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="testStringForMatching(), ContainsSubstring( &quot;STRING&quot; )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( testStringForMatching(), ContainsSubstring( "STRING" ) )
-with expansion:
-  "this string contains 'abc' as a substring" contains: "STRING"
-at Matchers.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Copy and then generate a range" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Copy and then generate a range/from var and iterators" time="{duration}" status="run"/>
@@ -576,14 +505,6 @@ with expansion:
   "this string contains 'abc' as a substring" ends with: "Substring"
 at Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="testStringForMatching(), EndsWith( &quot;this&quot;, Catch::CaseSensitive::No )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( testStringForMatching(), EndsWith( "this", Catch::CaseSensitive::No ) )
-with expansion:
-  "this string contains 'abc' as a substring" ends with: "this" (case
-  insensitive)
-at Matchers.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Enums can quickly have stringification enabled using CATCH_REGISTER_ENUM" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Enums in namespaces can quickly have stringification enabled using CATCH_REGISTER_ENUM" time="{duration}" status="run"/>
@@ -595,96 +516,6 @@ FAILED:
   CHECK( data.int_seven == 6 )
 with expansion:
   7 == 6
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven == 8" type="CHECK">
-FAILED:
-  CHECK( data.int_seven == 8 )
-with expansion:
-  7 == 8
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven == 0" type="CHECK">
-FAILED:
-  CHECK( data.int_seven == 0 )
-with expansion:
-  7 == 0
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one == Approx( 9.11f )" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one == Approx( 9.11f ) )
-with expansion:
-  9.100000381f
-  ==
-  Approx( 9.10999965667724609 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one == Approx( 9.0f )" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one == Approx( 9.0f ) )
-with expansion:
-  9.100000381f == Approx( 9.0 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one == Approx( 1 )" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one == Approx( 1 ) )
-with expansion:
-  9.100000381f == Approx( 1.0 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one == Approx( 0 )" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one == Approx( 0 ) )
-with expansion:
-  9.100000381f == Approx( 0.0 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.double_pi == Approx( 3.1415 )" type="CHECK">
-FAILED:
-  CHECK( data.double_pi == Approx( 3.1415 ) )
-with expansion:
-  3.14159265350000005
-  ==
-  Approx( 3.14150000000000018 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello == &quot;goodbye&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello == "goodbye" )
-with expansion:
-  "hello" == "goodbye"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello == &quot;hell&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello == "hell" )
-with expansion:
-  "hello" == "hell"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello == &quot;hello1&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello == "hello1" )
-with expansion:
-  "hello" == "hello1"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello.size() == 6" type="CHECK">
-FAILED:
-  CHECK( data.str_hello.size() == 6 )
-with expansion:
-  5 == 6
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="x == Approx( 1.301 )" type="CHECK">
-FAILED:
-  CHECK( x == Approx( 1.301 ) )
-with expansion:
-  1.30000000000000027
-  ==
-  Approx( 1.30099999999999993 )
 at Condition.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -699,25 +530,12 @@ with expansion:
   'ABC' as a substring"
 at Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="testStringForMatching(), Equals( &quot;something else&quot;, Catch::CaseSensitive::No )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( testStringForMatching(), Equals( "something else", Catch::CaseSensitive::No ) )
-with expansion:
-  "this string contains 'abc' as a substring" equals: "something else" (case
-  insensitive)
-at Matchers.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Exception as a value (e.g. in REQUIRE_THROWS_MATCHES) can be stringified" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Exception matchers that fail/No exception" time="{duration}" status="run">
       <failure message="doesNotThrow(), SpecialException, ExceptionMatcher{ 1 }" type="CHECK_THROWS_MATCHES">
 FAILED:
   CHECK_THROWS_MATCHES( doesNotThrow(), SpecialException, ExceptionMatcher{ 1 } )
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="doesNotThrow(), SpecialException, ExceptionMatcher{ 1 }" type="REQUIRE_THROWS_MATCHES">
-FAILED:
-  REQUIRE_THROWS_MATCHES( doesNotThrow(), SpecialException, ExceptionMatcher{ 1 } )
 at Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -728,24 +546,11 @@ FAILED:
 Unknown exception
 at Matchers.tests.cpp:<line number>
       </error>
-      <error message="throwsAsInt( 1 ), SpecialException, ExceptionMatcher{ 1 }" type="REQUIRE_THROWS_MATCHES">
-FAILED:
-  REQUIRE_THROWS_MATCHES( throwsAsInt( 1 ), SpecialException, ExceptionMatcher{ 1 } )
-Unknown exception
-at Matchers.tests.cpp:<line number>
-      </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="Exception matchers that fail/Contents are wrong" time="{duration}" status="run">
       <failure message="throwsSpecialException( 3 ), SpecialException, ExceptionMatcher{ 1 }" type="CHECK_THROWS_MATCHES">
 FAILED:
   CHECK_THROWS_MATCHES( throwsSpecialException( 3 ), SpecialException, ExceptionMatcher{ 1 } )
-with expansion:
-  SpecialException::what special exception has value of 1
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="throwsSpecialException( 4 ), SpecialException, ExceptionMatcher{ 1 }" type="REQUIRE_THROWS_MATCHES">
-FAILED:
-  REQUIRE_THROWS_MATCHES( throwsSpecialException( 4 ), SpecialException, ExceptionMatcher{ 1 } )
 with expansion:
   SpecialException::what special exception has value of 1
 at Matchers.tests.cpp:<line number>
@@ -766,17 +571,6 @@ FAILED:
 expected exception
 at Exception.tests.cpp:<line number>
       </error>
-      <failure message="thisDoesntThrow(), std::domain_error" type="CHECK_THROWS_AS">
-FAILED:
-  CHECK_THROWS_AS( thisDoesntThrow(), std::domain_error )
-at Exception.tests.cpp:<line number>
-      </failure>
-      <error message="thisThrows()" type="CHECK_NOTHROW">
-FAILED:
-  CHECK_NOTHROW( thisThrows() )
-expected exception
-at Exception.tests.cpp:<line number>
-      </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="FAIL aborts the test" time="{duration}" status="run">
       <failure type="FAIL">
@@ -792,12 +586,6 @@ FAILED:
 Throw a Catch::TestFailureException
 at AssertionHandler.tests.cpp:<line number>
       </failure>
-      <error message="do_fail()" type="CHECK_NOTHROW">
-FAILED:
-  CHECK_NOTHROW( do_fail() )
-{ nested assertion failed }
-at AssertionHandler.tests.cpp:<line number>
-      </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="FAIL does not require an argument" time="{duration}" status="run">
       <failure type="FAIL">
@@ -933,16 +721,6 @@ this message may be logged later
 this message should be logged
 at Message.tests.cpp:<line number>
       </failure>
-      <failure message="a == 0" type="CHECK">
-FAILED:
-  CHECK( a == 0 )
-with expansion:
-  2 == 0
-this message may be logged later
-this message should be logged
-and this, but later
-at Message.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="INFO is reset for each loop" time="{duration}" status="run">
       <failure message="i &lt; 10" type="REQUIRE">
@@ -971,38 +749,6 @@ FAILED:
   CHECK( data.int_seven != 7 )
 with expansion:
   7 != 7
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one != Approx( 9.1f )" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one != Approx( 9.1f ) )
-with expansion:
-  9.100000381f
-  !=
-  Approx( 9.10000038146972656 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.double_pi != Approx( 3.1415926535 )" type="CHECK">
-FAILED:
-  CHECK( data.double_pi != Approx( 3.1415926535 ) )
-with expansion:
-  3.14159265350000005
-  !=
-  Approx( 3.14159265350000005 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello != &quot;hello&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello != "hello" )
-with expansion:
-  "hello" != "hello"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello.size() != 5" type="CHECK">
-FAILED:
-  CHECK( data.str_hello.size() != 5 )
-with expansion:
-  5 != 5
 at Condition.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -1127,132 +873,6 @@ FAILED:
   CHECK( data.int_seven > 7 )
 with expansion:
   7 > 7
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven &lt; 7" type="CHECK">
-FAILED:
-  CHECK( data.int_seven &lt; 7 )
-with expansion:
-  7 &lt; 7
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven > 8" type="CHECK">
-FAILED:
-  CHECK( data.int_seven > 8 )
-with expansion:
-  7 > 8
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven &lt; 6" type="CHECK">
-FAILED:
-  CHECK( data.int_seven &lt; 6 )
-with expansion:
-  7 &lt; 6
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven &lt; 0" type="CHECK">
-FAILED:
-  CHECK( data.int_seven &lt; 0 )
-with expansion:
-  7 &lt; 0
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven &lt; -1" type="CHECK">
-FAILED:
-  CHECK( data.int_seven &lt; -1 )
-with expansion:
-  7 &lt; -1
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven >= 8" type="CHECK">
-FAILED:
-  CHECK( data.int_seven >= 8 )
-with expansion:
-  7 >= 8
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven &lt;= 6" type="CHECK">
-FAILED:
-  CHECK( data.int_seven &lt;= 6 )
-with expansion:
-  7 &lt;= 6
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one &lt; 9" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one &lt; 9 )
-with expansion:
-  9.100000381f &lt; 9
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one > 10" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one > 10 )
-with expansion:
-  9.100000381f > 10
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one > 9.2" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one > 9.2 )
-with expansion:
-  9.100000381f > 9.19999999999999929
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello > &quot;hello&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello > "hello" )
-with expansion:
-  "hello" > "hello"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello &lt; &quot;hello&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello &lt; "hello" )
-with expansion:
-  "hello" &lt; "hello"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello > &quot;hellp&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello > "hellp" )
-with expansion:
-  "hello" > "hellp"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello > &quot;z&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello > "z" )
-with expansion:
-  "hello" > "z"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello &lt; &quot;hellm&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello &lt; "hellm" )
-with expansion:
-  "hello" &lt; "hellm"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello &lt; &quot;a&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello &lt; "a" )
-with expansion:
-  "hello" &lt; "a"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello >= &quot;z&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello >= "z" )
-with expansion:
-  "hello" >= "z"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello &lt;= &quot;a&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello &lt;= "a" )
-with expansion:
-  "hello" &lt;= "a"
 at Condition.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -1384,22 +1004,6 @@ with expansion:
   'abc' as a substring" case sensitively
 at Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="testStringForMatching(), Matches( &quot;contains 'abc' as a substring&quot; )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( testStringForMatching(), Matches( "contains 'abc' as a substring" ) )
-with expansion:
-  "this string contains 'abc' as a substring" matches "contains 'abc' as a
-  substring" case sensitively
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="testStringForMatching(), Matches( &quot;this string contains 'abc' as a&quot; )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( testStringForMatching(), Matches( "this string contains 'abc' as a" ) )
-with expansion:
-  "this string contains 'abc' as a substring" matches "this string contains
-  'abc' as a" case sensitively
-at Matchers.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Registering reporter with '::' in name fails" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Regression test #1" time="{duration}" status="run"/>
@@ -1464,12 +1068,6 @@ FAILED:
 This will be reported multiple times
 at Message.tests.cpp:<line number>
       </failure>
-      <failure message="false" type="CHECK">
-FAILED:
-  CHECK( false )
-This will be reported multiple times
-at Message.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Scoped messages do not leave block with an exception" time="{duration}" status="run">
       <failure message="false" type="REQUIRE">
@@ -1512,14 +1110,6 @@ FAILED:
   CHECK_THAT( testStringForMatching(), StartsWith( "This String" ) )
 with expansion:
   "this string contains 'abc' as a substring" starts with: "This String"
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="testStringForMatching(), StartsWith( &quot;string&quot;, Catch::CaseSensitive::No )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( testStringForMatching(), StartsWith( "string", Catch::CaseSensitive::No ) )
-with expansion:
-  "this string contains 'abc' as a substring" starts with: "string" (case
-  insensitive)
 at Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -1875,13 +1465,6 @@ with expansion:
   { 1, 2, 3 } Contains: -1
 at Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="empty, VectorContains( 1 )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( empty, VectorContains( 1 ) )
-with expansion:
-  {  } Contains: 1
-at Matchers.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Vector matchers that fail/Contains (vector)" time="{duration}" status="run">
       <failure message="empty, Contains( v )" type="CHECK_THAT">
@@ -1889,13 +1472,6 @@ FAILED:
   CHECK_THAT( empty, Contains( v ) )
 with expansion:
   {  } Contains: { 1, 2, 3 }
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="v, Contains( v2 )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( v, Contains( v2 ) )
-with expansion:
-  { 1, 2, 3 } Contains: { 1, 2, 4 }
 at Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -1907,27 +1483,6 @@ with expansion:
   { 1, 2, 3 } Equals: { 1, 2 }
 at Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="v2, Equals( v )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( v2, Equals( v ) )
-with expansion:
-  { 1, 2 } Equals: { 1, 2, 3 }
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="empty, Equals( v )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( empty, Equals( v ) )
-with expansion:
-  {  } Equals: { 1, 2, 3 }
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="v, Equals( empty )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( v, Equals( empty ) )
-with expansion:
-  { 1, 2, 3 } Equals: {  }
-at Matchers.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Vector matchers that fail/UnorderedEquals" time="{duration}" status="run">
       <failure message="v, UnorderedEquals( empty )" type="CHECK_THAT">
@@ -1935,27 +1490,6 @@ FAILED:
   CHECK_THAT( v, UnorderedEquals( empty ) )
 with expansion:
   { 1, 2, 3 } UnorderedEquals: {  }
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="empty, UnorderedEquals( v )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( empty, UnorderedEquals( v ) )
-with expansion:
-  {  } UnorderedEquals: { 1, 2, 3 }
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="permuted, UnorderedEquals( v )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( permuted, UnorderedEquals( v ) )
-with expansion:
-  { 1, 3 } UnorderedEquals: { 1, 2, 3 }
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="permuted, UnorderedEquals( v )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( permuted, UnorderedEquals( v ) )
-with expansion:
-  { 3, 1 } UnorderedEquals: { 1, 2, 3 }
 at Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -2065,11 +1599,6 @@ SKIPPED
 skipping because answer = 41
 at Skip.tests.cpp:<line number>
       </skipped>
-      <skipped type="SKIP">
-SKIPPED
-skipping because answer = 43
-at Skip.tests.cpp:<line number>
-      </skipped>
     </testcase>
     <testcase classname="<exe-name>.global" name="empty tags are not allowed" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="erfc_inv" time="{duration}" status="run"/>
@@ -2086,28 +1615,12 @@ FAILED:
   CHECK( 3 == 4 )
 at Skip.tests.cpp:<line number>
       </failure>
-      <skipped type="SKIP">
-SKIPPED
-at Skip.tests.cpp:<line number>
-      </skipped>
     </testcase>
     <testcase classname="<exe-name>.global" name="failing for some generator values causes entire test case to fail" time="{duration}" status="run">
       <failure type="FAIL">
 FAILED:
 at Skip.tests.cpp:<line number>
       </failure>
-      <skipped type="SKIP">
-SKIPPED
-at Skip.tests.cpp:<line number>
-      </skipped>
-      <failure type="FAIL">
-FAILED:
-at Skip.tests.cpp:<line number>
-      </failure>
-      <skipped type="SKIP">
-SKIPPED
-at Skip.tests.cpp:<line number>
-      </skipped>
     </testcase>
     <testcase classname="<exe-name>.global" name="failing in some unskipped sections causes entire test case to fail/skipped" time="{duration}" status="run">
       <skipped type="SKIP">
@@ -2176,46 +1689,6 @@ FAILED:
 with expansion:
   1 == 0
 Testing if fib[0] (1) is even
-at Misc.tests.cpp:<line number>
-      </failure>
-      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
-FAILED:
-  CHECK( ( fib[i] % 2 ) == 0 )
-with expansion:
-  1 == 0
-Testing if fib[1] (1) is even
-at Misc.tests.cpp:<line number>
-      </failure>
-      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
-FAILED:
-  CHECK( ( fib[i] % 2 ) == 0 )
-with expansion:
-  1 == 0
-Testing if fib[3] (3) is even
-at Misc.tests.cpp:<line number>
-      </failure>
-      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
-FAILED:
-  CHECK( ( fib[i] % 2 ) == 0 )
-with expansion:
-  1 == 0
-Testing if fib[4] (5) is even
-at Misc.tests.cpp:<line number>
-      </failure>
-      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
-FAILED:
-  CHECK( ( fib[i] % 2 ) == 0 )
-with expansion:
-  1 == 0
-Testing if fib[6] (13) is even
-at Misc.tests.cpp:<line number>
-      </failure>
-      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
-FAILED:
-  CHECK( ( fib[i] % 2 ) == 0 )
-with expansion:
-  1 == 0
-Testing if fib[7] (21) is even
 at Misc.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -2360,15 +1833,6 @@ Count 1 to 3...
 1
 2
 3
-at Message.tests.cpp:<line number>
-      </failure>
-      <failure message="false" type="CHECK">
-FAILED:
-  CHECK( false )
-Count 4 to 6...
-4
-5
-6
 at Message.tests.cpp:<line number>
       </failure>
     </testcase>

--- a/tests/SelfTest/Baselines/junit.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.multi.approved.txt
@@ -106,51 +106,6 @@ FAILED:
   CHECK( false != false )
 at Condition.tests.cpp:<line number>
       </failure>
-      <failure message="true != true" type="CHECK">
-FAILED:
-  CHECK( true != true )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="!true" type="CHECK">
-FAILED:
-  CHECK( !true )
-with expansion:
-  false
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="!(true)" type="CHECK_FALSE">
-FAILED:
-  CHECK_FALSE( true )
-with expansion:
-  !true
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="!trueValue" type="CHECK">
-FAILED:
-  CHECK( !trueValue )
-with expansion:
-  false
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="!(trueValue)" type="CHECK_FALSE">
-FAILED:
-  CHECK_FALSE( trueValue )
-with expansion:
-  !true
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="!(1 == 1)" type="CHECK">
-FAILED:
-  CHECK( !(1 == 1) )
-with expansion:
-  false
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="!(1 == 1)" type="CHECK_FALSE">
-FAILED:
-  CHECK_FALSE( 1 == 1 )
-at Condition.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="'Not' checks that should succeed" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="(unimplemented) static bools can be evaluated" time="{duration}" status="run"/>
@@ -359,13 +314,6 @@ with expansion:
   0x<hex digits> == 0x<hex digits>
 at Tricky.tests.cpp:<line number>
       </failure>
-      <failure message="o1 == o2" type="CHECK">
-FAILED:
-  CHECK( o1 == o2 )
-with expansion:
-  {?} == {?}
-at Tricky.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Absolute margin" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="An empty test with no assertions" time="{duration}" status="run"/>
@@ -399,12 +347,6 @@ with expansion:
   2 > 10
 at AssertionHandler.tests.cpp:<line number>
       </failure>
-      <error message="foo( 2 ) == 2" type="CHECK">
-FAILED:
-  CHECK( foo( 2 ) == 2 )
-{ nested assertion failed }
-at AssertionHandler.tests.cpp:<line number>
-      </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="Assertions can be nested - REQUIRE" time="{duration}" status="run">
       <skipped message="TEST_CASE tagged with !mayfail"/>
@@ -415,12 +357,6 @@ with expansion:
   2 > 10
 at AssertionHandler.tests.cpp:<line number>
       </failure>
-      <error message="foo( 2 ) == 2" type="REQUIRE">
-FAILED:
-  REQUIRE( foo( 2 ) == 2 )
-{ nested assertion failed }
-at AssertionHandler.tests.cpp:<line number>
-      </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="Assertions then sections" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Assertions then sections/A section" time="{duration}" status="run"/>
@@ -512,13 +448,6 @@ with expansion:
   insensitive)
 at Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="testStringForMatching(), ContainsSubstring( &quot;STRING&quot; )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( testStringForMatching(), ContainsSubstring( "STRING" ) )
-with expansion:
-  "this string contains 'abc' as a substring" contains: "STRING"
-at Matchers.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Copy and then generate a range" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Copy and then generate a range/from var and iterators" time="{duration}" status="run"/>
@@ -575,14 +504,6 @@ with expansion:
   "this string contains 'abc' as a substring" ends with: "Substring"
 at Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="testStringForMatching(), EndsWith( &quot;this&quot;, Catch::CaseSensitive::No )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( testStringForMatching(), EndsWith( "this", Catch::CaseSensitive::No ) )
-with expansion:
-  "this string contains 'abc' as a substring" ends with: "this" (case
-  insensitive)
-at Matchers.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Enums can quickly have stringification enabled using CATCH_REGISTER_ENUM" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Enums in namespaces can quickly have stringification enabled using CATCH_REGISTER_ENUM" time="{duration}" status="run"/>
@@ -594,96 +515,6 @@ FAILED:
   CHECK( data.int_seven == 6 )
 with expansion:
   7 == 6
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven == 8" type="CHECK">
-FAILED:
-  CHECK( data.int_seven == 8 )
-with expansion:
-  7 == 8
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven == 0" type="CHECK">
-FAILED:
-  CHECK( data.int_seven == 0 )
-with expansion:
-  7 == 0
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one == Approx( 9.11f )" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one == Approx( 9.11f ) )
-with expansion:
-  9.100000381f
-  ==
-  Approx( 9.10999965667724609 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one == Approx( 9.0f )" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one == Approx( 9.0f ) )
-with expansion:
-  9.100000381f == Approx( 9.0 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one == Approx( 1 )" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one == Approx( 1 ) )
-with expansion:
-  9.100000381f == Approx( 1.0 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one == Approx( 0 )" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one == Approx( 0 ) )
-with expansion:
-  9.100000381f == Approx( 0.0 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.double_pi == Approx( 3.1415 )" type="CHECK">
-FAILED:
-  CHECK( data.double_pi == Approx( 3.1415 ) )
-with expansion:
-  3.14159265350000005
-  ==
-  Approx( 3.14150000000000018 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello == &quot;goodbye&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello == "goodbye" )
-with expansion:
-  "hello" == "goodbye"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello == &quot;hell&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello == "hell" )
-with expansion:
-  "hello" == "hell"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello == &quot;hello1&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello == "hello1" )
-with expansion:
-  "hello" == "hello1"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello.size() == 6" type="CHECK">
-FAILED:
-  CHECK( data.str_hello.size() == 6 )
-with expansion:
-  5 == 6
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="x == Approx( 1.301 )" type="CHECK">
-FAILED:
-  CHECK( x == Approx( 1.301 ) )
-with expansion:
-  1.30000000000000027
-  ==
-  Approx( 1.30099999999999993 )
 at Condition.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -698,25 +529,12 @@ with expansion:
   'ABC' as a substring"
 at Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="testStringForMatching(), Equals( &quot;something else&quot;, Catch::CaseSensitive::No )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( testStringForMatching(), Equals( "something else", Catch::CaseSensitive::No ) )
-with expansion:
-  "this string contains 'abc' as a substring" equals: "something else" (case
-  insensitive)
-at Matchers.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Exception as a value (e.g. in REQUIRE_THROWS_MATCHES) can be stringified" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Exception matchers that fail/No exception" time="{duration}" status="run">
       <failure message="doesNotThrow(), SpecialException, ExceptionMatcher{ 1 }" type="CHECK_THROWS_MATCHES">
 FAILED:
   CHECK_THROWS_MATCHES( doesNotThrow(), SpecialException, ExceptionMatcher{ 1 } )
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="doesNotThrow(), SpecialException, ExceptionMatcher{ 1 }" type="REQUIRE_THROWS_MATCHES">
-FAILED:
-  REQUIRE_THROWS_MATCHES( doesNotThrow(), SpecialException, ExceptionMatcher{ 1 } )
 at Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -727,24 +545,11 @@ FAILED:
 Unknown exception
 at Matchers.tests.cpp:<line number>
       </error>
-      <error message="throwsAsInt( 1 ), SpecialException, ExceptionMatcher{ 1 }" type="REQUIRE_THROWS_MATCHES">
-FAILED:
-  REQUIRE_THROWS_MATCHES( throwsAsInt( 1 ), SpecialException, ExceptionMatcher{ 1 } )
-Unknown exception
-at Matchers.tests.cpp:<line number>
-      </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="Exception matchers that fail/Contents are wrong" time="{duration}" status="run">
       <failure message="throwsSpecialException( 3 ), SpecialException, ExceptionMatcher{ 1 }" type="CHECK_THROWS_MATCHES">
 FAILED:
   CHECK_THROWS_MATCHES( throwsSpecialException( 3 ), SpecialException, ExceptionMatcher{ 1 } )
-with expansion:
-  SpecialException::what special exception has value of 1
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="throwsSpecialException( 4 ), SpecialException, ExceptionMatcher{ 1 }" type="REQUIRE_THROWS_MATCHES">
-FAILED:
-  REQUIRE_THROWS_MATCHES( throwsSpecialException( 4 ), SpecialException, ExceptionMatcher{ 1 } )
 with expansion:
   SpecialException::what special exception has value of 1
 at Matchers.tests.cpp:<line number>
@@ -765,17 +570,6 @@ FAILED:
 expected exception
 at Exception.tests.cpp:<line number>
       </error>
-      <failure message="thisDoesntThrow(), std::domain_error" type="CHECK_THROWS_AS">
-FAILED:
-  CHECK_THROWS_AS( thisDoesntThrow(), std::domain_error )
-at Exception.tests.cpp:<line number>
-      </failure>
-      <error message="thisThrows()" type="CHECK_NOTHROW">
-FAILED:
-  CHECK_NOTHROW( thisThrows() )
-expected exception
-at Exception.tests.cpp:<line number>
-      </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="FAIL aborts the test" time="{duration}" status="run">
       <failure type="FAIL">
@@ -791,12 +585,6 @@ FAILED:
 Throw a Catch::TestFailureException
 at AssertionHandler.tests.cpp:<line number>
       </failure>
-      <error message="do_fail()" type="CHECK_NOTHROW">
-FAILED:
-  CHECK_NOTHROW( do_fail() )
-{ nested assertion failed }
-at AssertionHandler.tests.cpp:<line number>
-      </error>
     </testcase>
     <testcase classname="<exe-name>.global" name="FAIL does not require an argument" time="{duration}" status="run">
       <failure type="FAIL">
@@ -932,16 +720,6 @@ this message may be logged later
 this message should be logged
 at Message.tests.cpp:<line number>
       </failure>
-      <failure message="a == 0" type="CHECK">
-FAILED:
-  CHECK( a == 0 )
-with expansion:
-  2 == 0
-this message may be logged later
-this message should be logged
-and this, but later
-at Message.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="INFO is reset for each loop" time="{duration}" status="run">
       <failure message="i &lt; 10" type="REQUIRE">
@@ -970,38 +748,6 @@ FAILED:
   CHECK( data.int_seven != 7 )
 with expansion:
   7 != 7
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one != Approx( 9.1f )" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one != Approx( 9.1f ) )
-with expansion:
-  9.100000381f
-  !=
-  Approx( 9.10000038146972656 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.double_pi != Approx( 3.1415926535 )" type="CHECK">
-FAILED:
-  CHECK( data.double_pi != Approx( 3.1415926535 ) )
-with expansion:
-  3.14159265350000005
-  !=
-  Approx( 3.14159265350000005 )
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello != &quot;hello&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello != "hello" )
-with expansion:
-  "hello" != "hello"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello.size() != 5" type="CHECK">
-FAILED:
-  CHECK( data.str_hello.size() != 5 )
-with expansion:
-  5 != 5
 at Condition.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -1126,132 +872,6 @@ FAILED:
   CHECK( data.int_seven > 7 )
 with expansion:
   7 > 7
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven &lt; 7" type="CHECK">
-FAILED:
-  CHECK( data.int_seven &lt; 7 )
-with expansion:
-  7 &lt; 7
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven > 8" type="CHECK">
-FAILED:
-  CHECK( data.int_seven > 8 )
-with expansion:
-  7 > 8
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven &lt; 6" type="CHECK">
-FAILED:
-  CHECK( data.int_seven &lt; 6 )
-with expansion:
-  7 &lt; 6
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven &lt; 0" type="CHECK">
-FAILED:
-  CHECK( data.int_seven &lt; 0 )
-with expansion:
-  7 &lt; 0
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven &lt; -1" type="CHECK">
-FAILED:
-  CHECK( data.int_seven &lt; -1 )
-with expansion:
-  7 &lt; -1
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven >= 8" type="CHECK">
-FAILED:
-  CHECK( data.int_seven >= 8 )
-with expansion:
-  7 >= 8
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.int_seven &lt;= 6" type="CHECK">
-FAILED:
-  CHECK( data.int_seven &lt;= 6 )
-with expansion:
-  7 &lt;= 6
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one &lt; 9" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one &lt; 9 )
-with expansion:
-  9.100000381f &lt; 9
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one > 10" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one > 10 )
-with expansion:
-  9.100000381f > 10
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.float_nine_point_one > 9.2" type="CHECK">
-FAILED:
-  CHECK( data.float_nine_point_one > 9.2 )
-with expansion:
-  9.100000381f > 9.19999999999999929
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello > &quot;hello&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello > "hello" )
-with expansion:
-  "hello" > "hello"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello &lt; &quot;hello&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello &lt; "hello" )
-with expansion:
-  "hello" &lt; "hello"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello > &quot;hellp&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello > "hellp" )
-with expansion:
-  "hello" > "hellp"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello > &quot;z&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello > "z" )
-with expansion:
-  "hello" > "z"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello &lt; &quot;hellm&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello &lt; "hellm" )
-with expansion:
-  "hello" &lt; "hellm"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello &lt; &quot;a&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello &lt; "a" )
-with expansion:
-  "hello" &lt; "a"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello >= &quot;z&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello >= "z" )
-with expansion:
-  "hello" >= "z"
-at Condition.tests.cpp:<line number>
-      </failure>
-      <failure message="data.str_hello &lt;= &quot;a&quot;" type="CHECK">
-FAILED:
-  CHECK( data.str_hello &lt;= "a" )
-with expansion:
-  "hello" &lt;= "a"
 at Condition.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -1383,22 +1003,6 @@ with expansion:
   'abc' as a substring" case sensitively
 at Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="testStringForMatching(), Matches( &quot;contains 'abc' as a substring&quot; )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( testStringForMatching(), Matches( "contains 'abc' as a substring" ) )
-with expansion:
-  "this string contains 'abc' as a substring" matches "contains 'abc' as a
-  substring" case sensitively
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="testStringForMatching(), Matches( &quot;this string contains 'abc' as a&quot; )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( testStringForMatching(), Matches( "this string contains 'abc' as a" ) )
-with expansion:
-  "this string contains 'abc' as a substring" matches "this string contains
-  'abc' as a" case sensitively
-at Matchers.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Registering reporter with '::' in name fails" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Regression test #1" time="{duration}" status="run"/>
@@ -1463,12 +1067,6 @@ FAILED:
 This will be reported multiple times
 at Message.tests.cpp:<line number>
       </failure>
-      <failure message="false" type="CHECK">
-FAILED:
-  CHECK( false )
-This will be reported multiple times
-at Message.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Scoped messages do not leave block with an exception" time="{duration}" status="run">
       <failure message="false" type="REQUIRE">
@@ -1511,14 +1109,6 @@ FAILED:
   CHECK_THAT( testStringForMatching(), StartsWith( "This String" ) )
 with expansion:
   "this string contains 'abc' as a substring" starts with: "This String"
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="testStringForMatching(), StartsWith( &quot;string&quot;, Catch::CaseSensitive::No )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( testStringForMatching(), StartsWith( "string", Catch::CaseSensitive::No ) )
-with expansion:
-  "this string contains 'abc' as a substring" starts with: "string" (case
-  insensitive)
 at Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -1874,13 +1464,6 @@ with expansion:
   { 1, 2, 3 } Contains: -1
 at Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="empty, VectorContains( 1 )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( empty, VectorContains( 1 ) )
-with expansion:
-  {  } Contains: 1
-at Matchers.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Vector matchers that fail/Contains (vector)" time="{duration}" status="run">
       <failure message="empty, Contains( v )" type="CHECK_THAT">
@@ -1888,13 +1471,6 @@ FAILED:
   CHECK_THAT( empty, Contains( v ) )
 with expansion:
   {  } Contains: { 1, 2, 3 }
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="v, Contains( v2 )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( v, Contains( v2 ) )
-with expansion:
-  { 1, 2, 3 } Contains: { 1, 2, 4 }
 at Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -1906,27 +1482,6 @@ with expansion:
   { 1, 2, 3 } Equals: { 1, 2 }
 at Matchers.tests.cpp:<line number>
       </failure>
-      <failure message="v2, Equals( v )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( v2, Equals( v ) )
-with expansion:
-  { 1, 2 } Equals: { 1, 2, 3 }
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="empty, Equals( v )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( empty, Equals( v ) )
-with expansion:
-  {  } Equals: { 1, 2, 3 }
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="v, Equals( empty )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( v, Equals( empty ) )
-with expansion:
-  { 1, 2, 3 } Equals: {  }
-at Matchers.tests.cpp:<line number>
-      </failure>
     </testcase>
     <testcase classname="<exe-name>.global" name="Vector matchers that fail/UnorderedEquals" time="{duration}" status="run">
       <failure message="v, UnorderedEquals( empty )" type="CHECK_THAT">
@@ -1934,27 +1489,6 @@ FAILED:
   CHECK_THAT( v, UnorderedEquals( empty ) )
 with expansion:
   { 1, 2, 3 } UnorderedEquals: {  }
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="empty, UnorderedEquals( v )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( empty, UnorderedEquals( v ) )
-with expansion:
-  {  } UnorderedEquals: { 1, 2, 3 }
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="permuted, UnorderedEquals( v )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( permuted, UnorderedEquals( v ) )
-with expansion:
-  { 1, 3 } UnorderedEquals: { 1, 2, 3 }
-at Matchers.tests.cpp:<line number>
-      </failure>
-      <failure message="permuted, UnorderedEquals( v )" type="CHECK_THAT">
-FAILED:
-  CHECK_THAT( permuted, UnorderedEquals( v ) )
-with expansion:
-  { 3, 1 } UnorderedEquals: { 1, 2, 3 }
 at Matchers.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -2064,11 +1598,6 @@ SKIPPED
 skipping because answer = 41
 at Skip.tests.cpp:<line number>
       </skipped>
-      <skipped type="SKIP">
-SKIPPED
-skipping because answer = 43
-at Skip.tests.cpp:<line number>
-      </skipped>
     </testcase>
     <testcase classname="<exe-name>.global" name="empty tags are not allowed" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="erfc_inv" time="{duration}" status="run"/>
@@ -2085,28 +1614,12 @@ FAILED:
   CHECK( 3 == 4 )
 at Skip.tests.cpp:<line number>
       </failure>
-      <skipped type="SKIP">
-SKIPPED
-at Skip.tests.cpp:<line number>
-      </skipped>
     </testcase>
     <testcase classname="<exe-name>.global" name="failing for some generator values causes entire test case to fail" time="{duration}" status="run">
       <failure type="FAIL">
 FAILED:
 at Skip.tests.cpp:<line number>
       </failure>
-      <skipped type="SKIP">
-SKIPPED
-at Skip.tests.cpp:<line number>
-      </skipped>
-      <failure type="FAIL">
-FAILED:
-at Skip.tests.cpp:<line number>
-      </failure>
-      <skipped type="SKIP">
-SKIPPED
-at Skip.tests.cpp:<line number>
-      </skipped>
     </testcase>
     <testcase classname="<exe-name>.global" name="failing in some unskipped sections causes entire test case to fail/skipped" time="{duration}" status="run">
       <skipped type="SKIP">
@@ -2175,46 +1688,6 @@ FAILED:
 with expansion:
   1 == 0
 Testing if fib[0] (1) is even
-at Misc.tests.cpp:<line number>
-      </failure>
-      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
-FAILED:
-  CHECK( ( fib[i] % 2 ) == 0 )
-with expansion:
-  1 == 0
-Testing if fib[1] (1) is even
-at Misc.tests.cpp:<line number>
-      </failure>
-      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
-FAILED:
-  CHECK( ( fib[i] % 2 ) == 0 )
-with expansion:
-  1 == 0
-Testing if fib[3] (3) is even
-at Misc.tests.cpp:<line number>
-      </failure>
-      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
-FAILED:
-  CHECK( ( fib[i] % 2 ) == 0 )
-with expansion:
-  1 == 0
-Testing if fib[4] (5) is even
-at Misc.tests.cpp:<line number>
-      </failure>
-      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
-FAILED:
-  CHECK( ( fib[i] % 2 ) == 0 )
-with expansion:
-  1 == 0
-Testing if fib[6] (13) is even
-at Misc.tests.cpp:<line number>
-      </failure>
-      <failure message="( fib[i] % 2 ) == 0" type="CHECK">
-FAILED:
-  CHECK( ( fib[i] % 2 ) == 0 )
-with expansion:
-  1 == 0
-Testing if fib[7] (21) is even
 at Misc.tests.cpp:<line number>
       </failure>
     </testcase>
@@ -2359,15 +1832,6 @@ Count 1 to 3...
 1
 2
 3
-at Message.tests.cpp:<line number>
-      </failure>
-      <failure message="false" type="CHECK">
-FAILED:
-  CHECK( false )
-Count 4 to 6...
-4
-5
-6
 at Message.tests.cpp:<line number>
       </failure>
     </testcase>


### PR DESCRIPTION
## Summary

The JUnit XML reporter previously emitted multiple `<failure>`, `<error>`, or `<skipped>` elements for a single `<testcase>` when several assertions failed (e.g. multiple `CHECK`s). Common JUnit consumers assume **at most one** such child per testcase, which breaks tools like [junitparser](https://github.com/gastlygem/junitparser) with errors such as “Only one result allowed per test case.”

This change tracks whether a result element was already written for the current testcase section and **suppresses further assertion result elements** after the first.

## Related issue

Fixes #1919

## Testing

- `python tools/scripts/approvalTests.py <path-to-SelfTest> <temp-dir>` — updated `junit.sw` / `junit.sw.multi` baselines
- `ctest -C Debug -R RunTests --test-dir <build-dir>`