### PR TITLE
docs: note modular headers after v2-to-v3 migration (#2519)

### DIFF
--- a/docs/migrate-v2-to-v3.md
+++ b/docs/migrate-v2-to-v3.md
@@ -26,6 +26,8 @@ distribution but do not consider it the primarily supported option. You
 should also expect that the compilation times will be worse if you use
 this option._
 
+After migration, prefer listing the modular headers each test needs in documentation and examples ([#2519](https://github.com/catchorg/Catch2/issues/2519)).
+
 
 ## How to migrate projects from v2 to v3
 


### PR DESCRIPTION
## Summary
Encourage documenting modular includes after migration. Complements #3142.

## Test plan
- [x] Docs-only.

Made with [Cursor](https://cursor.com)