### PR TITLE
fix: add missing backslash in macro definition

### DIFF
--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -110,7 +110,7 @@
 #        define CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS \
 	         _Pragma( "clang diagnostic ignored \"-Wc++20-extensions\"" )
 #    else
-#        define CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS
+#        define CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS \
              _Pragma( "clang diagnostic ignored \"-Wgnu-zero-variadic-macro-arguments\"" )
 #    endif
 


### PR DESCRIPTION
## Description
This PR adds a missing backslash in one of the definitions of `CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS`. This typo was introduced in v3.8.1. The inclusion of this backslash fixes as issue we were facing in https://github.com/libsemigroups/libsemigroups/pull/931 upon updating from v3.8.0 to v3.13.0.

## Minimal reproducible example
The following is a minimal reproducible example that demonstrates the error being thrown in our CI pipeline:

**Contents of `test.cpp`**:
```cpp
#include <string>  // for string
#include <vector>  // for vector

#pragma GCC diagnostic push
#include "catch_amalgamated.hpp"  // for TEMPLATE_TEST_CASE
#pragma GCC diagnostic pop

TEMPLATE_TEST_CASE("example", "[quick]", int, std::string) {
  std::vector<TestType> v(5);
  REQUIRE(v.size() == 5);
}
```

**Compile command**:
```bash
> clang++ -Werror -Wgnu-zero-variadic-macro-arguments -std=gnu++17 test.cpp catch_amalgamated.cpp -o test
```

**File structure**:
```
.
├── catch_amalgamated.cpp
├── catch_amalgamated.hpp
└── test.cpp
```

**Expected output**:
File compiles (which is achieved upon applying the changes in this PR).

**Actual output**:
```
test.cpp:8:1: error: must specify at least one argument for '...' parameter of variadic macro [-Werror,-Wgnu-zero-variadic-macro-arguments]
    8 | TEMPLATE_TEST_CASE("example", "[quick]", int, std::string) {
      | ^
./catch_amalgamated.hpp:7021:39: note: expanded from macro 'TEMPLATE_TEST_CASE'
 7021 |     #define TEMPLATE_TEST_CASE( ... ) INTERNAL_CATCH_TEMPLATE_TEST_CASE( __VA_ARGS__ )
      |                                       ^
./catch_amalgamated.hpp:6734:9: note: expanded from macro 'INTERNAL_CATCH_TEMPLATE_TEST_CASE'
 6734 |         INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( CATCH2_INTERNAL_TEMPLATE_TEST_ ), INTERNAL_CATCH_UNIQUE_NAME( CATCH2_INTERNAL_TEMPLATE_TEST_ ), Name, Tags, typename TestType, __VA_ARGS__ )
      |         ^
./catch_amalgamated.hpp:6712:13: note: expanded from macro 'INTERNAL_CATCH_TEMPLATE_TEST_CASE_2'
 6712 |             INTERNAL_CATCH_NTTP_GEN(INTERNAL_CATCH_REMOVE_PARENS(Signature))\
      |             ^
./catch_amalgamated.hpp:6625:465: note: expanded from macro 'INTERNAL_CATCH_NTTP_GEN'
 6625 | #define INTERNAL_CATCH_NTTP_GEN(...) INTERNAL_CATCH_VA_NARGS_IMPL(__VA_ARGS__, INTERNAL_CATCH_NTTP_1(__VA_ARGS__), INTERNAL_CATCH_NTTP_1(__VA_ARGS__), INTERNAL_CATCH_NTTP_1(__VA_ARGS__), INTERNAL_CATCH_NTTP_1(__VA_ARGS__), INTERNAL_CATCH_NTTP_1(__VA_ARGS__), INTERNAL_CATCH_NTTP_1( __VA_ARGS__), INTERNAL_CATCH_NTTP_1( __VA_ARGS__), INTERNAL_CATCH_NTTP_1( __VA_ARGS__), INTERNAL_CATCH_NTTP_1( __VA_ARGS__),INTERNAL_CATCH_NTTP_1( __VA_ARGS__), INTERNAL_CATCH_NTTP_0)
      |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 ^
./catch_amalgamated.hpp:6508:9: note: macro 'INTERNAL_CATCH_VA_NARGS_IMPL' defined here
 6508 | #define INTEclang++ --version
Ubuntu clang version 18.1.3 (1ubuntu1)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/binRNAL_CATCH_VA_NARGS_IMPL(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
      |         ^
test.cpp:8:1: error: must specify at least one argument for '...' parameter of variadic macro [-Werror,-Wgnu-zero-variadic-macro-arguments]
    8 | TEMPLATE_TEST_CASE("example", "[quick]", int, std::string) {
      | ^
./catch_amalgamated.hpp:7021:39: note: expanded from macro 'TEMPLATE_TEST_CASE'
 7021 |     #define TEMPLATE_TEST_CASE( ... ) INTERNAL_CATCH_TEMPLATE_TEST_CASE( __VA_ARGS__ )
      |                                       ^
./catch_amalgamated.hpp:6734:9: note: expanded from macro 'INTERNAL_CATCH_TEMPLATE_TEST_CASE'
 6734 |         INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( CATCH2_INTERNAL_TEMPLATE_TEST_ ), INTERNAL_CATCH_UNIQUE_NAME( CATCH2_INTERNAL_TEMPLATE_TEST_ ), Name, Tags, typename TestType, __VA_ARGS__ )
      |         ^
./catch_amalgamated.hpp:6724:22: note: expanded from macro 'INTERNAL_CATCH_TEMPLATE_TEST_CASE_2'
 6724 |             TestName<INTERNAL_CATCH_MAKE_TYPE_LISTS_FROM_TYPES(__VA_ARGS__)>();\
      |                      ^
./catch_amalgamated.hpp:6494:20: note: expanded from macro 'INTERNAL_CATCH_MAKE_TYPE_LISTS_FROM_TYPES'
 6494 |     CATCH_REC_LIST(INTERNAL_CATCH_MAKE_TYPE_LIST,__VA_ARGS__)
      |                    ^
./catch_amalgamated.hpp:6508:9: note: macro 'INTERNAL_CATCH_VA_NARGS_IMPL' defined here
 6508 | #define INTERNAL_CATCH_VA_NARGS_IMPL(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
      |         ^
test.cpp:8:1: error: must specify at least one argument for '...' parameter of variadic macro [-Werror,-Wgnu-zero-variadic-macro-arguments]
    8 | TEMPLATE_TEST_CASE("example", "[quick]", int, std::string) {
      | ^
./catch_amalgamated.hpp:7021:39: note: expanded from macro 'TEMPLATE_TEST_CASE'
 7021 |     #define TEMPLATE_TEST_CASE( ... ) INTERNAL_CATCH_TEMPLATE_TEST_CASE( __VA_ARGS__ )
      |                                       ^
./catch_amalgamated.hpp:6734:9: note: expanded from macro 'INTERNAL_CATCH_TEMPLATE_TEST_CASE'
 6734 |         INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( CATCH2_INTERNAL_TEMPLATE_TEST_ ), INTERNAL_CATCH_UNIQUE_NAME( CATCH2_INTERNAL_TEMPLATE_TEST_ ), Name, Tags, typename TestType, __VA_ARGS__ )
      |         ^
./catch_amalgamated.hpp:6724:22: note: expanded from macro 'INTERNAL_CATCH_TEMPLATE_TEST_CASE_2'
 6724 |             TestName<INTERNAL_CATCH_MAKE_TYPE_LISTS_FROM_TYPES(__VA_ARGS__)>();\
      |                      ^
./catch_amalgamated.hpp:6494:20: note: expanded from macro 'INTERNAL_CATCH_MAKE_TYPE_LISTS_FROM_TYPES'
 6494 |     CATCH_REC_LIST(INTERNAL_CATCH_MAKE_TYPE_LIST,__VA_ARGS__)
      |                    ^
./catch_amalgamated.hpp:6508:9: note: macro 'INTERNAL_CATCH_VA_NARGS_IMPL' defined here
 6508 | #define INTERNAL_CATCH_VA_NARGS_IMPL(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
      |         ^
3 errors generated.
```

**Other useful information**:
```bash
> clang++ --version
Ubuntu clang version 18.1.3 (1ubuntu1)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

## Testing
I have tested locally that the changes in this PR fix the errors outlined above; however, I wasn't sure how to add tests to the Catch2 test suite that illustrate this. I'd be happy to add tests here with a little bit of guidance!