### PR TITLE
docs: use lowercase include(FetchContent)

### DIFF
--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -47,7 +47,7 @@ above still works.
 
 Another possibility is to use [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html):
 ```cmake
-Include(FetchContent)
+include(FetchContent)
 
 FetchContent_Declare(
   Catch2


### PR DESCRIPTION
## Summary

`cmake-integration.md` used `Include(FetchContent)`; CMake commands are case-sensitive and the correct spelling is `include(FetchContent)`.

## Test plan

- [x] Documentation only