### PR TITLE
docs: add includes to limitations, configuration, and other-macros (#2519)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -259,6 +259,10 @@ happens instead of exception being thrown. To use it, define
 and provide a definition for this function:
 
 ```cpp
+#include <catch2/catch_config.hpp>
+
+#include <exception>
+
 namespace Catch {
     [[noreturn]]
     void throw_exception(std::exception const&);

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -15,6 +15,10 @@ different name per loop's iteration. The recommended way to do so is to
 incorporate the loop's counter into section's name, like so:
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
 TEST_CASE( "Looped section" ) {
     for (char i = '0'; i < '5'; ++i) {
         SECTION(std::string("Looped section ") + i) {
@@ -27,6 +31,8 @@ TEST_CASE( "Looped section" ) {
 or with a `DYNAMIC_SECTION` macro (that was made for exactly this purpose):
 
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
 TEST_CASE( "Looped section" ) {
     for (char i = '0'; i < '5'; ++i) {
         DYNAMIC_SECTION( "Looped section " << i) {
@@ -93,6 +99,8 @@ to trigger the compilation error:
 ```cpp
 #include <catch2/catch_test_macros.hpp>
 
+#include <string>
+
 TEST_CASE("test") {
     CHECK(std::string(R"("\)") == "\"\\");
 }
@@ -104,6 +112,8 @@ like so:
 ```cpp
 #define CATCH_CONFIG_DISABLE_STRINGIFICATION
 #include <catch2/catch_test_macros.hpp>
+
+#include <string>
 
 TEST_CASE("test") {
     CHECK(std::string(R"("\)") == "\"\\");

--- a/docs/other-macros.md
+++ b/docs/other-macros.md
@@ -125,6 +125,10 @@ the description can contain both name and tags.
 
 Example:
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
+void someFunction();
+
 REGISTER_TEST_CASE( someFunction, "ManuallyRegistered", "[tags]" );
 ```
 
@@ -143,6 +147,8 @@ generators, or when creating a `SECTION` dynamically, within a loop.
 
 Example:
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
 TEST_CASE( "looped SECTION tests" ) {
     int a = 1;
 


### PR DESCRIPTION
## Summary
- **limitations.md:** add `<string>` where needed; keep existing `catch_test_macros.hpp` blocks
- **configuration.md:** `catch_config.hpp` + `<exception>` for custom `throw_exception` handler
- **other-macros.md:** `REGISTER_TEST_CASE` and `DYNAMIC_SECTION` examples (complements #3124)

Continues #3118–#3127; partial fix for #2519.

## Test plan
- [x] Markdown-only change

Made with [Cursor](https://cursor.com)