### PR TITLE
Suppress GCC -Weffc++ and -Wctor-dtor-privacy warnings in public headers

### DIFF
--- a/src/catch2/catch_all.hpp
+++ b/src/catch2/catch_all.hpp
@@ -53,6 +53,9 @@
 #include <catch2/internal/catch_commandline.hpp>
 #include <catch2/internal/catch_compare_traits.hpp>
 #include <catch2/internal/catch_compiler_capabilities.hpp>
+CATCH_INTERNAL_START_WARNINGS_SUPPRESSION
+CATCH_INTERNAL_SUPPRESS_EFFCPP_WARNINGS
+CATCH_INTERNAL_SUPPRESS_CTOR_DTOR_PRIVACY_WARNINGS
 #include <catch2/internal/catch_config_android_logwrite.hpp>
 #include <catch2/internal/catch_config_counter.hpp>
 #include <catch2/internal/catch_config_prefix_messages.hpp>
@@ -137,5 +140,7 @@
 #include <catch2/internal/catch_xmlwriter.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
 #include <catch2/reporters/catch_reporters_all.hpp>
+
+CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
 #endif // CATCH_ALL_HPP_INCLUDED

--- a/src/catch2/catch_session.hpp
+++ b/src/catch2/catch_session.hpp
@@ -8,6 +8,12 @@
 #ifndef CATCH_SESSION_HPP_INCLUDED
 #define CATCH_SESSION_HPP_INCLUDED
 
+#include <catch2/internal/catch_compiler_capabilities.hpp>
+
+CATCH_INTERNAL_START_WARNINGS_SUPPRESSION
+CATCH_INTERNAL_SUPPRESS_EFFCPP_WARNINGS
+CATCH_INTERNAL_SUPPRESS_CTOR_DTOR_PRIVACY_WARNINGS
+
 #include <catch2/internal/catch_commandline.hpp>
 #include <catch2/internal/catch_noncopyable.hpp>
 #include <catch2/catch_config.hpp>
@@ -66,5 +72,7 @@ namespace Catch {
     };
 
 } // end namespace Catch
+
+CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
 #endif // CATCH_SESSION_HPP_INCLUDED

--- a/src/catch2/catch_template_test_macros.hpp
+++ b/src/catch2/catch_template_test_macros.hpp
@@ -8,6 +8,8 @@
 #ifndef CATCH_TEMPLATE_TEST_MACROS_HPP_INCLUDED
 #define CATCH_TEMPLATE_TEST_MACROS_HPP_INCLUDED
 
+#include <catch2/internal/catch_compiler_capabilities.hpp>
+
 // We need this suppression to leak, because it took until GCC 10
 // for the front end to handle local suppression via _Pragma properly
 // inside templates (so `TEMPLATE_TEST_CASE` and co).
@@ -15,6 +17,10 @@
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC) && __GNUC__ < 10
 #pragma GCC diagnostic ignored "-Wparentheses"
 #endif
+
+CATCH_INTERNAL_START_WARNINGS_SUPPRESSION
+CATCH_INTERNAL_SUPPRESS_EFFCPP_WARNINGS
+CATCH_INTERNAL_SUPPRESS_CTOR_DTOR_PRIVACY_WARNINGS
 
 
 #include <catch2/catch_test_macros.hpp>
@@ -120,5 +126,6 @@
 
 #endif // end of user facing macro declarations
 
+CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
 #endif // CATCH_TEMPLATE_TEST_MACROS_HPP_INCLUDED

--- a/src/catch2/catch_test_macros.hpp
+++ b/src/catch2/catch_test_macros.hpp
@@ -8,6 +8,12 @@
 #ifndef CATCH_TEST_MACROS_HPP_INCLUDED
 #define CATCH_TEST_MACROS_HPP_INCLUDED
 
+#include <catch2/internal/catch_compiler_capabilities.hpp>
+
+CATCH_INTERNAL_START_WARNINGS_SUPPRESSION
+CATCH_INTERNAL_SUPPRESS_EFFCPP_WARNINGS
+CATCH_INTERNAL_SUPPRESS_CTOR_DTOR_PRIVACY_WARNINGS
+
 #include <catch2/internal/catch_test_macro_impl.hpp>
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_user_config.hpp>
@@ -239,5 +245,7 @@
 #endif // ^^ unprefixed, disabled
 
 // end of user facing macros
+
+CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
 #endif // CATCH_TEST_MACROS_HPP_INCLUDED

--- a/src/catch2/generators/catch_generators.hpp
+++ b/src/catch2/generators/catch_generators.hpp
@@ -8,6 +8,12 @@
 #ifndef CATCH_GENERATORS_HPP_INCLUDED
 #define CATCH_GENERATORS_HPP_INCLUDED
 
+#include <catch2/internal/catch_compiler_capabilities.hpp>
+
+CATCH_INTERNAL_START_WARNINGS_SUPPRESSION
+CATCH_INTERNAL_SUPPRESS_EFFCPP_WARNINGS
+CATCH_INTERNAL_SUPPRESS_CTOR_DTOR_PRIVACY_WARNINGS
+
 #include <catch2/catch_tostring.hpp>
 #include <catch2/generators/catch_generators_throw.hpp>
 #include <catch2/interfaces/catch_interfaces_generatortracker.hpp>
@@ -257,5 +263,7 @@ namespace Generators {
     Catch::Generators::generate( CATCH_INTERNAL_GENERATOR_STRINGIZE(INTERNAL_CATCH_UNIQUE_NAME(generator)), \
                                  CATCH_INTERNAL_LINEINFO, \
                                  [&]{ using namespace Catch::Generators; return makeGenerators( __VA_ARGS__ ); } ) //NOLINT(google-build-using-namespace)
+
+CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
 #endif // CATCH_GENERATORS_HPP_INCLUDED

--- a/src/catch2/internal/catch_compiler_capabilities.hpp
+++ b/src/catch2/internal/catch_compiler_capabilities.hpp
@@ -62,6 +62,12 @@
 #    define CATCH_INTERNAL_SUPPRESS_SHADOW_WARNINGS \
          _Pragma( "GCC diagnostic ignored \"-Wshadow\"" )
 
+#    define CATCH_INTERNAL_SUPPRESS_EFFCPP_WARNINGS \
+         _Pragma( "GCC diagnostic ignored \"-Weffc++\"" )
+
+#    define CATCH_INTERNAL_SUPPRESS_CTOR_DTOR_PRIVACY_WARNINGS \
+         _Pragma( "GCC diagnostic ignored \"-Wctor-dtor-privacy\"" )
+
 #    define CATCH_INTERNAL_CONFIG_USE_BUILTIN_CONSTANT_P
 
 #endif
@@ -428,6 +434,12 @@
 #endif
 #if !defined( CATCH_INTERNAL_SUPPRESS_SHADOW_WARNINGS )
 #    define CATCH_INTERNAL_SUPPRESS_SHADOW_WARNINGS
+#endif
+#if !defined( CATCH_INTERNAL_SUPPRESS_EFFCPP_WARNINGS )
+#    define CATCH_INTERNAL_SUPPRESS_EFFCPP_WARNINGS
+#endif
+#if !defined( CATCH_INTERNAL_SUPPRESS_CTOR_DTOR_PRIVACY_WARNINGS )
+#    define CATCH_INTERNAL_SUPPRESS_CTOR_DTOR_PRIVACY_WARNINGS
 #endif
 
 #if defined(__APPLE__) && defined(__apple_build_version__) && (__clang_major__ < 10)

--- a/src/catch2/matchers/catch_matchers.hpp
+++ b/src/catch2/matchers/catch_matchers.hpp
@@ -8,6 +8,12 @@
 #ifndef CATCH_MATCHERS_HPP_INCLUDED
 #define CATCH_MATCHERS_HPP_INCLUDED
 
+#include <catch2/internal/catch_compiler_capabilities.hpp>
+
+CATCH_INTERNAL_START_WARNINGS_SUPPRESSION
+CATCH_INTERNAL_SUPPRESS_EFFCPP_WARNINGS
+CATCH_INTERNAL_SUPPRESS_CTOR_DTOR_PRIVACY_WARNINGS
+
 #include <catch2/matchers/internal/catch_matchers_impl.hpp>
 #include <catch2/internal/catch_move_and_forward.hpp>
 #include <catch2/internal/catch_lifetimebound.hpp>
@@ -249,5 +255,7 @@ namespace Matchers {
   #define REQUIRE_THAT( arg, matcher )                           (void)(0)
 
 #endif // end of user facing macro declarations
+
+CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
 #endif // CATCH_MATCHERS_HPP_INCLUDED


### PR DESCRIPTION
This pull request addresses warning leakage from Catch2 internals when users include Catch2 headers under strict compiler warning flags.
The change adds GCC-specific suppression macros for -Weffc++ and -Wctor-dtor-privacy in src/catch2/internal/catch_compiler_capabilities.hpp, and applies them at major public header boundaries so these warnings are contained within Catch2 rather than surfacing in downstream user builds.
The updated public entry headers are:
src/catch2/catch_test_macros.hpp
src/catch2/catch_template_test_macros.hpp
src/catch2/catch_session.hpp
src/catch2/catch_all.hpp
src/catch2/matchers/catch_matchers.hpp
src/catch2/generators/catch_generators.hpp
This is a minimal, boundary-based fix intended to align with Catch2’s existing warning suppression infrastructure rather than refactoring all internal warning-triggering patterns.
Validation performed:
cmake --build build succeeded
ctest --test-dir build --output-on-failure passed (75/75)
compile probes across the major public headers passed with -Weffc++ -Wctor-dtor-privacy -Werror in the local environment