### PR TITLE
add warning about default test order causing problems with MPI

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -460,7 +460,7 @@ be preferred to using `time`. Catch2 uses `std::random_device` by default.
 > [!WARNING]
 > You should not use this option when launching Catch2 tests on multiples processes that require synchronous communication,
 > (e.g., Message Passing Interface (MPI) code),
-> because the test order of execution will **not** be indentical on all processes.
+> because the test order of execution will **not** be identical on all processes.
 
 <a id="libidentify"></a>
 ## Identify framework and version according to the libIdentify standard

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -457,6 +457,10 @@ Using `random-device` asks for `std::random_device` to be used instead.
 If your implementation provides working `std::random_device`, it should
 be preferred to using `time`. Catch2 uses `std::random_device` by default.
 
+> [!WARNING]
+> You should not use this option when launching Catch2 tests on multiples processes that require synchronous communication,
+> (e.g., Message Passing Interface (MPI) code),
+> because the test order of execution will **not** be indentical on all processes.
 
 <a id="libidentify"></a>
 ## Identify framework and version according to the libIdentify standard


### PR DESCRIPTION
## Summary

This adds a warning in the documentation about the default (random) test order of execution possibly causing issues for MPI programs using Catch2 after version 3.9.1. 

We recently update Catch2 from version 3.1.0 to the 3.15.1, and we were surprised that our tests started encountering MPI deadlock due the default test execution being changed to random.  The fix is simple (use `--lex` or another non-default ordering option), but a google search was unhelpful.  I hope that including this warning in the documentation helps improve the visibility of the fix.