### PR TITLE
Change Catch2 library from static to shared

### DIFF
--- a/src/catch2/meson.build
+++ b/src/catch2/meson.build
@@ -361,11 +361,13 @@ if ((host_machine.system() == 'android') or
   catch2_dependencies += log_dep
 endif
 
-catch2 = static_library(
+catch2 = shared_library(
   'Catch2',
   sources,
   dependencies: catch2_dependencies,
   include_directories: '..',
+  version: meson.project_version(),
+  soversion: '3',
   install: get_option('install'),
 )
 
@@ -383,11 +385,13 @@ if get_option('install')
   )
 endif
 
-catch2_with_main = static_library(
+catch2_with_main = shared_library(
   'Catch2Main',
   'internal/catch_main.cpp',
   link_with: catch2,
   include_directories: '..',
+  version: meson.project_version(),
+  soversion: '3',
   install: get_option('install'),
 )
 


### PR DESCRIPTION
Change Catch2 library from static to shared. This also add's to the version to the library.