### PR TITLE
Fix typo in generator exception message ("Coud" -> "Could")

### DIFF
--- a/src/catch2/generators/catch_generators.hpp
+++ b/src/catch2/generators/catch_generators.hpp
@@ -95,7 +95,7 @@ namespace Generators {
         void skipToNthElementImpl( std::size_t n ) override {
             if ( n >= m_values.size() ) {
                 Detail::throw_generator_exception(
-                    "Coud not jump to Nth element: not enough elements" );
+                    "Could not jump to Nth element: not enough elements" );
             }
             m_idx = n;
         }

--- a/src/catch2/generators/catch_generators_adapters.hpp
+++ b/src/catch2/generators/catch_generators_adapters.hpp
@@ -27,7 +27,7 @@ namespace Generators {
         void skipToNthElementImpl( std::size_t n ) override {
             if ( n >= m_target ) {
                 Detail::throw_generator_exception(
-                    "Coud not jump to Nth element: not enough elements" );
+                    "Could not jump to Nth element: not enough elements" );
             }
 
             m_generator.skipToNthElement( n );

--- a/src/catch2/interfaces/catch_interfaces_generatortracker.cpp
+++ b/src/catch2/interfaces/catch_interfaces_generatortracker.cpp
@@ -28,7 +28,7 @@ namespace Catch {
                 bool isValid = next();
                 if ( !isValid ) {
                     Detail::throw_generator_exception(
-                        "Coud not jump to Nth element: not enough elements" );
+                        "Could not jump to Nth element: not enough elements" );
                 }
             }
         }


### PR DESCRIPTION
The exception message thrown by `throw_generator_exception()` when a generator cannot jump to the Nth element had "Coud" misspelled instead of "Could". The same message string appears in three places, all fixed here:

- `src/catch2/generators/catch_generators.hpp`
- `src/catch2/generators/catch_generators_adapters.hpp`
- `src/catch2/interfaces/catch_interfaces_generatortracker.cpp`

This is a user-facing string (surfaced when a generator is asked to skip past its available elements). No functional change.
