### PR TITLE
docs: use HTTPS and current URLs for external doc links

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -498,7 +498,7 @@ estimates for the mean and standard deviation. The estimates come with a lower
 bound and an upper bound, and the confidence interval (which is configurable but
 defaults to 95%).
 
- [bootstrapping]: http://en.wikipedia.org/wiki/Bootstrapping_%28statistics%29
+ [bootstrapping]: https://en.wikipedia.org/wiki/Bootstrapping_(statistics)
 
 <a id="benchmark-confidence-interval"></a>
 ## Specify the confidence-interval for bootstrapping

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -17,7 +17,7 @@ proceed.
 
 ### Incrementing version number
 
-Catch uses a variant of [semantic versioning](http://semver.org/), with breaking API changes (and thus major version increments) being very rare. Thus, the release will usually increment the patch version, when it only contains couple of bugfixes, or minor version, when it contains new functionality, or larger changes in implementation of current functionality.
+Catch uses a variant of [semantic versioning](https://semver.org/), with breaking API changes (and thus major version increments) being very rare. Thus, the release will usually increment the patch version, when it only contains couple of bugfixes, or minor version, when it contains new functionality, or larger changes in implementation of current functionality.
 
 After deciding which part of version number should be incremented, you can use one of the `*Release.py` scripts to perform the required changes to Catch.
 

--- a/docs/test-cases-and-sections.md
+++ b/docs/test-cases-and-sections.md
@@ -91,7 +91,7 @@ Now when `[@nhf]` is used on the command line this matches all tests that are ta
 
 ## BDD-style test cases
 
-In addition to Catch's take on the classic style of test cases, Catch supports an alternative syntax that allow tests to be written as "executable specifications" (one of the early goals of [Behaviour Driven Development](http://dannorth.net/introducing-bdd/)). This set of macros map on to ```TEST_CASE```s and ```SECTION```s, with a little internal support to make them smoother to work with.
+In addition to Catch's take on the classic style of test cases, Catch supports an alternative syntax that allow tests to be written as "executable specifications" (one of the early goals of [Behaviour Driven Development](https://dannorth.net/introducing-bdd/)). This set of macros map on to ```TEST_CASE```s and ```SECTION```s, with a little internal support to make them smoother to work with.
 
 * **SCENARIO(** _scenario name_ \[, _tags_ \] **)**
 
@@ -103,8 +103,8 @@ This macro maps onto ```TEST_CASE``` and works in the same way, except that the 
 
 These macros map onto ```SECTION```s except that the section names are the _something_ texts prefixed by
 "given: ", "when: " or "then: " respectively. These macros also map onto the AAA or A<sup>3</sup> test pattern
-(standing either for [Assemble-Activate-Assert](http://wiki.c2.com/?AssembleActivateAssert) or
-[Arrange-Act-Assert](http://wiki.c2.com/?ArrangeActAssert)), and in this context, the macros provide both code
+(standing either for [Assemble-Activate-Assert](https://wiki.c2.com/?AssembleActivateAssert) or
+[Arrange-Act-Assert](https://wiki.c2.com/?ArrangeActAssert)), and in this context, the macros provide both code
 documentation and reporting of these parts of a test case without the need for extra comments or code to do so.
 
 Semantically, a `GIVEN` clause may have multiple _independent_ `WHEN` clauses within it. This allows a test

--- a/docs/why-catch.md
+++ b/docs/why-catch.md
@@ -3,11 +3,11 @@
 
 Good question. For C++ there are quite a number of established frameworks,
 including (but not limited to),
-[Google Test](http://code.google.com/p/googletest/),
-[Boost.Test](http://www.boost.org/doc/libs/1_49_0/libs/test/doc/html/index.html),
-[CppUnit](http://sourceforge.net/apps/mediawiki/cppunit/index.php?title=Main_Page),
-[Cute](http://www.cute-test.com), and
-[many, many more](http://en.wikipedia.org/wiki/List_of_unit_testing_frameworks#C.2B.2B).
+[Google Test](https://github.com/google/googletest),
+[Boost.Test](https://www.boost.org/doc/libs/release/libs/test/doc/html/index.html),
+[CppUnit](https://freedesktop.org/wiki/Software/cppunit/),
+[Cute](https://www.cute-test.com), and
+[many, many more](https://en.wikipedia.org/wiki/List_of_unit_testing_frameworks#C++).
 
 So what does Catch2 bring to the party that differentiates it from these? Apart from the catchy name, of course.
 


### PR DESCRIPTION
## Summary
- Update semver.org, framework comparison, BDD, bootstrapping, and wiki.c2.com links to HTTPS
- Point Google Test and CppUnit links at maintained destinations

## Test plan
- [x] Doc-only change