### PR TITLE
Fix repeated SECTIONs in one test cycle

### DIFF
--- a/src/catch2/internal/catch_test_case_tracker.cpp
+++ b/src/catch2/internal/catch_test_case_tracker.cpp
@@ -242,6 +242,11 @@ namespace TestCaseTracking {
             currentTracker.addChild( CATCH_MOVE( newTracker ) );
         }
 
+        if ( ctx.completedCycle() && tracker->isOpen() ) {
+            CATCH_INTERNAL_ERROR(
+                "The same SECTION was encountered multiple times in one test cycle" );
+        }
+
         if ( !ctx.completedCycle() ) {
             tracker->tryOpen();
         }

--- a/tests/SelfTest/IntrospectiveTests/PartTracker.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/PartTracker.tests.cpp
@@ -164,6 +164,28 @@ TEST_CASE( "Tracker" ) {
     }
 }
 
+TEST_CASE( "Tracker rejects a section encountered twice in one cycle" ) {
+    TrackerContext ctx;
+    ITracker& root = ctx.startRun();
+    std::vector<PathFilter> dummyFilters;
+    root.setFilters( &dummyFilters, false );
+    ctx.startCycle();
+
+    ITracker& testCase = SectionTracker::acquire( ctx, makeNAL( "Testcase" ) );
+    ITracker& section = SectionTracker::acquire( ctx, makeNAL( "Section" ) );
+    ITracker& firstChild = SectionTracker::acquire( ctx, makeNAL( "First child" ) );
+
+    firstChild.close();
+    SectionTracker::acquire( ctx, makeNAL( "Second child" ) );
+    section.close();
+
+    REQUIRE( ctx.completedCycle() );
+    REQUIRE( section.isOpen() );
+    REQUIRE_THROWS( SectionTracker::acquire( ctx, makeNAL( "Section" ) ) );
+
+    testCase.close();
+}
+
 static bool previouslyRun = false;
 static bool previouslyRunNested = false;
 


### PR DESCRIPTION
## Summary
- reject a previously-open `SECTION` when the same source location is encountered again after the current test cycle has completed
- add tracker-level coverage for the repeated nested-section path

## Root cause
A helper called twice in the same test cycle can reacquire a section that is still marked open after one of its children completed the cycle. The second acquisition skips reopening it, but the public section wrapper still treats it as open and later closes it from an invalid tracker position, causing a hang or crash.

## Validation
- `cmake --build build --config Debug --target SelfTest --parallel 1`
- `build/tests/Debug/SelfTest.exe "Tracker rejects a section encountered twice in one cycle" --reporter compact`
- `build/tests/Debug/SelfTest.exe "Tracker" --reporter compact`
- a standalone nested-section reproducer: baseline hangs; with this change it fails immediately with a controlled Catch2 error

Fixes #2802