### PR TITLE
docs: link examples index from Readme (Fixes #1037)

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -4,6 +4,9 @@
 To get the most out of Catch2, start with the [tutorial](tutorial.md#top).
 Once you're up and running consider the following reference material.
 
+For complete, compilable sample programs, see the [list of examples](list-of-examples.md#top)
+in `examples/` (built as part of CI). Related: [#1037](https://github.com/catchorg/Catch2/issues/1037).
+
 **Writing tests:**
 * [Assertion macros](assertions.md#top)
 * [Matchers (asserting complex properties)](matchers.md#top)

--- a/docs/list-of-examples.md
+++ b/docs/list-of-examples.md
@@ -1,6 +1,10 @@
 <a id="top"></a>
 # List of examples
 
+The `.cpp` files under [`examples/`](../examples/) are complete, compilable programs
+referenced throughout the docs. They are built and run as part of Catch2's CMake/CI
+test suite, so they stay in sync with the library.
+
 ## Already available
 
 - Test Case: [Single-file](../examples/010-TestCase.cpp)
@@ -12,6 +16,7 @@
 - BDD: [SCENARIO, GIVEN, WHEN, THEN](../examples/120-Bdd-ScenarioGivenWhenThen.cpp)
 - Listener: [Listeners](../examples/210-Evt-EventListeners.cpp)
 - Configuration: [Provide your own output streams](../examples/231-Cfg-OutputStreams.cpp)
+- Configuration: [Provide your own main()](../examples/232-Cfg-CustomMain.cpp)
 - Generators: [Create your own generator](../examples/300-Gen-OwnGenerator.cpp)
 - Generators: [Use map to convert types in GENERATE expression](../examples/301-Gen-MapTypeConversion.cpp)
 - Generators: [Run test with a table of input values](../examples/302-Gen-Table.cpp)


### PR DESCRIPTION
## Summary
- Link `docs/list-of-examples.md` from the documentation index in `docs/Readme.md`.
- Note that `examples/` programs are built and run in CI.
- Add the custom-main configuration example to the examples list.

Fixes #1037

## Test plan
- [x] Docs-only change; verified links resolve to existing `examples/*.cpp` files.

Made with [Cursor](https://cursor.com)