### PR TITLE
docs: add required includes to skipping-passing-failing examples (#2519)

### DIFF
--- a/docs/skipping-passing-failing.md
+++ b/docs/skipping-passing-failing.md
@@ -21,6 +21,8 @@ SKIP( [streamable expression] )
 Example usage:
 
 ```c++
+#include <catch2/catch_test_macros.hpp>
+
 TEST_CASE("copy files between drives") {
     if(getNumberOfHardDrives() < 2) {
         SKIP("at least two hard drives required");
@@ -72,6 +74,9 @@ Sections, nested sections as well as specific outputs from [generators](generato
 can all be individually skipped, with the rest executing as usual:
 
 ```c++
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
 TEST_CASE("complex test case") {
   int value = GENERATE(2, 4, 6);
   SECTION("a") {

--- a/docs/skipping-passing-failing.md
+++ b/docs/skipping-passing-failing.md
@@ -127,6 +127,8 @@ _In practice, `SUCCEED` is usually used as a test placeholder, to avoid
 [failing a test case due to missing assertions](command-line.md#warnings)._
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
 TEST_CASE( "SUCCEED showcase" ) {
     int I = 1;
     SUCCEED( "I is " << I );
@@ -142,6 +144,8 @@ _In practice, `FAIL` is usually used to stop executing test that is currently
 known to be broken, but has to be fixed later._
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
 TEST_CASE( "FAIL showcase" ) {
     FAIL( "This test case causes segfault, which breaks CI." );
     // ... this will not be executed ...


### PR DESCRIPTION
## Summary
- Add `#include` lines to representative `SKIP`, `GENERATE`, `SUCCEED`, and `FAIL` examples

Continues #3118–#3122; partial fix for #2519.

## Test plan
- [x] Markdown-only change

Made with [Cursor](https://cursor.com)