### PR TITLE
(v2.x) Remove space in user-defined literal operators to fix MSVC C4996 warning

### DIFF
--- a/include/internal/catch_approx.cpp
+++ b/include/internal/catch_approx.cpp
@@ -73,10 +73,10 @@ namespace Detail {
 } // end namespace Detail
 
 namespace literals {
-    Detail::Approx operator "" _a(long double val) {
+    Detail::Approx operator ""_a(long double val) {
         return Detail::Approx(val);
     }
-    Detail::Approx operator "" _a(unsigned long long val) {
+    Detail::Approx operator ""_a(unsigned long long val) {
         return Detail::Approx(val);
     }
 } // end namespace literals

--- a/include/internal/catch_approx.h
+++ b/include/internal/catch_approx.h
@@ -118,8 +118,8 @@ namespace Detail {
 } // end namespace Detail
 
 namespace literals {
-    Detail::Approx operator "" _a(long double val);
-    Detail::Approx operator "" _a(unsigned long long val);
+    Detail::Approx operator ""_a(long double val);
+    Detail::Approx operator ""_a(unsigned long long val);
 } // end namespace literals
 
 template<>

--- a/include/internal/catch_stringref.h
+++ b/include/internal/catch_stringref.h
@@ -92,12 +92,12 @@ namespace Catch {
     auto operator << ( std::ostream& os, StringRef const& sr ) -> std::ostream&;
 
 
-    constexpr auto operator "" _sr( char const* rawChars, std::size_t size ) noexcept -> StringRef {
+    constexpr auto operator ""_sr( char const* rawChars, std::size_t size ) noexcept -> StringRef {
         return StringRef( rawChars, size );
     }
 } // namespace Catch
 
-constexpr auto operator "" _catch_sr( char const* rawChars, std::size_t size ) noexcept -> Catch::StringRef {
+constexpr auto operator ""_catch_sr( char const* rawChars, std::size_t size ) noexcept -> Catch::StringRef {
     return Catch::StringRef( rawChars, size );
 }
 

--- a/projects/SelfTest/IntrospectiveTests/String.tests.cpp
+++ b/projects/SelfTest/IntrospectiveTests/String.tests.cpp
@@ -141,7 +141,7 @@ TEST_CASE("StringRef at compilation time", "[Strings][StringRef][constexpr]") {
         STATIC_REQUIRE(sr1.size() == 3);
         STATIC_REQUIRE(sr1.isNullTerminated());
 
-        using Catch::operator"" _sr;
+        using Catch::operator""_sr;
         constexpr auto sr2 = ""_sr;
         STATIC_REQUIRE(sr2.empty());
         STATIC_REQUIRE(sr2.size() == 0);

--- a/single_include/catch2/catch.hpp
+++ b/single_include/catch2/catch.hpp
@@ -677,12 +677,12 @@ namespace Catch {
     auto operator += ( std::string& lhs, StringRef const& sr ) -> std::string&;
     auto operator << ( std::ostream& os, StringRef const& sr ) -> std::ostream&;
 
-    constexpr auto operator "" _sr( char const* rawChars, std::size_t size ) noexcept -> StringRef {
+    constexpr auto operator ""_sr( char const* rawChars, std::size_t size ) noexcept -> StringRef {
         return StringRef( rawChars, size );
     }
 } // namespace Catch
 
-constexpr auto operator "" _catch_sr( char const* rawChars, std::size_t size ) noexcept -> Catch::StringRef {
+constexpr auto operator ""_catch_sr( char const* rawChars, std::size_t size ) noexcept -> Catch::StringRef {
     return Catch::StringRef( rawChars, size );
 }
 
@@ -3177,8 +3177,8 @@ namespace Detail {
 } // end namespace Detail
 
 namespace literals {
-    Detail::Approx operator "" _a(long double val);
-    Detail::Approx operator "" _a(unsigned long long val);
+    Detail::Approx operator ""_a(long double val);
+    Detail::Approx operator ""_a(unsigned long long val);
 } // end namespace literals
 
 template<>
@@ -7920,10 +7920,10 @@ namespace Detail {
 } // end namespace Detail
 
 namespace literals {
-    Detail::Approx operator "" _a(long double val) {
+    Detail::Approx operator ""_a(long double val) {
         return Detail::Approx(val);
     }
-    Detail::Approx operator "" _a(unsigned long long val) {
+    Detail::Approx operator ""_a(unsigned long long val) {
         return Detail::Approx(val);
     }
 } // end namespace literals


### PR DESCRIPTION
Remove the space between "" and the suffix in user-defined literal operators (e.g. operator ""_a instead of operator "" _a) to avoid MSVC deprecation warning C5311.

## Description

In MSVC, `operator "" _a` (with a space between `""` and the suffix) triggers deprecation warning C5311.

The standard-compliant form is `operator ""_a` (no space), as described on [cppreference](https://en.cppreference.com/w/cpp/language/user_literal).