### PR TITLE
Allow matchers to be used in constexpr code

### DIFF
--- a/src/catch2/matchers/catch_matchers.cpp
+++ b/src/catch2/matchers/catch_matchers.cpp
@@ -19,7 +19,5 @@ namespace Matchers {
         return m_cachedToString;
     }
 
-    MatcherUntypedBase::~MatcherUntypedBase() = default;
-
 } // namespace Matchers
 } // namespace Catch

--- a/src/catch2/matchers/catch_matchers.hpp
+++ b/src/catch2/matchers/catch_matchers.hpp
@@ -31,7 +31,7 @@ namespace Matchers {
         std::string toString() const;
 
     protected:
-        virtual ~MatcherUntypedBase(); // = default;
+        virtual ~MatcherUntypedBase() = default;
         virtual std::string describe() const = 0;
         mutable std::string m_cachedToString;
     };

--- a/src/catch2/matchers/catch_matchers_templated.cpp
+++ b/src/catch2/matchers/catch_matchers_templated.cpp
@@ -9,8 +9,6 @@
 
 namespace Catch {
 namespace Matchers {
-    MatcherGenericBase::~MatcherGenericBase() = default;
-
     namespace Detail {
 
         std::string describe_multi_matcher(StringRef combine, std::string const* descriptions_begin, std::string const* descriptions_end) {

--- a/src/catch2/matchers/catch_matchers_templated.hpp
+++ b/src/catch2/matchers/catch_matchers_templated.hpp
@@ -24,7 +24,7 @@ namespace Matchers {
     class MatcherGenericBase : public MatcherUntypedBase {
     public:
         MatcherGenericBase() = default;
-        ~MatcherGenericBase() override; // = default;
+        ~MatcherGenericBase() override = default;
 
         MatcherGenericBase(MatcherGenericBase const&) = default;
         MatcherGenericBase(MatcherGenericBase&&) = default;


### PR DESCRIPTION
This PR defines the default destructors for `MatcherGenericBase` and `MatcherUntypedBase` inline, making them implicitly constexpr, meaning some matchers can be used in compile-time tests, e.g.:

```c++
#include <catch2/catch_test_macros.hpp>
#include <catch2/matchers/catch_matchers_range_equals.hpp>

#define CONSTEXPR_REQUIRE_THAT(a, matcher)                                                         \
    if consteval                                                                                   \
    {                                                                                              \
        assert((matcher).match(a));                                                                \
    }                                                                                              \
    else                                                                                           \
    {                                                                                              \
        REQUIRE_THAT(a, matcher);                                                                  \
    }

TEST_CASE("std::string comparison", "[string]")
{
    constexpr static auto test_impl = [] -> bool {
        std::string str = "A string";
        std::string str2 = "A different string";
        CONSTEXPR_REQUIRE_THAT(str, Catch::Matchers::RangeEquals(str2));
        return true;
    };
    static_assert(test_impl()); // Fails at compile time
    test_impl(); // Fails at runtime
}
```

Unfortunately this currently only works with the `RangeEquals` matchers, as the rest aren't constexpr, but that's still useful for implementing some constexpr tests without having to resort to `REQUIRE(std::ranges::equal(a, b))`, which results in less helpful output at runtime

This has a small impact on compile times:
```
> hyperfine -w 1 --prepare "git switch devel && ninja clean" "ninja -j 10" --prepare "git switch const
expr-matcher-destructors && ninja clean" "ninja -j 10"
Benchmark 1: ninja -j 10
  Time (mean ± σ):     24.548 s ±  0.053 s    [User: 200.507 s, System: 40.747 s]
  Range (min … max):   24.459 s … 24.643 s    10 runs
 
Benchmark 2: ninja -j 10
  Time (mean ± σ):     24.771 s ±  0.253 s    [User: 202.411 s, System: 41.080 s]
  Range (min … max):   24.421 s … 25.097 s    10 runs
 
Summary
  ninja -j 10 ran
    1.01 ± 0.01 times faster than ninja -j 10
```