### PR TITLE
Ensure locale is not used when writing int to json stream

### DIFF
--- a/src/catch2/internal/catch_jsonwriter.hpp
+++ b/src/catch2/internal/catch_jsonwriter.hpp
@@ -14,6 +14,8 @@
 
 #include <cstdint>
 #include <sstream>
+#include <string>
+#include <type_traits>
 
 namespace Catch {
     class JsonObjectWriter;
@@ -34,7 +36,14 @@ namespace Catch {
         JsonObjectWriter writeObject() &&;
         JsonArrayWriter writeArray() &&;
 
-        template <typename T>
+        template <typename T,
+                  typename = typename std::enable_if_t<std::is_integral_v<T>>>
+        void write( T value ) && {
+            writeImpl( std::to_string(value), false );
+        }
+
+        template <typename T,
+                  typename = typename std::enable_if_t<!std::is_integral_v<T>>>
         void write( T const& value ) && {
             writeImpl( value, !std::is_arithmetic<T>::value );
         }


### PR DESCRIPTION
## Description

If a locale has been introduced to a stream, then the locale may provide a certain coding convention for integral values. 

For instance, the locale may introduce a comma character or space character, as a delimiter within the string representation of an integral value much greater than 999. This might be visible when printing the value of Config::rngSeed in test report data, e.g with `--list-tests -r json`

```json
{
  "version": 1,
  "metadata": {
      "name": "test_mywidget",
      "rng-seed": 3,492,809,809,
      "catch2-version": "3.15.2"
    },
  // ...
}
```

Of course, this would not be valid JSON. For these tests, the cmake function `catch_discover_tests()` may fail due to the locale-formatted output. 

This has been observed with tests using the Gtk toolkit in versions 3 and 4, and in some other test cases.

If the value would be written as an unquoted string, first converted with e.g `std::to_string`, then this should serve to work around the locale encoding for integral values.

Known limitations
- Not tested: Writing float values, whether as JSON float or quoted string (Not seen in Config)

## GitHub Issues

(None)