### PR TITLE
docs: link commercial-users to contributing guide

### DIFF
--- a/docs/commercial-users.md
+++ b/docs/commercial-users.md
@@ -5,7 +5,7 @@ Catch2 is also widely used in proprietary code bases. This page contains
 some of them that are willing to share this information.
 
 If you want to add your organisation, please check that there is no issue
-with you sharing this fact.
+with you sharing this fact. See [contributing.md](contributing.md#top) for how to propose an update.
 
  - Bloomberg
  - [Bloomlife](https://bloomlife.com)


### PR DESCRIPTION
## Summary
Docs-only improvement.

## Test plan
- [x] Docs-only.

Made with [Cursor](https://cursor.com)