### PR TITLE
Ignore non-JSON stdout preamble in catch_discover_tests (#3162)

### DIFF
--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -134,6 +134,19 @@ function(catch_discover_tests_impl)
     endforeach()
   endif()
 
+  # The test executable might print to stdout before Catch2 emits its JSON,
+  # e.g. a third-party library logging from a static initializer. Such text
+  # would break the JSON parser, so we strip everything before the first '{',
+  # which is where Catch2's JSON output starts.
+  string(FIND "${listing_output}" "{" json_start)
+  if(json_start EQUAL -1)
+    message(FATAL_ERROR
+      "Could not find the start of JSON output when listing tests from executable '${_TEST_EXECUTABLE}':\n"
+      "  Output: ${listing_output}\n"
+    )
+  endif()
+  string(SUBSTRING "${listing_output}" ${json_start} -1 listing_output)
+
   # Parse JSON output for list of tests/class names/tags
   string(JSON version GET "${listing_output}" "version")
   if(NOT version STREQUAL "1")

--- a/tests/TestScripts/DiscoverTests/VerifyRegistration.py
+++ b/tests/TestScripts/DiscoverTests/VerifyRegistration.py
@@ -79,7 +79,12 @@ def get_test_names(build_path: str) -> List[TestInfo]:
                             check = True,
                             text = True)
 
-    test_listing = json.loads(result.stdout)
+    # The executable might print to stdout before Catch2's JSON output, e.g.
+    # from a third-party library's static initializer, so we skip everything
+    # before the first '{', just like CatchAddTests.cmake does.
+    json_start = result.stdout.find('{')
+    assert json_start != -1, f"Could not find JSON output in:\n{result.stdout}"
+    test_listing = json.loads(result.stdout[json_start:])
 
     assert test_listing['version'] == 1
 

--- a/tests/TestScripts/DiscoverTests/register-tests.cpp
+++ b/tests/TestScripts/DiscoverTests/register-tests.cpp
@@ -8,6 +8,20 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <iostream>
+
+namespace {
+    // Emulate a third-party library that writes to stdout from a static
+    // initializer. This text precedes Catch2's JSON output during test
+    // discovery, and `catch_discover_tests` has to ignore it. See #3162.
+    struct PrintsDuringStaticInit {
+        PrintsDuringStaticInit() {
+            std::cout << "Some third-party library started up successfully\n";
+        }
+    };
+    const PrintsDuringStaticInit printsDuringStaticInit{};
+}
+
 TEST_CASE("@Script[C:\\EPM1A]=x;\"SCALA_ZERO:\"", "[script regressions]"){}
 TEST_CASE("Some test") {}
 TEST_CASE( "Let's have a test case with a long name. Longer. No, even longer. "


### PR DESCRIPTION
### What

`catch_discover_tests()` runs the test executable with
`--list-tests --reporter json` and feeds the **entire** stdout into CMake's
`string(JSON ...)`. If anything writes to stdout *before* `main` runs - most
commonly a third-party library logging from a static initializer - that text
precedes Catch2's JSON and the parser fails with:

string sub-command JSON failed parsing json string: * Line 1, Column 1
Syntax error: value, object or array expected.

Older versions used the plain `--list-tests` text output, which tolerated such
noise, so this is a regression people hit when upgrading.

Closes #3162.

### How

Before parsing, strip everything before the first `{` (where Catch2's JSON
output begins) in `extras/CatchAddTests.cmake`. If no `{` is present at all,
fail with a clear error that includes the captured output.
This intentionally covers only the case described in the issue - output printed
*before* discovery starts (e.g. static-init constructors). It does not attempt
to handle output interleaved into the middle of the JSON.

### Tests

Extended the existing `CMakeHelper::DiscoverTests` integration test:
- `register-tests.cpp` now prints to stdout from a static initializer, so the
  discovered executable reproduces the scenario.
- `VerifyRegistration.py` parses the executable's raw stdout directly, so it
  skips to the first `{` the same way the CMake script does.

Verified locally: the test fails on `devel` (JSON syntax error during
discovery) and passes with this change (`5 tests matched`).