### PR TITLE
docs: link examples index from tutorial Next steps (#1037)

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -222,6 +222,9 @@ can get you quite far, but there are many more. However, you can read
 about these as you go, in the ever-growing [reference section](Readme.md#top)
 of the documentation.
 
+For full, compilable sample programs, see the [list of examples](list-of-examples.md#top)
+in `examples/` ([#1037](https://github.com/catchorg/Catch2/issues/1037)).
+
 
 ---
 


### PR DESCRIPTION
## Summary
- Point readers finishing the tutorial to `list-of-examples.md` for full compilable samples in `examples/`.

Complements #3135 (Readme link). Related to #1037.

## Test plan
- [x] Docs-only change; link target exists on `devel`.

Made with [Cursor](https://cursor.com)