### PR TITLE
Extend section filtering to support wildcards (Issue #3072)

### DIFF
--- a/src/catch2/internal/catch_path_filter.hpp
+++ b/src/catch2/internal/catch_path_filter.hpp
@@ -9,6 +9,8 @@
 #define CATCH_PATH_FILTER_HPP_INCLUDED
 
 #include <catch2/internal/catch_move_and_forward.hpp>
+#include <catch2/internal/catch_optional.hpp>
+#include <catch2/internal/catch_wildcard_pattern.hpp>
 
 #include <string>
 
@@ -20,10 +22,16 @@ namespace Catch {
             Generator,
         };
         PathFilter( For type_, std::string filter_ ):
-            type( type_ ), filter( CATCH_MOVE( filter_ ) ) {}
+            type( type_ ),
+            filter( CATCH_MOVE( filter_ ) ) {
+            if ( type == For::Section ) {
+                wildcardPattern = WildcardPattern( filter, CaseSensitive::Yes );
+            }
+        }
 
         For type;
         std::string filter;
+        Optional<WildcardPattern> wildcardPattern;
 
         friend bool operator==( PathFilter const& lhs, PathFilter const& rhs );
     };

--- a/src/catch2/internal/catch_test_case_tracker.cpp
+++ b/src/catch2/internal/catch_test_case_tracker.cpp
@@ -174,14 +174,15 @@ namespace TestCaseTracking {
             m_newStyleFilters ? m_allTrackerDepth : m_sectionOnlyDepth;
 
         if ( filterIndex < m_filterRef->size() ) {
+            auto const& pathFilter = ( *m_filterRef )[filterIndex];
             // 1) New style filter must explicitly target section
-            if ( m_newStyleFilters && ( *m_filterRef )[filterIndex].type !=
+            if ( m_newStyleFilters && pathFilter.type !=
                                           PathFilter::For::Section ) {
                 return true;
             }
-            // 2) Both style filters must match the trimmed name exactly
-            if ( m_trimmed_name !=
-                 StringRef( ( *m_filterRef )[filterIndex].filter ) ) {
+            // 2) Both style filters must match using wildcard pattern
+            assert( pathFilter.wildcardPattern.some() );
+            if ( !pathFilter.wildcardPattern->matches( static_cast<std::string>( m_trimmed_name ) ) ) {
                 return true;
             }
         }
@@ -204,15 +205,16 @@ namespace TestCaseTracking {
         const size_t filterIndex =
             m_newStyleFilters ? m_allTrackerDepth : m_sectionOnlyDepth;
         if ( filterIndex < m_filterRef->size() ) {
+            auto const& pathFilter = ( *m_filterRef )[filterIndex];
             // There is active filter, check it
             // 1) New style filter must explicitly target section
-            if ( m_newStyleFilters && ( *m_filterRef )[filterIndex].type !=
+            if ( m_newStyleFilters && pathFilter.type !=
                                           PathFilter::For::Section ) {
                 return true;
             }
-            // 2) Both style filters must match the trimmed name exactly
-            if ( m_trimmed_name !=
-                 StringRef( ( *m_filterRef )[filterIndex].filter ) ) {
+            // 2) Both style filters must match using wildcard pattern
+            assert( pathFilter.wildcardPattern.some() );
+            if ( !pathFilter.wildcardPattern->matches( static_cast<std::string>( m_trimmed_name ) ) ) {
                 return true;
             }
         }

--- a/src/catch2/internal/catch_wildcard_pattern.cpp
+++ b/src/catch2/internal/catch_wildcard_pattern.cpp
@@ -11,34 +11,53 @@
 
 namespace Catch {
 
+    namespace {
+        bool glob_match(const char* pattern, const char* str) {
+            while (*pattern) {
+                if (*pattern == '\\') {
+                    pattern++;
+                    if (!*pattern) {
+                        return *str == '\\' && glob_match(pattern, str + 1);
+                    }
+                    if (*pattern != *str) {
+                        return false;
+                    }
+                    pattern++;
+                    str++;
+                } else if (*pattern == '*') {
+                    while (*pattern == '*') {
+                        pattern++;
+                    }
+                    if (!*pattern) {
+                        return true;
+                    }
+                    while (*str) {
+                        if (glob_match(pattern, str)) {
+                            return true;
+                        }
+                        str++;
+                    }
+                    return false;
+                } else {
+                    if (*pattern != *str) {
+                        return false;
+                    }
+                    pattern++;
+                    str++;
+                }
+            }
+            return *str == '\0';
+        }
+    }
+
     WildcardPattern::WildcardPattern( std::string const& pattern,
                                       CaseSensitive caseSensitivity )
     :   m_caseSensitivity( caseSensitivity ),
         m_pattern( normaliseString( pattern ) )
-    {
-        if( startsWith( m_pattern, '*' ) ) {
-            m_pattern = m_pattern.substr( 1 );
-            m_wildcard = WildcardAtStart;
-        }
-        if( endsWith( m_pattern, '*' ) ) {
-            m_pattern = m_pattern.substr( 0, m_pattern.size()-1 );
-            m_wildcard = static_cast<WildcardPosition>( m_wildcard | WildcardAtEnd );
-        }
-    }
+    {}
 
     bool WildcardPattern::matches( std::string const& str ) const {
-        switch( m_wildcard ) {
-            case NoWildcard:
-                return m_pattern == normaliseString( str );
-            case WildcardAtStart:
-                return endsWith( normaliseString( str ), m_pattern );
-            case WildcardAtEnd:
-                return startsWith( normaliseString( str ), m_pattern );
-            case WildcardAtBothEnds:
-                return contains( normaliseString( str ), m_pattern );
-            default:
-                CATCH_INTERNAL_ERROR( "Unknown enum" );
-        }
+        return glob_match( m_pattern.c_str(), normaliseString( str ).c_str() );
     }
 
     std::string WildcardPattern::normaliseString( std::string const& str ) const {

--- a/src/catch2/internal/catch_wildcard_pattern.hpp
+++ b/src/catch2/internal/catch_wildcard_pattern.hpp
@@ -15,13 +15,6 @@
 namespace Catch
 {
     class WildcardPattern {
-        enum WildcardPosition {
-            NoWildcard = 0,
-            WildcardAtStart = 1,
-            WildcardAtEnd = 2,
-            WildcardAtBothEnds = WildcardAtStart | WildcardAtEnd
-        };
-
     public:
 
         WildcardPattern( std::string const& pattern, CaseSensitive caseSensitivity );
@@ -30,7 +23,6 @@ namespace Catch
     private:
         std::string normaliseString( std::string const& str ) const;
         CaseSensitive m_caseSensitivity;
-        WildcardPosition m_wildcard = NoWildcard;
         std::string m_pattern;
     };
 }

--- a/tests/SelfTest/IntrospectiveTests/PartTracker.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/PartTracker.tests.cpp
@@ -255,3 +255,49 @@ TEST_CASE("#1938 - Section followed by flat generate", "[.][regression][generato
     auto m = GENERATE(2, 3);
     REQUIRE(m);
 }
+
+TEST_CASE( "Tracker section wildcard filtering", "[tracker][wildcard]" ) {
+    TrackerContext ctx;
+    ITracker& root = ctx.startRun();
+    
+    std::vector<PathFilter> filters;
+    filters.emplace_back( PathFilter::For::Section, "S*" );
+    root.setFilters( &filters, true );
+    
+    ctx.startCycle();
+    
+    ITracker& testCase = SectionTracker::acquire( ctx, makeNAL( "Testcase" ) );
+    REQUIRE( testCase.isOpen() );
+    
+    ITracker& s1 = SectionTracker::acquire( ctx, makeNAL( "S1" ) );
+    REQUIRE( s1.isOpen() );
+    s1.close();
+    
+    ITracker& a1 = SectionTracker::acquire( ctx, makeNAL( "A1" ) );
+    REQUIRE( a1.isOpen() == false );
+    
+    testCase.close();
+}
+
+TEST_CASE( "Tracker section wildcard filtering with escaping", "[tracker][wildcard]" ) {
+    TrackerContext ctx;
+    ITracker& root = ctx.startRun();
+    
+    std::vector<PathFilter> filters;
+    filters.emplace_back( PathFilter::For::Section, "S\\*" );
+    root.setFilters( &filters, true );
+    
+    ctx.startCycle();
+    
+    ITracker& testCase = SectionTracker::acquire( ctx, makeNAL( "Testcase" ) );
+    REQUIRE( testCase.isOpen() );
+    
+    ITracker& s_star = SectionTracker::acquire( ctx, makeNAL( "S*" ) );
+    REQUIRE( s_star.isOpen() );
+    s_star.close();
+    
+    ITracker& s1 = SectionTracker::acquire( ctx, makeNAL( "S1" ) );
+    REQUIRE( s1.isOpen() == false );
+    
+    testCase.close();
+}


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description

### What:
We have extended section path filtering to support wildcards and backslash escaping:
1. **Glob Pattern Matching:** Reimplemented `WildcardPattern` to use a recursive `glob_match` helper instead of a simple start/end wildcard check. This enables full glob matching (including mid-string wildcards like `A*B` and multiple wildcards).
2. **Backslash Escaping:** Added support for escaping backslashes and wildcards using `\`. For example, `A\*` matches `A*` exactly, and `A\\*` matches `A\` at the start.
3. **PathFilter Integration:** Pre-compiles section filters into `WildcardPattern` objects inside the `PathFilter` structure at CLI parsing time.
4. **Tracker Integration:** Replaced exact string comparisons in `SectionTracker` (`isFilteredImpl` and `isComplete`) with `wildcardPattern->matches(...)`.
5. **Unit Tests:** Added unit tests verifying wildcard filtering and escaping behaviors directly in `PartTracker.tests.cpp`.

### Why:
This enables flexible execution of nested test subsets. Users can now run a specific group of sections matching a naming convention (e.g., executing paragraphs or requirement groups) without having to specify each section individually, resolving a long-standing feature request.

## GitHub Issues

Addresses https://github.com/catchorg/Catch2/issues/3072