### PR TITLE
Remove debug message for environment variable check

### DIFF
--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -31,7 +31,6 @@ function(make_temp_file_path OUT_VARIABLE FALLBACK_PATH)
   )
 
   foreach(var ${ENV_VARS})
-    message(NOTICE "Checking ${var} env var")
     if(DEFINED ENV{${var}} AND NOT "$ENV{${var}}" STREQUAL "")
         set(TEMP_DIR "$ENV{${var}}")
         break()


### PR DESCRIPTION
## Description
The `make_temp_file_path` function had a leftover debugging message call and therefore produced a lot of noise in the build output. This PR removes this leftover since it does not seem to be required anymore (see https://github.com/catchorg/Catch2/commit/9ec44dd62b1b593e01feaf95eb485d26fcdd50ce#r192489445)
