### PR TITLE
docs: in-repo Clara documentation (fixes #2312)

### DIFF
--- a/docs/clara.md
+++ b/docs/clara.md
@@ -1,0 +1,13 @@
+# Clara (command-line parsing)
+
+Catch2 embeds **Clara** as `Catch::Clara` (`catch2/internal/catch_clara.hpp`). The
+standalone [Clara repository](https://github.com/catchorg/Clara) is archived;
+new development happens only inside Catch2.
+
+## Getting started
+
+- [Adding your own command line options](own-main.md#adding-your-own-command-line-options) —
+  extend Catch2's CLI with custom flags
+- [232-Cfg-CustomMain.cpp](../examples/232-Cfg-CustomMain.cpp) — full custom-`main`
+  example composing `Catch::Clara` with `Catch::Session`
+- [command-line.md](command-line.md) — built-in Catch2 flags and reporters

--- a/docs/opensource-users.md
+++ b/docs/opensource-users.md
@@ -41,8 +41,8 @@ A, header-only, embedded scripting language designed from the ground up to direc
 ### [ChakraCore](https://github.com/Microsoft/ChakraCore)
 The core part of the Chakra JavaScript engine that powers Microsoft Edge.
 
-### [Clara](https://github.com/philsquared/Clara)
-A, single-header-only, type-safe, command line parser - which also prints formatted usage strings.
+### Clara (embedded in Catch2)
+Catch2's built-in type-safe command-line parser ([clara.md](clara.md)); formerly a separate project.
 
 ### [Couchbase-lite-core](https://github.com/couchbase/couchbase-lite-core)
 The next-generation core storage and query engine for Couchbase Lite.

--- a/docs/own-main.md
+++ b/docs/own-main.md
@@ -111,8 +111,7 @@ int main( int argc, char* argv[] ) {
 }
 ```
 
-See the [Clara documentation](https://github.com/catchorg/Clara/blob/master/README.md)
-for more details on how to use the Clara parser.
+See [clara.md](clara.md) for more details on the embedded `Catch::Clara` parser.
 
 
 ## Version detection


### PR DESCRIPTION
## Summary

Fixes #2312.

Adds `docs/clara.md` describing the embedded `Catch::Clara` API and points `own-main.md` / `opensource-users.md` at it instead of the archived standalone Clara repository.

## Test plan

- [x] Markdown links only