### PR TITLE
docs: link usage tips to examples and include guidance (#2519)

### DIFF
--- a/docs/usage-tips.md
+++ b/docs/usage-tips.md
@@ -1,6 +1,9 @@
 <a id="top"></a>
 # Best practices and other tips on using Catch2
 
+Reference pages list the Catch2 headers required for each feature ([#2519](https://github.com/catchorg/Catch2/issues/2519)).
+Compilable samples live under [`examples/`](list-of-examples.md#top) ([#1037](https://github.com/catchorg/Catch2/issues/1037)).
+
 ## Running tests
 
 Your tests should be run in a manner roughly equivalent with:


### PR DESCRIPTION
## Summary
- Note #2519 include guidance and link to the examples index ([#1037](https://github.com/catchorg/Catch2/issues/1037)).

## Test plan
- [x] Docs-only.

Made with [Cursor](https://cursor.com)