### PR TITLE
docs: add required includes to thread-safety and filtering examples (#2519)

### DIFF
--- a/docs/filtering-execution-path.md
+++ b/docs/filtering-execution-path.md
@@ -49,6 +49,8 @@ the section can be opened. If not, Catch2 will skip over that section.
 #### Simple section nesting
 Given
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
 TEST_CASE( "foo" ) {
     REQUIRE( true );
     SECTION( "A" ) {
@@ -75,6 +77,9 @@ Note that old behaviour completely _ignores_ generators. This means both
 that they can't be filtered, but also that they aren't taken into account
 for the filter depth. In other words, given
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
 TEST_CASE( "bar" ) {
     REQUIRE( true );
     SECTION( "A" ) { REQUIRE( true ); }
@@ -100,6 +105,9 @@ TEST_CASE( "bar" ) {
 For cases where sections have sibling generators, the filtering can get
 even more surprising.
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
 TEST_CASE( "qux" ) {
     REQUIRE( true );
     SECTION( "A" ) { REQUIRE( true ); }
@@ -151,6 +159,9 @@ equivalent, causing the section to be considered skipped.
 
 #### Nested generators
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
 TEST_CASE( "waldo" ) {
     auto i = GENERATE( 1, 10, 100 );
     auto j = GENERATE( 2, 20, 200 );
@@ -171,6 +182,9 @@ TEST_CASE( "waldo" ) {
 
 #### Generator with a nested dynamic section
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
 TEST_CASE( "grault" ) {
     REQUIRE( true );
     auto i = GENERATE( 1, 2, 3 );
@@ -191,6 +205,9 @@ Because generators have to stop test execution when they don't pass filter,
 it is impossible to run only a section with sibling generator without
 triggering a test case skip. Consider this test case from an earlier example:
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
 TEST_CASE( "qux" ) {
     REQUIRE( true );
     SECTION( "A" ) { REQUIRE( true ); }

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -70,6 +70,11 @@ thread will not be seen by the main thread, and vice versa.
 ### `REQUIRE` from the main thread, `CHECK` from spawned threads
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
+#include <thread>
+#include <vector>
+
 TEST_CASE( "Failed REQUIRE in the main thread is fine" ) {
     std::vector<std::jthread> threads;
     for ( size_t t = 0; t < 16; ++t) {
@@ -94,6 +99,11 @@ the spawned threads will keep running.
 ### `REQUIRE` from spawned threads
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
+#include <thread>
+#include <vector>
+
 TEST_CASE( "Successful REQUIRE in spawned thread is fine" ) {
     std::vector<std::jthread> threads;
     for ( size_t t = 0; t < 16; ++t) {
@@ -108,6 +118,11 @@ TEST_CASE( "Successful REQUIRE in spawned thread is fine" ) {
 This will also work as expected, because the `REQUIRE` is successful.
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
+#include <thread>
+#include <vector>
+
 TEST_CASE( "Failed REQUIRE in spawned thread kills the process" ) {
     std::vector<std::jthread> threads;
     for ( size_t t = 0; t < 16; ++t) {
@@ -125,6 +140,10 @@ This will fail catastrophically and terminate the process.
 ### INFO across threads
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
+#include <thread>
+
 TEST_CASE( "messages don't cross threads" ) {
     std::jthread t1( [&]() {
         for ( size_t i = 0; i < 100; ++i ) {
@@ -156,6 +175,11 @@ assertions in `t2`.
 ### FAIL/SKIP from the main thread
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
+#include <thread>
+#include <vector>
+
 TEST_CASE( "FAIL in the main thread is fine" ) {
     std::vector<std::jthread> threads;
     for ( size_t t = 0; t < 16; ++t) {
@@ -185,6 +209,11 @@ the spawned threads will keep running and may fail the test case.
 ### FAIL/SKIP from spawned threads
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
+#include <thread>
+#include <vector>
+
 TEST_CASE( "FAIL/SKIP in spawned thread kills the process" ) {
     std::vector<std::jthread> threads;
     for ( size_t t = 0; t < 16; ++t) {


### PR DESCRIPTION
## Summary
- **thread-safety.md:** `catch_test_macros.hpp` plus `<thread>`/`<vector>` for jthread examples
- **filtering-execution-path.md:** `catch_generators.hpp` where `GENERATE` is used

Continues #3118–#3126; partial fix for #2519.

## Test plan
- [x] Markdown-only change

Made with [Cursor](https://cursor.com)