### PR TITLE
Document that DISCOVERY_MODE PRE_TEST should be used with catch_discover_tests when used with XCode.

### DIFF
--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -212,6 +212,17 @@ execution (useful e.g. in cross-compilation environments).
 calling ``catch_discover_tests``. This provides a mechanism for globally
 selecting a preferred test discovery behavior.
 
+_Note that on Apple Silicon with the Xcode generator you must use `PRE_TEST`,
+e.g. `catch_discover_tests(tests DISCOVERY_MODE PRE_TEST)`. With the default
+`POST_BUILD` mode the build fails with `Result: Subprocess killed`, because
+macOS on Apple Silicon refuses to run unsigned binaries and Xcode code-signs
+the test executable only **after** the post-build script that `POST_BUILD`
+mode uses to run it for test discovery. `PRE_TEST` avoids this by delaying
+discovery until test time, when the executable is already signed. The same
+limitation affects CMake's `gtest_discover_tests`; see
+[Catch2 #2411](https://github.com/catchorg/Catch2/issues/2411) and
+[CMake #21845](https://gitlab.kitware.com/cmake/cmake/-/issues/21845)._
+
 * `SKIP_IS_FAILURE`
 
 Skipped tests will be marked as failed instead.

--- a/extras/Catch.cmake
+++ b/extras/Catch.cmake
@@ -146,6 +146,12 @@ same as the Catch name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
     calling ``catch_discover_tests``. This provides a mechanism for globally selecting
     a preferred test discovery behavior without having to modify each call site.
 
+    On Apple Silicon with the Xcode generator you must use ``PRE_TEST``. With the
+    default ``POST_BUILD`` mode the build fails with ``Result: Subprocess killed``,
+    because macOS on Apple Silicon refuses to run unsigned binaries and Xcode
+    code-signs the test executable only after the post-build script that
+    ``POST_BUILD`` mode uses to run it for test discovery. See Catch2 issue #2411.
+
   ``SKIP_IS_FAILURE``
     Disables skipped test detection.
 


### PR DESCRIPTION
## Description

This addresses https://github.com/catchorg/Catch2/issues/2411 by making the "workaround" the official approach and is consistent with how gtest and cmake deal with the same situation.

When using the Xcode generator on Apple Silicon using the default discover mode, `POST_BUILD`, macOS will refuse to run due to being unsigned. The build is signed later in the process - after the post build script. So the remedy is to use the `PRE_TEST` discover mode, that runs _after_ the code has been signed.

Changing the default discovery mode for Xcode to `POST_BUILD` was considered, but this would have been a change in behaviour for Intel Mac users (if there are any left), so being explicit seemed to be the better option.

We could also have pre-signed (which would have been later overwritten) but this seemed more heavyweight, disruptive and potentially error prone.

## GitHub Issues

Addresses #2411