### PR TITLE
Add ExtraTest for CATCH_CONFIG_FAST_COMPILE

### DIFF
--- a/tests/ExtraTests/CMakeLists.txt
+++ b/tests/ExtraTests/CMakeLists.txt
@@ -541,6 +541,7 @@ set(EXTRA_TEST_BINARIES
   NoTests
   ListenersGetEventsBeforeReporters
   MixingClearedAndUnclearedMessages
+  FastCompile
 #  DebugBreakMacros
 )
 
@@ -602,4 +603,17 @@ set_tests_properties(Warnings::InfiniteGenerators
     # One test case fails with infinite generator, but the other one runs
     PASS_REGULAR_EXPRESSION "test cases: 2 \\| 1 passed \\| 1 failed"
     TIMEOUT 5
+)
+
+add_executable(FastCompile ${TESTS_DIR}/X96-FastCompile.cpp)
+target_compile_definitions(FastCompile PRIVATE CATCH_CONFIG_FAST_COMPILE)
+target_link_libraries(FastCompile PRIVATE Catch2::Catch2WithMain)
+
+add_test(
+  NAME CATCH_CONFIG_FAST_COMPILE
+  COMMAND $<TARGET_FILE:FastCompile>
+)
+set_tests_properties(CATCH_CONFIG_FAST_COMPILE
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION "All tests passed"
 )

--- a/tests/ExtraTests/X96-FastCompile.cpp
+++ b/tests/ExtraTests/X96-FastCompile.cpp
@@ -1,0 +1,28 @@
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+
+
+/**\file
+ * Test that Catch2 works correctly when CATCH_CONFIG_FAST_COMPILE
+ * is defined.
+ *
+ * This flag trades off some features for faster compilation.
+ */
+
+ #include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("Fast compile mode runs basic assertions correctly") {
+    REQUIRE(1 == 1);
+    CHECK(2 == 2);
+    REQUIRE_FALSE(1 == 2);
+    CHECK_FALSE(3 == 4);
+
+    SECTION("Sections still work") {
+        REQUIRE("hello" != "world");
+    }
+}


### PR DESCRIPTION
## Description

Adds an ExtraTest for `CATCH_CONFIG_FAST_COMPILE`, which was listed as
untested in `tests/ExtraTests/ToDo.txt`. The test verifies that basic
assertions, sections, and checks still work correctly when this
compile-time flag is enabled.

## GitHub Issues

No existing issue. This addresses the TODO in `tests/ExtraTests/ToDo.txt`.