### PR TITLE
docs: add missing v3 include to logging.md

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -5,6 +5,11 @@ Catch2 provides various macros for logging extra information when
 running a test. These macros default to being scoped, and associate with
 all assertions in the scope, regardless of whether they pass or fail.
 
+To use the logging macros described on this page, include:
+```cpp
+#include <catch2/catch_test_macros.hpp>
+```
+
 **example**
 ```cpp
 TEST_CASE("Simple info") {


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
Add missing #include statement to logging.md for Catch2 v3:
- catch_test_macros.hpp for all logging macros (INFO, WARN, CAPTURE, etc.)

## GitHub Issues
Part of #2829
