### PR TITLE
Exclude std::optional from generic range StringMaker (C++26 P3168 fix)

### DIFF
--- a/src/catch2/catch_tostring.hpp
+++ b/src/catch2/catch_tostring.hpp
@@ -25,6 +25,10 @@
 #include <string_view>
 #endif
 
+#ifdef CATCH_CONFIG_CPP17_OPTIONAL
+#include <optional>
+#endif
+
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable:4180) // We attempt to stream a function (address) by const&, which MSVC complains about but is harmless
@@ -481,6 +485,16 @@ namespace Catch {
 
         template <typename T>
         struct is_range_impl<T, void_t<decltype(begin(std::declval<T>()))>> : std::true_type {};
+
+        // Used to exclude std::optional from the generic range StringMaker so it
+        // does not collide with the dedicated optional StringMaker (or a
+        // user-provided one). std::optional models std::ranges::range since
+        // C++26 (P3168), so is_range<std::optional<T>> is true and both partial
+        // specializations would otherwise match StringMaker<std::optional<T>>.
+        template <typename T> struct is_optional : std::false_type {};
+#if defined(CATCH_CONFIG_CPP17_OPTIONAL)
+        template <typename T> struct is_optional<std::optional<T>> : std::true_type {};
+#endif
     } // namespace Detail
 
     template <typename T>
@@ -516,7 +530,9 @@ namespace Catch {
     }
 
     template<typename R>
-    struct StringMaker<R, std::enable_if_t<is_range<R>::value && !::Catch::Detail::IsStreamInsertable_v<R>>> {
+    struct StringMaker<R, std::enable_if_t<is_range<R>::value
+                                           && !::Catch::Detail::IsStreamInsertable_v<R>
+                                           && !::Catch::Detail::is_optional<R>::value>> {
         static std::string convert( R const& range ) {
             return rangeToString( range );
         }

--- a/tests/SelfTest/UsageTests/ToStringOptional.tests.cpp
+++ b/tests/SelfTest/UsageTests/ToStringOptional.tests.cpp
@@ -32,4 +32,19 @@ TEST_CASE( "std::nullopt -> toString", "[toString][optional][approvals]" ) {
     REQUIRE( "{ }" == ::Catch::Detail::stringify( std::nullopt ) );
 }
 
+namespace {
+    struct NonStreamable { int v; };
+}
+
+// Regression: under C++26, std::optional models std::ranges::range (P3168), so
+// without the is_optional carve-out in the range StringMaker the dedicated
+// optional StringMaker collides with the range one and instantiation becomes
+// ambiguous. This test just needs to compile.
+TEST_CASE( "std::optional<NonStreamable> -> toString does not collide with range StringMaker",
+           "[toString][optional][approvals]" ) {
+    using type = std::optional<NonStreamable>;
+    REQUIRE( "{ }" == ::Catch::Detail::stringify( type{} ) );
+    REQUIRE( "{?}" == ::Catch::Detail::stringify( type{ NonStreamable{ 42 } } ) );
+}
+
 #endif // CATCH_INTERNAL_CONFIG_CPP17_OPTIONAL


### PR DESCRIPTION
## Description

C++26's [P3168](https://wg21.link/P3168) ("Give std::optional Range Support") makes `std::optional<T>` model `std::ranges::range`. As a result, `Catch::is_range<std::optional<T>>::value` becomes `true` under C++26, and the generic range `StringMaker` partial specialization (`catch_tostring.hpp`) starts matching `StringMaker<std::optional<T>>`. This collides with:

1. Catch2's own dedicated `StringMaker<std::optional<T>>` (when `CATCH_CONFIG_ENABLE_OPTIONAL_STRINGMAKER` is enabled), and
2. Any user-provided `StringMaker<std::optional<T>>` partial specialization.

Both partial specializations deduce to the same `StringMaker<std::optional<T>, void>` instantiation, which compilers reject as ambiguous:

```
error: ambiguous template instantiation for 'struct Catch::StringMaker<std::optional<X>, void>'
```

The existing `ToStringOptional.tests.cpp` baseline tests already fail to build with GCC 16 in `-std=c++26` mode for this reason.

## Approach

`is_range` itself is left honest — `std::optional<T>` genuinely is a range, and downstream code keying off the trait should keep working. Instead, the generic range `StringMaker` is constrained via a new `Detail::is_optional` trait so it defers to optional-aware `StringMaker`s. This:

- Fixes Catch2's own `StringMaker<std::optional<T>>` (when the macro is enabled),
- Lets users keep writing `StringMaker<std::optional<T>>` partial specializations without conflict,
- Falls through to the unstreamable fallback when no optional-aware `StringMaker` is provided (matching pre-C++26 behavior).

The same opt-out pattern already exists in the file for managed types (`T^`).

## Test plan

- [x] Reproduced the failure: stashed the patch and confirmed `SelfTest` fails to build under `-std=c++26` with GCC 16.1.1 due to ambiguous instantiation on the existing `std::optional<std::string>` test.
- [x] Applied the patch: `SelfTest` builds clean under `-std=c++26`.
- [x] `[optional]`-tagged tests pass (29 assertions, 7 cases).
- [x] Full `SelfTest` run passes: 499 passed, 7 skipped, 16 expected-failures.
- [x] `tools/scripts/approvalTests.py` reports `Results matched` for every reporter format.
- [x] Added a regression test `std::optional<NonStreamable> -> toString does not collide with range StringMaker` exercising the path that was ambiguous in C++26.