### PR TITLE
docs: add required includes to tostring and benchmarks examples (#2519)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -183,6 +183,8 @@ It is also possible to just provide an argument name to the simple `BENCHMARK` m
 the same semantics as providing a callable to `meter.measure` with `int` argument:
 
 ```c++
+#include <catch2/benchmark/catch_benchmark.hpp>
+
 BENCHMARK("indexed", i){ return long_computation(i); };
 ```
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -57,6 +57,11 @@ std::uint64_t Fibonacci(std::uint64_t number) {
 ```
 Now the most straight forward way to benchmark this function, is just adding a `BENCHMARK` macro to our test case:
 ```c++
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+
 TEST_CASE("Fibonacci") {
     CHECK(Fibonacci(0) == 1);
     // some more asserts..
@@ -122,6 +127,8 @@ while the blocks of the advanced benchmarks are invoked exactly twice:
 once during the estimation phase, and another time during the execution phase.
 
 ```c++
+#include <catch2/benchmark/catch_benchmark.hpp>
+
 BENCHMARK("simple"){ return long_computation(); };
 
 BENCHMARK_ADVANCED("advanced")(Catch::Benchmark::Chronometer meter) {
@@ -146,6 +153,8 @@ The callable object passed in to `measure` can optionally accept an `int`
 parameter.
 
 ```c++
+#include <catch2/benchmark/catch_benchmark.hpp>
+
 meter.measure([](int i) { return long_computation(i); });
 ```
 
@@ -156,6 +165,11 @@ for example. The number of runs can be known beforehand by calling
 mutated by each run.
 
 ```c++
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+#include <string>
+#include <vector>
+
 std::vector<std::string> v(meter.runs());
 std::fill(v.begin(), v.end(), test_string());
 meter.measure([&v](int i) { in_place_escape(v[i]); });
@@ -186,6 +200,8 @@ construct and destroy objects without dynamic allocation and in a way that lets
 you measure construction and destruction separately.
 
 ```c++
+#include <catch2/benchmark/catch_benchmark.hpp>
+
 BENCHMARK_ADVANCED("construct")(Catch::Benchmark::Chronometer meter) {
     std::vector<Catch::Benchmark::storage_for<std::string>> storage(meter.runs());
     meter.measure([&](int i) { storage[i].construct("thing"); });
@@ -232,6 +248,8 @@ That helps with keeping the code in a natural fashion.
 Here's an example:
 
 ```c++
+#include <catch2/benchmark/catch_benchmark.hpp>
+
 // may measure nothing at all by skipping the long calculation since its
 // result is not used
 BENCHMARK("no return"){ long_calculation(); };

--- a/docs/tostring.md
+++ b/docs/tostring.md
@@ -64,6 +64,8 @@ namespace Catch {
 By default all exceptions deriving from `std::exception` will be translated to strings by calling the `what()` method. For exception types that do not derive from `std::exception` - or if `what()` does not return a suitable string - use `CATCH_TRANSLATE_EXCEPTION`. This defines a function that takes your exception type, by reference, and returns a string. It can appear anywhere in the code - it doesn't have to be in the same translation unit. For example:
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
 CATCH_TRANSLATE_EXCEPTION( MyType const& ex ) {
     return ex.message();
 }
@@ -81,6 +83,8 @@ Simply provide it the (qualified) enum name, followed by all the enum values, an
 E.g.
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
 enum class Fruits { Banana, Apple, Mango };
 
 CATCH_REGISTER_ENUM( Fruits, Fruits::Banana, Fruits::Apple, Fruits::Mango )
@@ -92,6 +96,8 @@ TEST_CASE() {
 
 ... or if the enum is in a namespace:
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
 namespace Bikeshed {
     enum class Colours { Red, Green, Blue };
 }
@@ -118,6 +124,8 @@ but you can customize it by modifying the `precision` static variable
 inside the `StringMaker` specialization, like so:
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
         Catch::StringMaker<float>::precision = 15;
         const float testFloat1 = 1.12345678901234567899f;
         const float testFloat2 = 1.12345678991234567899f;


### PR DESCRIPTION
## Summary
- **tostring.md:** `catch_test_macros.hpp` for `CATCH_TRANSLATE_EXCEPTION`, `CATCH_REGISTER_ENUM`, and `StringMaker` precision examples
- **benchmarks.md:** `catch_benchmark.hpp` and `catch_test_macros.hpp` for benchmark snippets

Continues #3118–#3125; partial fix for #2519.

## Test plan
- [x] Markdown-only change

Made with [Cursor](https://cursor.com)