### PR TITLE
docs: Compiler Explorer steps for Try online badge (#2330)

### DIFF
--- a/docs/ci-and-misc.md
+++ b/docs/ci-and-misc.md
@@ -6,6 +6,7 @@
 [Bazel test runner integration](#bazel-test-runner-integration)<br>
 [Low-level tools](#low-level-tools)<br>
 [CMake](#cmake)<br>
+[Try Catch2 online (Compiler Explorer)](#try-catch2-online-compiler-explorer)<br>
 
 This page talks about Catch2's integration with other related tooling,
 like Continuous Integration and 3rd party test runners.
@@ -110,6 +111,17 @@ when stepping through code.
 
 [As it has been getting kinda long, the documentation of Catch2's
 integration with CMake has been moved to its own page.](cmake-integration.md#top)
+
+
+## Try Catch2 online (Compiler Explorer)
+
+You can experiment with Catch2 without installing it by using the
+**Try online** badge in the [project README](../README.md). It opens a
+Compiler Explorer session with Catch2 linked as a prebuilt library.
+
+Maintainers: when preparing a release, see the
+["Try online" link (Compiler Explorer)](release-process.md#try-online-link-compiler-explorer)
+section in the release process documentation for how to refresh the badge URL.
 
 
 ---

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -10,9 +10,8 @@ These steps are necessary and have to be performed before each new release. They
 
 ### Testing
 
-All of the tests are currently run in our CI setup based on TravisCI and
-AppVeyor. As long as the last commit tested green, the release can
-proceed.
+All of the tests are run in GitHub Actions and AppVeyor. As long as the
+last commit on the release branch tested green, the release can proceed.
 
 
 ### Incrementing version number
@@ -21,8 +20,29 @@ Catch uses a variant of [semantic versioning](http://semver.org/), with breaking
 
 After deciding which part of version number should be incremented, you can use one of the `*Release.py` scripts to perform the required changes to Catch.
 
-This will take care of generating the single include header, updating
-version numbers everywhere and pushing the new version to Wandbox.
+This will take care of generating the single include header and updating
+version numbers everywhere.
+
+
+### "Try online" link (Compiler Explorer)
+
+The README **Try online** badge should point to a [Compiler Explorer](https://godbolt.org/)
+session that uses Catch2's prebuilt library (not uploaded sources). CE refreshes
+its library builds on a regular schedule, so a link created for release `X.Y.Z`
+may only show that exact version after CE has picked up the package.
+
+When cutting a release:
+
+1. Open Compiler Explorer and configure a C++23 (or your target) environment with
+   the **Catch2** library enabled (the packaged `catchorg/catch2` entry).
+2. Add a minimal example (e.g. the factorial test from the README) and confirm it
+   compiles and runs.
+3. Use **Share** → **Permanent link** and copy the short URL (`https://godbolt.org/z/...`).
+4. Update the badge URL in the root [`README.md`](../README.md) (`[![Try online](...)]`).
+5. Optionally add a similar link to the new GitHub release description.
+
+Full automation is tracked in [#2330](https://github.com/catchorg/Catch2/issues/2330);
+until then this step is manual.
 
 
 ### Release notes


### PR DESCRIPTION
## Summary

Documents how to refresh the README **Try online** Compiler Explorer link when cutting a release, replacing the obsolete Wandbox reference in `release-process.md`.

Also updates the CI blurb to mention GitHub Actions and adds a short pointer from `ci-and-misc.md`.

Fixes #2330 (manual workflow; full automation can follow later).

## Test plan

- [x] Documentation-only.