### PR TITLE
docs: add includes to assertions workaround examples (#2519)

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -174,6 +174,8 @@ less clear.
 
 2) Parenthesize the expression:
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
 TEST_CASE_METHOD((Fixture<int, int>), "foo", "[bar]") {
     SUCCEED();
 }

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -160,6 +160,11 @@ but the macro accepts only 2. There are two possible workarounds.
 
 1) Use typedef:
 ```cpp
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdexcept>
+#include <utility>
+
 using int_pair = std::pair<int, int>;
 REQUIRE_THROWS_AS(int_pair(1, 2), std::invalid_argument);
 ```


### PR DESCRIPTION
## Summary
Add `catch_test_macros.hpp` and standard headers to preprocessor workaround examples in `assertions.md` (complements #3120).

Continues #3118–#3129; partial fix for #2519.

## Test plan
- [x] Markdown-only change

Made with [Cursor](https://cursor.com)