### PR TITLE
Keep UnorderedRangeEquals comparator argument order

### DIFF
--- a/src/catch2/matchers/catch_matchers_range_equals.hpp
+++ b/src/catch2/matchers/catch_matchers_range_equals.hpp
@@ -12,6 +12,7 @@
 #include <catch2/matchers/catch_matchers_templated.hpp>
 
 #include <functional>
+#include <vector>
 
 namespace Catch {
     namespace Matchers {
@@ -74,15 +75,38 @@ namespace Catch {
                 m_predicate( CATCH_FORWARD( predicate ) ) {}
 
             template <typename RangeLike>
-            constexpr
             bool match( RangeLike&& rng ) const {
                 using std::begin;
                 using std::end;
-                return Catch::Detail::is_permutation( begin( m_desired ),
-                                                      end( m_desired ),
-                                                      begin( rng ),
-                                                      end( rng ),
-                                                      m_predicate );
+
+                const auto target_begin = begin( m_desired );
+                const auto target_end = end( m_desired );
+                const auto target_size = static_cast<size_t>(
+                    Catch::Detail::sentinel_distance( target_begin,
+                                                      target_end ) );
+                std::vector<bool> matched( target_size, false );
+
+                size_t matched_count = 0;
+                for ( auto&& element : rng ) {
+                    if ( matched_count == target_size ) { return false; }
+
+                    auto target = target_begin;
+                    bool found_match = false;
+                    for ( size_t index = 0; target != target_end;
+                          ++target, ++index ) {
+                        if ( !matched[index] &&
+                             m_predicate( element, *target ) ) {
+                            matched[index] = true;
+                            ++matched_count;
+                            found_match = true;
+                            break;
+                        }
+                    }
+
+                    if ( !found_match ) { return false; }
+                }
+
+                return matched_count == target_size;
             }
 
             std::string describe() const override {

--- a/src/catch2/matchers/catch_matchers_range_equals.hpp
+++ b/src/catch2/matchers/catch_matchers_range_equals.hpp
@@ -75,6 +75,9 @@ namespace Catch {
                 m_predicate( CATCH_FORWARD( predicate ) ) {}
 
             template <typename RangeLike>
+#if defined( CATCH_INTERNAL_CONSTEXPR_MATCHERS_ENABLED )
+            constexpr
+#endif
             bool match( RangeLike&& rng ) const {
                 using std::begin;
                 using std::end;

--- a/tests/SelfTest/Baselines/compact.sw.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.approved.txt
@@ -2440,6 +2440,7 @@ MatchersRanges.tests.cpp:<line number>: passed: array_a, !UnorderedRangeEquals( 
 MatchersRanges.tests.cpp:<line number>: passed: vector_a, !UnorderedRangeEquals( vector_b ) for: { 1, 2, 3 } not unordered elements are { 1, 2, 3, 4 }
 MatchersRanges.tests.cpp:<line number>: passed: vector_a, UnorderedRangeEquals( vector_a_plus_1, close_enough ) for: { 1, 10, 20 } unordered elements are { 11, 21, 2 }
 MatchersRanges.tests.cpp:<line number>: passed: vector_a, !UnorderedRangeEquals( vector_b, close_enough ) for: { 1, 10, 21 } not unordered elements are { 11, 21, 3 }
+MatchersRanges.tests.cpp:<line number>: passed: actual, UnorderedRangeEquals( expected, []( UnorderedRangeActual const& lhs, UnorderedRangeExpected const& rhs ) { return lhs.value == rhs.value; } ) for: { 1, 2, 3, 4 } unordered elements are { 4, 2, 3, 1 }
 MatchersRanges.tests.cpp:<line number>: passed: needs_adl1, UnorderedRangeEquals( needs_adl2 ) for: { 1, 2, 3, 4, 5 } unordered elements are { 1, 2, 3, 4, 5 }
 MatchersRanges.tests.cpp:<line number>: passed: array_a, UnorderedRangeEquals( { 10, 20, 1 } ) for: { 1, 10, 20 } unordered elements are { 10, 20, 1 }
 MatchersRanges.tests.cpp:<line number>: passed: array_a, UnorderedRangeEquals( { 11, 21, 2 }, []( int l, int r ) { return std::abs( l - r ) <= 1; } ) for: { 1, 10, 20 } unordered elements are { 11, 21, 2 }
@@ -3001,6 +3002,6 @@ InternalBenchmark.tests.cpp:<line number>: passed: q3 == 23. for: 23.0 == 23.0
 Misc.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: passed:
 test cases:  451 |  331 passed |  96 failed | 6 skipped | 18 failed as expected
-assertions: 2416 | 2215 passed | 158 failed | 43 failed as expected
+assertions: 2417 | 2216 passed | 158 failed | 43 failed as expected
 
 

--- a/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
@@ -2433,6 +2433,7 @@ MatchersRanges.tests.cpp:<line number>: passed: array_a, !UnorderedRangeEquals( 
 MatchersRanges.tests.cpp:<line number>: passed: vector_a, !UnorderedRangeEquals( vector_b ) for: { 1, 2, 3 } not unordered elements are { 1, 2, 3, 4 }
 MatchersRanges.tests.cpp:<line number>: passed: vector_a, UnorderedRangeEquals( vector_a_plus_1, close_enough ) for: { 1, 10, 20 } unordered elements are { 11, 21, 2 }
 MatchersRanges.tests.cpp:<line number>: passed: vector_a, !UnorderedRangeEquals( vector_b, close_enough ) for: { 1, 10, 21 } not unordered elements are { 11, 21, 3 }
+MatchersRanges.tests.cpp:<line number>: passed: actual, UnorderedRangeEquals( expected, []( UnorderedRangeActual const& lhs, UnorderedRangeExpected const& rhs ) { return lhs.value == rhs.value; } ) for: { 1, 2, 3, 4 } unordered elements are { 4, 2, 3, 1 }
 MatchersRanges.tests.cpp:<line number>: passed: needs_adl1, UnorderedRangeEquals( needs_adl2 ) for: { 1, 2, 3, 4, 5 } unordered elements are { 1, 2, 3, 4, 5 }
 MatchersRanges.tests.cpp:<line number>: passed: array_a, UnorderedRangeEquals( { 10, 20, 1 } ) for: { 1, 10, 20 } unordered elements are { 10, 20, 1 }
 MatchersRanges.tests.cpp:<line number>: passed: array_a, UnorderedRangeEquals( { 11, 21, 2 }, []( int l, int r ) { return std::abs( l - r ) <= 1; } ) for: { 1, 10, 20 } unordered elements are { 11, 21, 2 }
@@ -2990,6 +2991,6 @@ InternalBenchmark.tests.cpp:<line number>: passed: q3 == 23. for: 23.0 == 23.0
 Misc.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: passed:
 test cases:  451 |  331 passed |  96 failed | 6 skipped | 18 failed as expected
-assertions: 2416 | 2215 passed | 158 failed | 43 failed as expected
+assertions: 2417 | 2216 passed | 158 failed | 43 failed as expected
 
 

--- a/tests/SelfTest/Baselines/console.std.approved.txt
+++ b/tests/SelfTest/Baselines/console.std.approved.txt
@@ -1744,5 +1744,5 @@ due to unexpected exception with message:
 
 ===============================================================================
 test cases:  451 |  349 passed |  76 failed | 7 skipped | 19 failed as expected
-assertions: 2394 | 2215 passed | 136 failed | 43 failed as expected
+assertions: 2395 | 2216 passed | 136 failed | 43 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.approved.txt
@@ -16187,6 +16187,19 @@ with expansion:
 
 -------------------------------------------------------------------------------
 Usage of UnorderedRangeEquals range matcher
+  Custom predicate
+  Different element types keep predicate argument order
+-------------------------------------------------------------------------------
+MatchersRanges.tests.cpp:<line number>
+...............................................................................
+
+MatchersRanges.tests.cpp:<line number>: PASSED:
+  CHECK_THAT( actual, UnorderedRangeEquals( expected, []( UnorderedRangeActual const& lhs, UnorderedRangeExpected const& rhs ) { return lhs.value == rhs.value; } ) )
+with expansion:
+  { 1, 2, 3, 4 } unordered elements are { 4, 2, 3, 1 }
+
+-------------------------------------------------------------------------------
+Usage of UnorderedRangeEquals range matcher
   Ranges that need ADL begin/end
 -------------------------------------------------------------------------------
 MatchersRanges.tests.cpp:<line number>
@@ -20135,5 +20148,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  451 |  331 passed |  96 failed | 6 skipped | 18 failed as expected
-assertions: 2416 | 2215 passed | 158 failed | 43 failed as expected
+assertions: 2417 | 2216 passed | 158 failed | 43 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.multi.approved.txt
@@ -16180,6 +16180,19 @@ with expansion:
 
 -------------------------------------------------------------------------------
 Usage of UnorderedRangeEquals range matcher
+  Custom predicate
+  Different element types keep predicate argument order
+-------------------------------------------------------------------------------
+MatchersRanges.tests.cpp:<line number>
+...............................................................................
+
+MatchersRanges.tests.cpp:<line number>: PASSED:
+  CHECK_THAT( actual, UnorderedRangeEquals( expected, []( UnorderedRangeActual const& lhs, UnorderedRangeExpected const& rhs ) { return lhs.value == rhs.value; } ) )
+with expansion:
+  { 1, 2, 3, 4 } unordered elements are { 4, 2, 3, 1 }
+
+-------------------------------------------------------------------------------
+Usage of UnorderedRangeEquals range matcher
   Ranges that need ADL begin/end
 -------------------------------------------------------------------------------
 MatchersRanges.tests.cpp:<line number>
@@ -20124,5 +20137,5 @@ Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
 test cases:  451 |  331 passed |  96 failed | 6 skipped | 18 failed as expected
-assertions: 2416 | 2215 passed | 158 failed | 43 failed as expected
+assertions: 2417 | 2216 passed | 158 failed | 43 failed as expected
 

--- a/tests/SelfTest/Baselines/junit.sw.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="141" skipped="12" tests="2428" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="141" skipped="12" tests="2429" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="random-seed" value="1"/>
       <property name="filters" value="&quot;*&quot; ~[!nonportable] ~[!benchmark] ~[approvals]"/>
@@ -1417,6 +1417,7 @@ at Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Usage of UnorderedRangeEquals range matcher/Custom predicate" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Usage of UnorderedRangeEquals range matcher/Custom predicate/Two equal non-empty containers (close enough)" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Usage of UnorderedRangeEquals range matcher/Custom predicate/Two non-equal non-empty containers (close enough)" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="Usage of UnorderedRangeEquals range matcher/Custom predicate/Different element types keep predicate argument order" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Usage of UnorderedRangeEquals range matcher/Ranges that need ADL begin/end" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Usage of UnorderedRangeEquals range matcher/Compare against std::initializer_list" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Usage of the SizeIs range matcher" time="{duration}" status="run"/>

--- a/tests/SelfTest/Baselines/junit.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.multi.approved.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="<exe-name>" errors="17" failures="141" skipped="12" tests="2428" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="141" skipped="12" tests="2429" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="random-seed" value="1"/>
       <property name="filters" value="&quot;*&quot; ~[!nonportable] ~[!benchmark] ~[approvals]"/>
@@ -1416,6 +1416,7 @@ at Message.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Usage of UnorderedRangeEquals range matcher/Custom predicate" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Usage of UnorderedRangeEquals range matcher/Custom predicate/Two equal non-empty containers (close enough)" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Usage of UnorderedRangeEquals range matcher/Custom predicate/Two non-equal non-empty containers (close enough)" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="Usage of UnorderedRangeEquals range matcher/Custom predicate/Different element types keep predicate argument order" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Usage of UnorderedRangeEquals range matcher/Ranges that need ADL begin/end" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Usage of UnorderedRangeEquals range matcher/Compare against std::initializer_list" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="Usage of the SizeIs range matcher" time="{duration}" status="run"/>

--- a/tests/SelfTest/Baselines/sonarqube.sw.approved.txt
+++ b/tests/SelfTest/Baselines/sonarqube.sw.approved.txt
@@ -1709,6 +1709,7 @@ at Matchers.tests.cpp:<line number>
     <testCase name="Usage of UnorderedRangeEquals range matcher/Custom predicate" duration="{duration}"/>
     <testCase name="Usage of UnorderedRangeEquals range matcher/Custom predicate/Two equal non-empty containers (close enough)" duration="{duration}"/>
     <testCase name="Usage of UnorderedRangeEquals range matcher/Custom predicate/Two non-equal non-empty containers (close enough)" duration="{duration}"/>
+    <testCase name="Usage of UnorderedRangeEquals range matcher/Custom predicate/Different element types keep predicate argument order" duration="{duration}"/>
     <testCase name="Usage of UnorderedRangeEquals range matcher/Ranges that need ADL begin/end" duration="{duration}"/>
     <testCase name="Usage of UnorderedRangeEquals range matcher/Compare against std::initializer_list" duration="{duration}"/>
     <testCase name="Usage of the SizeIs range matcher" duration="{duration}"/>

--- a/tests/SelfTest/Baselines/sonarqube.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/sonarqube.sw.multi.approved.txt
@@ -1708,6 +1708,7 @@ at Matchers.tests.cpp:<line number>
     <testCase name="Usage of UnorderedRangeEquals range matcher/Custom predicate" duration="{duration}"/>
     <testCase name="Usage of UnorderedRangeEquals range matcher/Custom predicate/Two equal non-empty containers (close enough)" duration="{duration}"/>
     <testCase name="Usage of UnorderedRangeEquals range matcher/Custom predicate/Two non-equal non-empty containers (close enough)" duration="{duration}"/>
+    <testCase name="Usage of UnorderedRangeEquals range matcher/Custom predicate/Different element types keep predicate argument order" duration="{duration}"/>
     <testCase name="Usage of UnorderedRangeEquals range matcher/Ranges that need ADL begin/end" duration="{duration}"/>
     <testCase name="Usage of UnorderedRangeEquals range matcher/Compare against std::initializer_list" duration="{duration}"/>
     <testCase name="Usage of the SizeIs range matcher" duration="{duration}"/>

--- a/tests/SelfTest/Baselines/tap.sw.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.approved.txt
@@ -3888,6 +3888,8 @@ ok {test-number} - vector_a, UnorderedRangeEquals( vector_a_plus_1, close_enough
 # Usage of UnorderedRangeEquals range matcher
 ok {test-number} - vector_a, !UnorderedRangeEquals( vector_b, close_enough ) for: { 1, 10, 21 } not unordered elements are { 11, 21, 3 }
 # Usage of UnorderedRangeEquals range matcher
+ok {test-number} - actual, UnorderedRangeEquals( expected, []( UnorderedRangeActual const& lhs, UnorderedRangeExpected const& rhs ) { return lhs.value == rhs.value; } ) for: { 1, 2, 3, 4 } unordered elements are { 4, 2, 3, 1 }
+# Usage of UnorderedRangeEquals range matcher
 ok {test-number} - needs_adl1, UnorderedRangeEquals( needs_adl2 ) for: { 1, 2, 3, 4, 5 } unordered elements are { 1, 2, 3, 4, 5 }
 # Usage of UnorderedRangeEquals range matcher
 ok {test-number} - array_a, UnorderedRangeEquals( { 10, 20, 1 } ) for: { 1, 10, 20 } unordered elements are { 10, 20, 1 }
@@ -4851,5 +4853,5 @@ ok {test-number} - q3 == 23. for: 23.0 == 23.0
 ok {test-number} -
 # xmlentitycheck
 ok {test-number} -
-1..2428
+1..2429
 

--- a/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
@@ -3881,6 +3881,8 @@ ok {test-number} - vector_a, UnorderedRangeEquals( vector_a_plus_1, close_enough
 # Usage of UnorderedRangeEquals range matcher
 ok {test-number} - vector_a, !UnorderedRangeEquals( vector_b, close_enough ) for: { 1, 10, 21 } not unordered elements are { 11, 21, 3 }
 # Usage of UnorderedRangeEquals range matcher
+ok {test-number} - actual, UnorderedRangeEquals( expected, []( UnorderedRangeActual const& lhs, UnorderedRangeExpected const& rhs ) { return lhs.value == rhs.value; } ) for: { 1, 2, 3, 4 } unordered elements are { 4, 2, 3, 1 }
+# Usage of UnorderedRangeEquals range matcher
 ok {test-number} - needs_adl1, UnorderedRangeEquals( needs_adl2 ) for: { 1, 2, 3, 4, 5 } unordered elements are { 1, 2, 3, 4, 5 }
 # Usage of UnorderedRangeEquals range matcher
 ok {test-number} - array_a, UnorderedRangeEquals( { 10, 20, 1 } ) for: { 1, 10, 20 } unordered elements are { 10, 20, 1 }
@@ -4840,5 +4842,5 @@ ok {test-number} - q3 == 23. for: 23.0 == 23.0
 ok {test-number} -
 # xmlentitycheck
 ok {test-number} -
-1..2428
+1..2429
 

--- a/tests/SelfTest/Baselines/xml.sw.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.approved.txt
@@ -18919,6 +18919,20 @@ There is no extra whitespace here
       </Section>
       <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
     </Section>
+    <Section name="Custom predicate" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
+      <Section name="Different element types keep predicate argument order" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
+        <Expression success="true" type="CHECK_THAT" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
+          <Original>
+            actual, UnorderedRangeEquals( expected, []( UnorderedRangeActual const&amp; lhs, UnorderedRangeExpected const&amp; rhs ) { return lhs.value == rhs.value; } )
+          </Original>
+          <Expanded>
+            { 1, 2, 3, 4 } unordered elements are { 4, 2, 3, 1 }
+          </Expanded>
+        </Expression>
+        <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+      </Section>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
     <Section name="Ranges that need ADL begin/end" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
       <Expression success="true" type="REQUIRE_THAT" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
         <Original>
@@ -23385,6 +23399,6 @@ Approx( -1.95996398454005449 )
     </Section>
     <OverallResult success="true" skips="0"/>
   </TestCase>
-  <OverallResults successes="2215" failures="158" expectedFailures="43" skips="12"/>
+  <OverallResults successes="2216" failures="158" expectedFailures="43" skips="12"/>
   <OverallResultsCases successes="331" failures="96" expectedFailures="18" skips="6"/>
 </Catch2TestRun>

--- a/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
@@ -18919,6 +18919,20 @@ There is no extra whitespace here
       </Section>
       <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
     </Section>
+    <Section name="Custom predicate" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
+      <Section name="Different element types keep predicate argument order" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
+        <Expression success="true" type="CHECK_THAT" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
+          <Original>
+            actual, UnorderedRangeEquals( expected, []( UnorderedRangeActual const&amp; lhs, UnorderedRangeExpected const&amp; rhs ) { return lhs.value == rhs.value; } )
+          </Original>
+          <Expanded>
+            { 1, 2, 3, 4 } unordered elements are { 4, 2, 3, 1 }
+          </Expanded>
+        </Expression>
+        <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+      </Section>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
     <Section name="Ranges that need ADL begin/end" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
       <Expression success="true" type="REQUIRE_THAT" filename="tests/<exe-name>/UsageTests/MatchersRanges.tests.cpp" >
         <Original>
@@ -23384,6 +23398,6 @@ Approx( -1.95996398454005449 )
     </Section>
     <OverallResult success="true" skips="0"/>
   </TestCase>
-  <OverallResults successes="2215" failures="158" expectedFailures="43" skips="12"/>
+  <OverallResults successes="2216" failures="158" expectedFailures="43" skips="12"/>
   <OverallResultsCases successes="331" failures="96" expectedFailures="18" skips="6"/>
 </Catch2TestRun>

--- a/tests/SelfTest/UsageTests/MatchersRanges.tests.cpp
+++ b/tests/SelfTest/UsageTests/MatchersRanges.tests.cpp
@@ -41,6 +41,30 @@ struct MoveOnlyTestElement {
     }
 };
 
+namespace {
+
+    struct UnorderedRangeActual {
+        int value;
+    };
+
+    struct UnorderedRangeExpected {
+        int value;
+    };
+
+    std::ostream& operator<<( std::ostream& out,
+                              UnorderedRangeActual const& value ) {
+        out << value.value;
+        return out;
+    }
+
+    std::ostream& operator<<( std::ostream& out,
+                              UnorderedRangeExpected const& value ) {
+        out << value.value;
+        return out;
+    }
+
+} // end unnamed namespace
+
 TEST_CASE("Basic use of the Contains range matcher", "[matchers][templated][contains]") {
     using Catch::Matchers::Contains;
 
@@ -818,6 +842,20 @@ TEST_CASE( "Usage of UnorderedRangeEquals range matcher",
             const std::vector<int> vector_b{ { 11, 21, 3 } };
             CHECK_THAT( vector_a,
                         !UnorderedRangeEquals( vector_b, close_enough ) );
+        }
+        SECTION( "Different element types keep predicate argument order" ) {
+            const std::vector<UnorderedRangeActual> actual{
+                { 1 }, { 2 }, { 3 }, { 4 } };
+            const std::vector<UnorderedRangeExpected> expected{
+                { 4 }, { 2 }, { 3 }, { 1 } };
+
+            CHECK_THAT( actual,
+                        UnorderedRangeEquals(
+                            expected,
+                            []( UnorderedRangeActual const& lhs,
+                                UnorderedRangeExpected const& rhs ) {
+                                return lhs.value == rhs.value;
+                            } ) );
         }
     }
 


### PR DESCRIPTION
## Description
- match unordered ranges with a matched-element bitmap instead of `is_permutation` counting
- keep custom predicates called as `(actual_element, expected_element)` for every comparison
- add a regression test for different actual/expected element types and refresh approval baselines

## GitHub Issues
References #3043

## Tests
- `cmake -B /tmp/catch2-basic-build -S . -DCMAKE_BUILD_TYPE=Debug --preset basic-tests`
- `cmake --build /tmp/catch2-basic-build --target SelfTest -j 4`
- `/tmp/catch2-basic-build/tests/SelfTest "Usage of UnorderedRangeEquals range matcher" --rng-seed 1`
- `ctest --test-dir /tmp/catch2-basic-build -R "RunTests|ApprovalTests" --output-on-failure -j 2`
- `ctest --test-dir /tmp/catch2-basic-build --output-on-failure -j 4`
- `git diff --check`