### PR TITLE
docs: add missing v3 include to assertions.md

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -13,6 +13,11 @@ Most test frameworks have a large collection of assertion macros to capture all 
 
 Catch is different. Because it decomposes natural C-style conditional expressions most of these forms are reduced to one or two that you will use all the time. That said there is a rich set of auxiliary macros as well. We'll describe all of these here.
 
+To use the assertion macros described on this page, include:
+```cpp
+#include <catch2/catch_test_macros.hpp>
+```
+
 Most of these macros come in two forms:
 
 ## Natural Expressions


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
Add missing #include statement to assertions.md for Catch2 v3:
- catch_test_macros.hpp for all assertion macros (REQUIRE, CHECK, etc.)

## GitHub Issues
Part of #2829
