### PR TITLE
docs: add required includes to matchers.md examples (#2519)

### DIFF
--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -26,6 +26,9 @@ For example, to assert that a string ends with the "as a service"
 substring, you can write the following assertion
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
 using Catch::Matchers::EndsWith;
 
 REQUIRE_THAT( getSomeString(), EndsWith("as a service") );
@@ -35,6 +38,9 @@ Individual matchers can also be combined using the C++ logical
 operators, that is `&&`, `||`, and `!`, like so:
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
 using Catch::Matchers::EndsWith;
 using Catch::Matchers::ContainsSubstring;
 


### PR DESCRIPTION
## Summary
- Add `#include <catch2/catch_test_macros.hpp>` and `#include <catch2/matchers/catch_matchers_string.hpp>` to the introductory `REQUIRE_THAT` examples in `docs/matchers.md`

Continues #3118 (generators page); partial fix for #2519.

## Test plan
- [x] Markdown-only change

Made with [Cursor](https://cursor.com)