### PR TITLE
docs: add missing v3 include to test-cases-and-sections.md

### DIFF
--- a/docs/test-cases-and-sections.md
+++ b/docs/test-cases-and-sections.md
@@ -12,6 +12,11 @@ While Catch fully supports the traditional, xUnit, style of class-based fixtures
 
 Instead Catch provides a powerful mechanism for nesting test case sections within a test case. For a more detailed discussion see the [tutorial](tutorial.md#test-cases-and-sections).
 
+To use the macros described on this page, include:
+```cpp
+#include <catch2/catch_test_macros.hpp>
+```
+
 Test cases and sections are very easy to use in practice:
 
 * **TEST_CASE(** _test name_ \[, _tags_ \] **)**


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
Add missing #include statement to test-cases-and-sections.md for Catch2 v3:
- catch_test_macros.hpp for TEST_CASE, SECTION, SCENARIO and related macros

## GitHub Issues
Part of #2829
