### PR TITLE
docs: Enable syntax coloring for code example

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -26,7 +26,7 @@ The ```CHECK``` family are equivalent but execution continues in the same test c
 Evaluates the expression and records the result. If an exception is thrown, it is caught, reported, and counted as a failure. These are the macros you will use most of the time.
 
 Examples:
-```
+```cpp
 CHECK( str == "string value" );
 CHECK( thisReturnsTrue() );
 REQUIRE( i == 42 );

--- a/docs/test-cases-and-sections.md
+++ b/docs/test-cases-and-sections.md
@@ -36,10 +36,12 @@ Tags allow an arbitrary number of additional strings to be associated with a tes
 
 As an example - given the following test cases:
 
-    TEST_CASE( "A", "[widget]" ) { /* ... */ }
-    TEST_CASE( "B", "[widget]" ) { /* ... */ }
-    TEST_CASE( "C", "[gadget]" ) { /* ... */ }
-    TEST_CASE( "D", "[widget][gadget]" ) { /* ... */ }
+```cpp
+TEST_CASE( "A", "[widget]" ) { /* ... */ }
+TEST_CASE( "B", "[widget]" ) { /* ... */ }
+TEST_CASE( "C", "[gadget]" ) { /* ... */ }
+TEST_CASE( "D", "[widget][gadget]" ) { /* ... */ }
+```
 
 The tag expression, ```"[widget]"``` selects A, B & D. ```"[gadget]"``` selects C & D. ```"[widget][gadget]"``` selects just D and ```"[widget],[gadget]"``` selects all four test cases.
 


### PR DESCRIPTION
## Description

While the other code examples in this document use syntax coloring, this one doesn't.
