### PR TITLE
[CMake]Optimize JSON parsing in catch_discover_tests()

### DIFF
--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -199,9 +199,13 @@ function(catch_discover_tests_impl)
   math(EXPR num_tests "${num_tests} - 1")
 
   foreach(idx RANGE ${num_tests})
-    string(JSON single_test GET ${test_listing} ${idx})
-    string(JSON test_tags GET "${single_test}" "tags")
-    string(JSON plain_name GET "${single_test}" "name")
+    if(add_tags)
+      string(JSON single_test GET "${test_listing}" ${idx})
+      string(JSON test_tags GET "${single_test}" "tags")
+      string(JSON plain_name GET "${single_test}" "name")
+    else()
+      string(JSON plain_name GET "${test_listing}" ${idx} "name")
+    endif()
 
     # Escape characters in test case names that would be parsed by Catch2
     # Note that the \ escaping must happen FIRST! Do not change the order.


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
Optimizes the CMake JSON parsing logic in `catch_discover_tests()` by avoiding materialization of full per-test JSON object when `ADD_TAGS_AS_LABELS` is not used.

## GitHub Issues
Closes #3168
