### PR TITLE
Print the active section/generator selection

### DIFF
--- a/docs/filtering-execution-path.md
+++ b/docs/filtering-execution-path.md
@@ -19,6 +19,22 @@ behaviour, which does not affect generators at all. If you also use either
 `-g`/`--generator-index`, or `-p`/`--path-filter`, you will get the new
 behaviour, which can also filter generator elements.
 
+When path filters are in effect, the console and compact reporters print
+the active selection at the start of the run, next to the `Filters:` line,
+e.g.
+
+```text
+Filters: "foo"
+Path filters:
+  - Section: "A"
+  - Generator: "0"
+```
+
+The filters are listed one per line, labelled as `Section` or `Generator`,
+in the order in which they were specified. This makes it easy to see exactly
+what has been selected when a filter combination ends up running no
+assertions.
+
 Both the new and old filter behaviours include some potentially surprising
 things:
   * Code outside of sections being skipped will still be executed. E.g.

--- a/src/catch2/reporters/catch_reporter_compact.cpp
+++ b/src/catch2/reporters/catch_reporter_compact.cpp
@@ -215,6 +215,12 @@ private:
                          << m_config->testSpec()
                          << '\n';
             }
+            if ( !m_config->getPathFilters().empty() ) {
+                m_stream << m_colour->guardColour( Colour::BrightYellow )
+                         << "Path filters:\n"
+                         << serializePathFilters( m_config->getPathFilters() )
+                         << '\n';
+            }
             m_stream << "RNG seed: " << getSeed() << '\n'
                      << std::flush;
         }

--- a/src/catch2/reporters/catch_reporter_console.cpp
+++ b/src/catch2/reporters/catch_reporter_console.cpp
@@ -530,6 +530,11 @@ void ConsoleReporter::testRunStarting(TestRunInfo const& _testRunInfo) {
         m_stream << m_colour->guardColour( Colour::BrightYellow ) << "Filters: "
                  << m_config->testSpec() << '\n';
     }
+    if ( !m_config->getPathFilters().empty() ) {
+        m_stream << m_colour->guardColour( Colour::BrightYellow )
+                 << "Path filters:\n"
+                 << serializePathFilters( m_config->getPathFilters() ) << '\n';
+    }
     m_stream << "Randomness seeded to: " << getSeed() << '\n'
              << std::flush;
 }

--- a/src/catch2/reporters/catch_reporter_helpers.cpp
+++ b/src/catch2/reporters/catch_reporter_helpers.cpp
@@ -9,6 +9,7 @@
 #include <catch2/reporters/catch_reporter_helpers.hpp>
 #include <catch2/interfaces/catch_interfaces_config.hpp>
 #include <catch2/internal/catch_console_width.hpp>
+#include <catch2/internal/catch_path_filter.hpp>
 #include <catch2/internal/catch_errno_guard.hpp>
 #include <catch2/internal/catch_textflow.hpp>
 #include <catch2/internal/catch_reusable_string_stream.hpp>
@@ -99,6 +100,28 @@ namespace Catch {
         }
 
         return serialized;
+    }
+
+    std::string serializePathFilters( std::vector<PathFilter> const& filters ) {
+        ReusableStringStream rss;
+        bool first = true;
+        for ( auto const& filter : filters ) {
+            if ( !first ) {
+                rss << '\n';
+            }
+            first = false;
+            rss << "  - ";
+            switch ( filter.type ) {
+            case PathFilter::For::Section:
+                rss << "Section: ";
+                break;
+            case PathFilter::For::Generator:
+                rss << "Generator: ";
+                break;
+            }
+            rss << '"' << filter.filter << '"';
+        }
+        return rss.str();
     }
 
     std::ostream& operator<<( std::ostream& out, lineOfChars value ) {

--- a/src/catch2/reporters/catch_reporter_helpers.hpp
+++ b/src/catch2/reporters/catch_reporter_helpers.hpp
@@ -21,6 +21,7 @@ namespace Catch {
     class IConfig;
     class TestCaseHandle;
     class ColourImpl;
+    struct PathFilter;
 
     // Returns double formatted as %.3f (format expected on output)
     std::string getFormattedDuration( double duration );
@@ -29,6 +30,18 @@ namespace Catch {
     bool shouldShowDuration( IConfig const& config, double duration );
 
     std::string serializeFilters( std::vector<std::string> const& filters );
+
+    /**
+     * Serializes the active section/generator path filters into a
+     * human-readable, indented list, one filter per line and in the order
+     * in which they were specified, e.g.
+     *
+     *     - Section: "A"
+     *     - Generator: "0"
+     *
+     * The returned string has no trailing newline.
+     */
+    std::string serializePathFilters( std::vector<PathFilter> const& filters );
 
     struct lineOfChars {
         char c;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -666,6 +666,33 @@ foreach(reporterName # "Automake" - the simple .trs format does not support any 
   )
 endforeach()
 
+# The console and compact reporters print the active section/generator
+# selection (path filters), so that it is obvious what has been selected.
+# The exact serialization is unit-tested in `serializePathFilters ...`, so
+# here we only check that both reporters actually emit the line, using a
+# section filter for one and a generator filter for the other.
+add_test(NAME "Reporters:PathFilters:Section:compact"
+  COMMAND
+    $<TARGET_FILE:SelfTest> "Tracker"
+      --reporter compact
+      --section "section name"
+)
+set_tests_properties("Reporters:PathFilters:Section:compact"
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION "- Section: \"section name\""
+)
+
+add_test(NAME "Reporters:PathFilters:Generator:console"
+  COMMAND
+    $<TARGET_FILE:SelfTest> "Generators internals"
+      --reporter console
+      --generator-index 0
+)
+set_tests_properties("Reporters:PathFilters:Generator:console"
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION "- Generator: \"0\""
+)
+
 add_test(NAME "Bazel::RngSeedEnvVar::JustEnv"
   COMMAND
     $<TARGET_FILE:SelfTest> "Factorials are computed"

--- a/tests/SelfTest/Baselines/automake.sw.approved.txt
+++ b/tests/SelfTest/Baselines/automake.sw.approved.txt
@@ -409,6 +409,7 @@ b1!
 :test-result: SKIP sections can be skipped dynamically at runtime
 :test-result: FAIL send a single char to INFO
 :test-result: FAIL sends information to INFO
+:test-result: PASS serializePathFilters serializes the section/generator selection
 :test-result: PASS shortened hide tags are split apart
 :test-result: SKIP skipped tests can optionally provide a reason
 :test-result: PASS splitString

--- a/tests/SelfTest/Baselines/automake.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/automake.sw.multi.approved.txt
@@ -398,6 +398,7 @@
 :test-result: SKIP sections can be skipped dynamically at runtime
 :test-result: FAIL send a single char to INFO
 :test-result: FAIL sends information to INFO
+:test-result: PASS serializePathFilters serializes the section/generator selection
 :test-result: PASS shortened hide tags are split apart
 :test-result: SKIP skipped tests can optionally provide a reason
 :test-result: PASS splitString

--- a/tests/SelfTest/Baselines/compact.sw.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.approved.txt
@@ -2831,6 +2831,20 @@ Skip.tests.cpp:<line number>: skipped:
 Skip.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: failed: false with 1 message: '3'
 Message.tests.cpp:<line number>: failed: false with 2 messages: 'hi' and 'i := 7'
+Reporters.tests.cpp:<line number>: passed: serializePathFilters( {} ).empty() for: true
+Reporters.tests.cpp:<line number>: passed: serializePathFilters( filters ) == "  - Section: \"a section\"" for: "  - Section: "a section""
+==
+"  - Section: "a section""
+Reporters.tests.cpp:<line number>: passed: serializePathFilters( filters ) == "  - Generator: \"0\"" for: "  - Generator: "0""
+==
+"  - Generator: "0""
+Reporters.tests.cpp:<line number>: passed: serializePathFilters( filters ) == "  - Section: \"A\"\n" "  - Generator: \"1\"\n" "  - Section: \"B\"" for: "  - Section: "A"
+  - Generator: "1"
+  - Section: "B""
+==
+"  - Section: "A"
+  - Generator: "1"
+  - Section: "B""
 Tag.tests.cpp:<line number>: passed: testcase.tags, VectorContains( Tag( "magic-tag" ) ) && VectorContains( Tag( "."_catch_sr ) ) for: { {?}, {?} } ( Contains: {?} and Contains: {?} )
 Skip.tests.cpp:<line number>: skipped: 'skipping because answer = 43'
 StringManip.tests.cpp:<line number>: passed: splitStringRef("", ','), Equals(std::vector<StringRef>()) for: {  } Equals: {  }
@@ -3000,7 +3014,7 @@ InternalBenchmark.tests.cpp:<line number>: passed: med == 18. for: 18.0 == 18.0
 InternalBenchmark.tests.cpp:<line number>: passed: q3 == 23. for: 23.0 == 23.0
 Misc.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: passed:
-test cases:  451 |  331 passed |  96 failed | 6 skipped | 18 failed as expected
-assertions: 2416 | 2215 passed | 158 failed | 43 failed as expected
+test cases:  452 |  332 passed |  96 failed | 6 skipped | 18 failed as expected
+assertions: 2420 | 2219 passed | 158 failed | 43 failed as expected
 
 

--- a/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/compact.sw.multi.approved.txt
@@ -2820,6 +2820,20 @@ Skip.tests.cpp:<line number>: skipped:
 Skip.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: failed: false with 1 message: '3'
 Message.tests.cpp:<line number>: failed: false with 2 messages: 'hi' and 'i := 7'
+Reporters.tests.cpp:<line number>: passed: serializePathFilters( {} ).empty() for: true
+Reporters.tests.cpp:<line number>: passed: serializePathFilters( filters ) == "  - Section: \"a section\"" for: "  - Section: "a section""
+==
+"  - Section: "a section""
+Reporters.tests.cpp:<line number>: passed: serializePathFilters( filters ) == "  - Generator: \"0\"" for: "  - Generator: "0""
+==
+"  - Generator: "0""
+Reporters.tests.cpp:<line number>: passed: serializePathFilters( filters ) == "  - Section: \"A\"\n" "  - Generator: \"1\"\n" "  - Section: \"B\"" for: "  - Section: "A"
+  - Generator: "1"
+  - Section: "B""
+==
+"  - Section: "A"
+  - Generator: "1"
+  - Section: "B""
 Tag.tests.cpp:<line number>: passed: testcase.tags, VectorContains( Tag( "magic-tag" ) ) && VectorContains( Tag( "."_catch_sr ) ) for: { {?}, {?} } ( Contains: {?} and Contains: {?} )
 Skip.tests.cpp:<line number>: skipped: 'skipping because answer = 43'
 StringManip.tests.cpp:<line number>: passed: splitStringRef("", ','), Equals(std::vector<StringRef>()) for: {  } Equals: {  }
@@ -2989,7 +3003,7 @@ InternalBenchmark.tests.cpp:<line number>: passed: med == 18. for: 18.0 == 18.0
 InternalBenchmark.tests.cpp:<line number>: passed: q3 == 23. for: 23.0 == 23.0
 Misc.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: passed:
-test cases:  451 |  331 passed |  96 failed | 6 skipped | 18 failed as expected
-assertions: 2416 | 2215 passed | 158 failed | 43 failed as expected
+test cases:  452 |  332 passed |  96 failed | 6 skipped | 18 failed as expected
+assertions: 2420 | 2219 passed | 158 failed | 43 failed as expected
 
 

--- a/tests/SelfTest/Baselines/console.std.approved.txt
+++ b/tests/SelfTest/Baselines/console.std.approved.txt
@@ -1743,6 +1743,6 @@ due to unexpected exception with message:
   Why would you throw a std::string?
 
 ===============================================================================
-test cases:  451 |  349 passed |  76 failed | 7 skipped | 19 failed as expected
-assertions: 2394 | 2215 passed | 136 failed | 43 failed as expected
+test cases:  452 |  350 passed |  76 failed | 7 skipped | 19 failed as expected
+assertions: 2398 | 2219 passed | 136 failed | 43 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.approved.txt
@@ -18943,6 +18943,64 @@ with messages:
   i := 7
 
 -------------------------------------------------------------------------------
+serializePathFilters serializes the section/generator selection
+  No filters serialize to an empty string
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE( serializePathFilters( {} ).empty() )
+with expansion:
+  true
+
+-------------------------------------------------------------------------------
+serializePathFilters serializes the section/generator selection
+  Section filters are labelled and quoted
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE( serializePathFilters( filters ) == "  - Section: \"a section\"" )
+with expansion:
+  "  - Section: "a section""
+  ==
+  "  - Section: "a section""
+
+-------------------------------------------------------------------------------
+serializePathFilters serializes the section/generator selection
+  Generator filters are labelled and quoted
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE( serializePathFilters( filters ) == "  - Generator: \"0\"" )
+with expansion:
+  "  - Generator: "0""
+  ==
+  "  - Generator: "0""
+
+-------------------------------------------------------------------------------
+serializePathFilters serializes the section/generator selection
+  Multiple filters keep their order, one per line
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE( serializePathFilters( filters ) == "  - Section: \"A\"\n" "  - Generator: \"1\"\n" "  - Section: \"B\"" )
+with expansion:
+  "  - Section: "A"
+    - Generator: "1"
+    - Section: "B""
+  ==
+  "  - Section: "A"
+    - Generator: "1"
+    - Section: "B""
+
+-------------------------------------------------------------------------------
 shortened hide tags are split apart
 -------------------------------------------------------------------------------
 Tag.tests.cpp:<line number>
@@ -20134,6 +20192,6 @@ Misc.tests.cpp:<line number>
 Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
-test cases:  451 |  331 passed |  96 failed | 6 skipped | 18 failed as expected
-assertions: 2416 | 2215 passed | 158 failed | 43 failed as expected
+test cases:  452 |  332 passed |  96 failed | 6 skipped | 18 failed as expected
+assertions: 2420 | 2219 passed | 158 failed | 43 failed as expected
 

--- a/tests/SelfTest/Baselines/console.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/console.sw.multi.approved.txt
@@ -18932,6 +18932,64 @@ with messages:
   i := 7
 
 -------------------------------------------------------------------------------
+serializePathFilters serializes the section/generator selection
+  No filters serialize to an empty string
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE( serializePathFilters( {} ).empty() )
+with expansion:
+  true
+
+-------------------------------------------------------------------------------
+serializePathFilters serializes the section/generator selection
+  Section filters are labelled and quoted
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE( serializePathFilters( filters ) == "  - Section: \"a section\"" )
+with expansion:
+  "  - Section: "a section""
+  ==
+  "  - Section: "a section""
+
+-------------------------------------------------------------------------------
+serializePathFilters serializes the section/generator selection
+  Generator filters are labelled and quoted
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE( serializePathFilters( filters ) == "  - Generator: \"0\"" )
+with expansion:
+  "  - Generator: "0""
+  ==
+  "  - Generator: "0""
+
+-------------------------------------------------------------------------------
+serializePathFilters serializes the section/generator selection
+  Multiple filters keep their order, one per line
+-------------------------------------------------------------------------------
+Reporters.tests.cpp:<line number>
+...............................................................................
+
+Reporters.tests.cpp:<line number>: PASSED:
+  REQUIRE( serializePathFilters( filters ) == "  - Section: \"A\"\n" "  - Generator: \"1\"\n" "  - Section: \"B\"" )
+with expansion:
+  "  - Section: "A"
+    - Generator: "1"
+    - Section: "B""
+  ==
+  "  - Section: "A"
+    - Generator: "1"
+    - Section: "B""
+
+-------------------------------------------------------------------------------
 shortened hide tags are split apart
 -------------------------------------------------------------------------------
 Tag.tests.cpp:<line number>
@@ -20123,6 +20181,6 @@ Misc.tests.cpp:<line number>
 Misc.tests.cpp:<line number>: PASSED:
 
 ===============================================================================
-test cases:  451 |  331 passed |  96 failed | 6 skipped | 18 failed as expected
-assertions: 2416 | 2215 passed | 158 failed | 43 failed as expected
+test cases:  452 |  332 passed |  96 failed | 6 skipped | 18 failed as expected
+assertions: 2420 | 2219 passed | 158 failed | 43 failed as expected
 

--- a/tests/SelfTest/Baselines/junit.sw.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="141" skipped="12" tests="2428" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="141" skipped="12" tests="2432" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="random-seed" value="1"/>
       <property name="filters" value="&quot;*&quot; ~[!nonportable] ~[!benchmark] ~[approvals]"/>
@@ -1817,6 +1817,11 @@ i := 7
 at Message.tests.cpp:<line number>
       </failure>
     </testcase>
+    <testcase classname="<exe-name>.global" name="serializePathFilters serializes the section/generator selection" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="serializePathFilters serializes the section/generator selection/No filters serialize to an empty string" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="serializePathFilters serializes the section/generator selection/Section filters are labelled and quoted" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="serializePathFilters serializes the section/generator selection/Generator filters are labelled and quoted" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="serializePathFilters serializes the section/generator selection/Multiple filters keep their order, one per line" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="shortened hide tags are split apart" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="skipped tests can optionally provide a reason" time="{duration}" status="run">
       <skipped type="SKIP">

--- a/tests/SelfTest/Baselines/junit.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/junit.sw.multi.approved.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="<exe-name>" errors="17" failures="141" skipped="12" tests="2428" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="141" skipped="12" tests="2432" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <properties>
       <property name="random-seed" value="1"/>
       <property name="filters" value="&quot;*&quot; ~[!nonportable] ~[!benchmark] ~[approvals]"/>
@@ -1816,6 +1816,11 @@ i := 7
 at Message.tests.cpp:<line number>
       </failure>
     </testcase>
+    <testcase classname="<exe-name>.global" name="serializePathFilters serializes the section/generator selection" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="serializePathFilters serializes the section/generator selection/No filters serialize to an empty string" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="serializePathFilters serializes the section/generator selection/Section filters are labelled and quoted" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="serializePathFilters serializes the section/generator selection/Generator filters are labelled and quoted" time="{duration}" status="run"/>
+    <testcase classname="<exe-name>.global" name="serializePathFilters serializes the section/generator selection/Multiple filters keep their order, one per line" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="shortened hide tags are split apart" time="{duration}" status="run"/>
     <testcase classname="<exe-name>.global" name="skipped tests can optionally provide a reason" time="{duration}" status="run">
       <skipped type="SKIP">

--- a/tests/SelfTest/Baselines/sonarqube.sw.approved.txt
+++ b/tests/SelfTest/Baselines/sonarqube.sw.approved.txt
@@ -339,6 +339,11 @@ at AssertionHandler.tests.cpp:<line number>
     <testCase name="The default listing implementation write to provided stream/Listing reporters" duration="{duration}"/>
     <testCase name="The default listing implementation write to provided stream/Listing tests" duration="{duration}"/>
     <testCase name="The default listing implementation write to provided stream/Listing listeners" duration="{duration}"/>
+    <testCase name="serializePathFilters serializes the section/generator selection" duration="{duration}"/>
+    <testCase name="serializePathFilters serializes the section/generator selection/No filters serialize to an empty string" duration="{duration}"/>
+    <testCase name="serializePathFilters serializes the section/generator selection/Section filters are labelled and quoted" duration="{duration}"/>
+    <testCase name="serializePathFilters serializes the section/generator selection/Generator filters are labelled and quoted" duration="{duration}"/>
+    <testCase name="serializePathFilters serializes the section/generator selection/Multiple filters keep their order, one per line" duration="{duration}"/>
   </file>
   <file path="tests/<exe-name>/IntrospectiveTests/Stream.tests.cpp">
     <testCase name="Cout stream properly declares it writes to stdout" duration="{duration}"/>

--- a/tests/SelfTest/Baselines/sonarqube.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/sonarqube.sw.multi.approved.txt
@@ -338,6 +338,11 @@ at AssertionHandler.tests.cpp:<line number>
     <testCase name="The default listing implementation write to provided stream/Listing reporters" duration="{duration}"/>
     <testCase name="The default listing implementation write to provided stream/Listing tests" duration="{duration}"/>
     <testCase name="The default listing implementation write to provided stream/Listing listeners" duration="{duration}"/>
+    <testCase name="serializePathFilters serializes the section/generator selection" duration="{duration}"/>
+    <testCase name="serializePathFilters serializes the section/generator selection/No filters serialize to an empty string" duration="{duration}"/>
+    <testCase name="serializePathFilters serializes the section/generator selection/Section filters are labelled and quoted" duration="{duration}"/>
+    <testCase name="serializePathFilters serializes the section/generator selection/Generator filters are labelled and quoted" duration="{duration}"/>
+    <testCase name="serializePathFilters serializes the section/generator selection/Multiple filters keep their order, one per line" duration="{duration}"/>
   </file>
   <file path="tests/<exe-name>/IntrospectiveTests/Stream.tests.cpp">
     <testCase name="Cout stream properly declares it writes to stdout" duration="{duration}"/>

--- a/tests/SelfTest/Baselines/tap.sw.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.approved.txt
@@ -4585,6 +4585,14 @@ ok {test-number} -
 not ok {test-number} - false with 1 message: '3'
 # sends information to INFO
 not ok {test-number} - false with 2 messages: 'hi' and 'i := 7'
+# serializePathFilters serializes the section/generator selection
+ok {test-number} - serializePathFilters( {} ).empty() for: true
+# serializePathFilters serializes the section/generator selection
+ok {test-number} - serializePathFilters( filters ) == "  - Section: \"a section\"" for: "  - Section: "a section"" == "  - Section: "a section""
+# serializePathFilters serializes the section/generator selection
+ok {test-number} - serializePathFilters( filters ) == "  - Generator: \"0\"" for: "  - Generator: "0"" == "  - Generator: "0""
+# serializePathFilters serializes the section/generator selection
+ok {test-number} - serializePathFilters( filters ) == "  - Section: \"A\"\n" "  - Generator: \"1\"\n" "  - Section: \"B\"" for: "  - Section: "A"   - Generator: "1"   - Section: "B"" == "  - Section: "A"   - Generator: "1"   - Section: "B""
 # shortened hide tags are split apart
 ok {test-number} - testcase.tags, VectorContains( Tag( "magic-tag" ) ) && VectorContains( Tag( "."_catch_sr ) ) for: { {?}, {?} } ( Contains: {?} and Contains: {?} )
 # skipped tests can optionally provide a reason
@@ -4851,5 +4859,5 @@ ok {test-number} - q3 == 23. for: 23.0 == 23.0
 ok {test-number} -
 # xmlentitycheck
 ok {test-number} -
-1..2428
+1..2432
 

--- a/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/tap.sw.multi.approved.txt
@@ -4574,6 +4574,14 @@ ok {test-number} -
 not ok {test-number} - false with 1 message: '3'
 # sends information to INFO
 not ok {test-number} - false with 2 messages: 'hi' and 'i := 7'
+# serializePathFilters serializes the section/generator selection
+ok {test-number} - serializePathFilters( {} ).empty() for: true
+# serializePathFilters serializes the section/generator selection
+ok {test-number} - serializePathFilters( filters ) == "  - Section: \"a section\"" for: "  - Section: "a section"" == "  - Section: "a section""
+# serializePathFilters serializes the section/generator selection
+ok {test-number} - serializePathFilters( filters ) == "  - Generator: \"0\"" for: "  - Generator: "0"" == "  - Generator: "0""
+# serializePathFilters serializes the section/generator selection
+ok {test-number} - serializePathFilters( filters ) == "  - Section: \"A\"\n" "  - Generator: \"1\"\n" "  - Section: \"B\"" for: "  - Section: "A"   - Generator: "1"   - Section: "B"" == "  - Section: "A"   - Generator: "1"   - Section: "B""
 # shortened hide tags are split apart
 ok {test-number} - testcase.tags, VectorContains( Tag( "magic-tag" ) ) && VectorContains( Tag( "."_catch_sr ) ) for: { {?}, {?} } ( Contains: {?} and Contains: {?} )
 # skipped tests can optionally provide a reason
@@ -4840,5 +4848,5 @@ ok {test-number} - q3 == 23. for: 23.0 == 23.0
 ok {test-number} -
 # xmlentitycheck
 ok {test-number} -
-1..2428
+1..2432
 

--- a/tests/SelfTest/Baselines/teamcity.sw.approved.txt
+++ b/tests/SelfTest/Baselines/teamcity.sw.approved.txt
@@ -992,6 +992,8 @@ loose text artifact
 ##teamcity[testStarted name='sends information to INFO']
 ##teamcity[testFailed name='sends information to INFO' message='Message.tests.cpp:<line number>|n...............................................................................|n|nMessage.tests.cpp:<line number>|nexpression failed with messages:|n  "hi"|n  "i := 7"|n  REQUIRE( false )|nwith expansion:|n  false|n']
 ##teamcity[testFinished name='sends information to INFO' duration="{duration}"]
+##teamcity[testStarted name='serializePathFilters serializes the section/generator selection']
+##teamcity[testFinished name='serializePathFilters serializes the section/generator selection' duration="{duration}"]
 ##teamcity[testStarted name='shortened hide tags are split apart']
 ##teamcity[testFinished name='shortened hide tags are split apart' duration="{duration}"]
 ##teamcity[testStarted name='skipped tests can optionally provide a reason']

--- a/tests/SelfTest/Baselines/teamcity.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/teamcity.sw.multi.approved.txt
@@ -991,6 +991,8 @@
 ##teamcity[testStarted name='sends information to INFO']
 ##teamcity[testFailed name='sends information to INFO' message='Message.tests.cpp:<line number>|n...............................................................................|n|nMessage.tests.cpp:<line number>|nexpression failed with messages:|n  "hi"|n  "i := 7"|n  REQUIRE( false )|nwith expansion:|n  false|n']
 ##teamcity[testFinished name='sends information to INFO' duration="{duration}"]
+##teamcity[testStarted name='serializePathFilters serializes the section/generator selection']
+##teamcity[testFinished name='serializePathFilters serializes the section/generator selection' duration="{duration}"]
 ##teamcity[testStarted name='shortened hide tags are split apart']
 ##teamcity[testFinished name='shortened hide tags are split apart' duration="{duration}"]
 ##teamcity[testStarted name='skipped tests can optionally provide a reason']

--- a/tests/SelfTest/Baselines/xml.sw.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.approved.txt
@@ -22075,6 +22075,63 @@ Approx( -1.95996398454005449 )
     </Expression>
     <OverallResult success="false" skips="0"/>
   </TestCase>
+  <TestCase name="serializePathFilters serializes the section/generator selection" tags="[reporter-helpers][reporters]" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+    <Section name="No filters serialize to an empty string" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          serializePathFilters( {} ).empty()
+        </Original>
+        <Expanded>
+          true
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Section name="Section filters are labelled and quoted" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          serializePathFilters( filters ) == "  - Section: \"a section\""
+        </Original>
+        <Expanded>
+          "  - Section: "a section""
+==
+"  - Section: "a section""
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Section name="Generator filters are labelled and quoted" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          serializePathFilters( filters ) == "  - Generator: \"0\""
+        </Original>
+        <Expanded>
+          "  - Generator: "0""
+==
+"  - Generator: "0""
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Section name="Multiple filters keep their order, one per line" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          serializePathFilters( filters ) == "  - Section: \"A\"\n" "  - Generator: \"1\"\n" "  - Section: \"B\""
+        </Original>
+        <Expanded>
+          "  - Section: "A"
+  - Generator: "1"
+  - Section: "B""
+==
+"  - Section: "A"
+  - Generator: "1"
+  - Section: "B""
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <OverallResult success="true" skips="0"/>
+  </TestCase>
   <TestCase name="shortened hide tags are split apart" tags="[tags]" filename="tests/<exe-name>/IntrospectiveTests/Tag.tests.cpp" >
     <Expression success="true" type="REQUIRE_THAT" filename="tests/<exe-name>/IntrospectiveTests/Tag.tests.cpp" >
       <Original>
@@ -23385,6 +23442,6 @@ Approx( -1.95996398454005449 )
     </Section>
     <OverallResult success="true" skips="0"/>
   </TestCase>
-  <OverallResults successes="2215" failures="158" expectedFailures="43" skips="12"/>
-  <OverallResultsCases successes="331" failures="96" expectedFailures="18" skips="6"/>
+  <OverallResults successes="2219" failures="158" expectedFailures="43" skips="12"/>
+  <OverallResultsCases successes="332" failures="96" expectedFailures="18" skips="6"/>
 </Catch2TestRun>

--- a/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
+++ b/tests/SelfTest/Baselines/xml.sw.multi.approved.txt
@@ -22074,6 +22074,63 @@ Approx( -1.95996398454005449 )
     </Expression>
     <OverallResult success="false" skips="0"/>
   </TestCase>
+  <TestCase name="serializePathFilters serializes the section/generator selection" tags="[reporter-helpers][reporters]" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+    <Section name="No filters serialize to an empty string" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          serializePathFilters( {} ).empty()
+        </Original>
+        <Expanded>
+          true
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Section name="Section filters are labelled and quoted" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          serializePathFilters( filters ) == "  - Section: \"a section\""
+        </Original>
+        <Expanded>
+          "  - Section: "a section""
+==
+"  - Section: "a section""
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Section name="Generator filters are labelled and quoted" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          serializePathFilters( filters ) == "  - Generator: \"0\""
+        </Original>
+        <Expanded>
+          "  - Generator: "0""
+==
+"  - Generator: "0""
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <Section name="Multiple filters keep their order, one per line" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+      <Expression success="true" type="REQUIRE" filename="tests/<exe-name>/IntrospectiveTests/Reporters.tests.cpp" >
+        <Original>
+          serializePathFilters( filters ) == "  - Section: \"A\"\n" "  - Generator: \"1\"\n" "  - Section: \"B\""
+        </Original>
+        <Expanded>
+          "  - Section: "A"
+  - Generator: "1"
+  - Section: "B""
+==
+"  - Section: "A"
+  - Generator: "1"
+  - Section: "B""
+        </Expanded>
+      </Expression>
+      <OverallResults successes="1" failures="0" expectedFailures="0" skipped="false"/>
+    </Section>
+    <OverallResult success="true" skips="0"/>
+  </TestCase>
   <TestCase name="shortened hide tags are split apart" tags="[tags]" filename="tests/<exe-name>/IntrospectiveTests/Tag.tests.cpp" >
     <Expression success="true" type="REQUIRE_THAT" filename="tests/<exe-name>/IntrospectiveTests/Tag.tests.cpp" >
       <Original>
@@ -23384,6 +23441,6 @@ Approx( -1.95996398454005449 )
     </Section>
     <OverallResult success="true" skips="0"/>
   </TestCase>
-  <OverallResults successes="2215" failures="158" expectedFailures="43" skips="12"/>
-  <OverallResultsCases successes="331" failures="96" expectedFailures="18" skips="6"/>
+  <OverallResults successes="2219" failures="158" expectedFailures="43" skips="12"/>
+  <OverallResultsCases successes="332" failures="96" expectedFailures="18" skips="6"/>
 </Catch2TestRun>

--- a/tests/SelfTest/IntrospectiveTests/Reporters.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/Reporters.tests.cpp
@@ -16,6 +16,7 @@
 #include <catch2/internal/catch_console_colour.hpp>
 #include <catch2/internal/catch_enforce.hpp>
 #include <catch2/internal/catch_list.hpp>
+#include <catch2/internal/catch_path_filter.hpp>
 #include <catch2/internal/catch_reporter_registry.hpp>
 #include <catch2/internal/catch_istream.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
@@ -93,6 +94,35 @@ TEST_CASE( "The default listing implementation write to provided stream",
         REQUIRE_THAT( listingString,
                       ContainsSubstring( "fakeListener"s ) &&
                           ContainsSubstring( "fake description"s ) );
+    }
+}
+
+TEST_CASE( "serializePathFilters serializes the section/generator selection",
+           "[reporters][reporter-helpers]" ) {
+    using Catch::PathFilter;
+    using Catch::serializePathFilters;
+
+    SECTION( "No filters serialize to an empty string" ) {
+        REQUIRE( serializePathFilters( {} ).empty() );
+    }
+    SECTION( "Section filters are labelled and quoted" ) {
+        std::vector<PathFilter> filters{ { PathFilter::For::Section, "a section" } };
+        REQUIRE( serializePathFilters( filters ) == "  - Section: \"a section\"" );
+    }
+    SECTION( "Generator filters are labelled and quoted" ) {
+        std::vector<PathFilter> filters{ { PathFilter::For::Generator, "0" } };
+        REQUIRE( serializePathFilters( filters ) == "  - Generator: \"0\"" );
+    }
+    SECTION( "Multiple filters keep their order, one per line" ) {
+        std::vector<PathFilter> filters{
+            { PathFilter::For::Section, "A" },
+            { PathFilter::For::Generator, "1" },
+            { PathFilter::For::Section, "B" },
+        };
+        REQUIRE( serializePathFilters( filters ) ==
+                 "  - Section: \"A\"\n"
+                 "  - Generator: \"1\"\n"
+                 "  - Section: \"B\"" );
     }
 }
 


### PR DESCRIPTION
## Description

When a section/generator selection (`-c`/`--section`, `-g`/`--generator-index`,
or `-p`/`--path-filter`) is in effect, the console and compact reporters now
print the active path filters on a `Path filters:` line, right below the
existing `Filters:` line and using the same highlight colour:

```text
Filters: "foo"
Path filters: c:"A" g:0
```

Section filters are serialized as `c:"<filter>"` and generator filters as
`g:<filter>`, mirroring the `-p`/`--path-filter` syntax. The line is only
printed when path filters are present, so default runs are unaffected.

The motivation: Catch2 currently gives no feedback about what was actually
selected, which makes it hard to tell what went wrong when a filter
combination ends up running no assertions, e.g.:

```text
Filters: "Scenario: Create and train model on entire dataset"
Randomness seeded to: 3221299838
===============================================================================
test cases: 1 | 1 passed
assertions: - none -
```

Implementation notes:
- Added a `serializePathFilters()` helper in `catch_reporter_helpers`,
  alongside the existing `serializeFilters()`.
- Wired it into `ConsoleReporter::testRunStarting` and
  `CompactReporter::testRunStarting`.
- Documented the printout in `docs/filtering-execution-path.md`.
- Tests: a unit test for `serializePathFilters` (format + ordering) and two
  CTest integration tests verifying both reporters emit the line. Baselines
  were updated to account for the new self-test case.

Structured reporters (XML/JSON/JUnit/TAP/SonarQube) are intentionally left
out of scope; this could be a follow-up if desired.

## GitHub Issues

Implements the request in #3099.
