### PR TITLE
Model `REQUIRE/REQUIRE_FALSE` and `REQUIRE_THROWS/NOTHROW/THROWS_AS` early termination for Static Analysis mode

### DIFF
--- a/.github/workflows/linux-other-builds.yml
+++ b/.github/workflows/linux-other-builds.yml
@@ -127,3 +127,26 @@ jobs:
 
     - name: Run clang-tidy
       run: cmake --build build
+
+  static-analysis-tests:
+    name: static analysis support tests
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Prepare environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ninja-build clang-18 clang-tidy-18
+
+    - name: Configure
+      run: |
+        cmake --preset basic-tests -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_CXX_COMPILER=clang++-18 \
+              -DCMAKE_CXX_STANDARD=17 \
+              -DCATCH_ENABLE_STATIC_ANALYSIS_TESTS=ON \
+              -DCATCH_CLANG_TIDY_COMMAND=clang-tidy-18
+
+    - name: Test
+      run: ctest --test-dir build -R "StaticAnalysis" --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ cmake_dependent_option(CATCH_ENABLE_WERROR "Enables Werror during build" ON "CAT
 cmake_dependent_option(CATCH_BUILD_SURROGATES "Enable generating and building surrogate TUs for the main headers" OFF "CATCH_DEVELOPMENT_BUILD" OFF)
 cmake_dependent_option(CATCH_ENABLE_CONFIGURE_TESTS "Enable CMake configuration tests. WARNING: VERY EXPENSIVE" OFF "CATCH_DEVELOPMENT_BUILD" OFF)
 cmake_dependent_option(CATCH_ENABLE_CMAKE_HELPER_TESTS "Enable CMake helper tests. WARNING: VERY EXPENSIVE" OFF "CATCH_DEVELOPMENT_BUILD" OFF)
+cmake_dependent_option(CATCH_ENABLE_STATIC_ANALYSIS_TESTS "Enable static analysis tests. WARNING: VERY EXPENSIVE, needs clang-tidy 17 or newer" OFF "CATCH_DEVELOPMENT_BUILD" OFF)
+set(CATCH_CLANG_TIDY_COMMAND "clang-tidy" CACHE STRING "clang-tidy binary used by the static analysis tests, has to be version 17 or newer")
 
 # Catch2's build breaks if done in-tree. You probably should not build
 # things in tree anyway, but we can allow projects that include Catch2

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,7 +33,8 @@
             "description": "Enables development build with examples and ALL tests",
             "cacheVariables": {
                 "CATCH_ENABLE_CONFIGURE_TESTS": "ON",
-                "CATCH_ENABLE_CMAKE_HELPER_TESTS": "ON"
+                "CATCH_ENABLE_CMAKE_HELPER_TESTS": "ON",
+                "CATCH_ENABLE_STATIC_ANALYSIS_TESTS": "ON"
             }
         }
     ]   

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -84,12 +84,19 @@ time. This can be either because they take a long time to run, or because
 they take a long time to compile, e.g. because they test compile time
 configuration and require separate compilation.
 
-Finally, CMake config tests test that you set Catch2's compile-time
+CMake config tests test that you set Catch2's compile-time
 configuration options through CMake, using CMake options of the same name.
 
+Finally, static analysis tests check Catch2's static analysis support, by
+running clang-tidy over dedicated test files and comparing its warnings
+against the expected ones. They need clang-tidy 17 or newer, either on
+`PATH` or pointed at with `-DCATCH_CLANG_TIDY_COMMAND=<binary>`, and are
+skipped otherwise.
+
 These test categories can be enabled one by one, by passing
-`-DCATCH_BUILD_EXAMPLES=ON`, `-DCATCH_BUILD_EXTRA_TESTS=ON`, and
-`-DCATCH_ENABLE_CONFIGURE_TESTS=ON` when configuring the build.
+`-DCATCH_BUILD_EXAMPLES=ON`, `-DCATCH_BUILD_EXTRA_TESTS=ON`,
+`-DCATCH_ENABLE_CONFIGURE_TESTS=ON`, and
+`-DCATCH_ENABLE_STATIC_ANALYSIS_TESTS=ON` when configuring the build.
 
 Catch2 also provides a preset that promises to enable _all_ test types,
 `all-tests`.

--- a/src/catch2/internal/catch_result_type.hpp
+++ b/src/catch2/internal/catch_result_type.hpp
@@ -57,6 +57,9 @@ namespace Catch {
     constexpr bool isFalseTest( int flags ) {
         return ( flags & ResultDisposition::FalseTest ) != 0;
     }
+    constexpr bool shouldTerminateOnFailure( int flags ) {
+        return ( flags & ResultDisposition::Normal ) != 0;
+    }
     constexpr bool shouldSuppressFailure( int flags ) {
         return ( flags & ResultDisposition::SuppressFail ) != 0;
     }

--- a/src/catch2/internal/catch_test_macro_impl.hpp
+++ b/src/catch2/internal/catch_test_macro_impl.hpp
@@ -190,6 +190,8 @@ namespace Catch {
 
 #endif // CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
 
+#if !defined( CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT )
+
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_THROWS_AS( macroName, exceptionType, resultDisposition, expr ) \
     do { \
@@ -213,6 +215,30 @@ namespace Catch {
             catchAssertionHandler.handleThrowingCallSkipped(); \
         catchAssertionHandler.complete(); \
     } while( false )
+
+#else  // ^^ !CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT | vv CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
+
+///////////////////////////////////////////////////////////////////////////////
+#    define INTERNAL_CATCH_THROWS_AS( macroName, exceptionType, resultDisposition, expr ) \
+        do { \
+            bool catchInternalCaughtExpected = false; \
+            try { \
+                CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
+                CATCH_INTERNAL_SUPPRESS_UNUSED_RESULT \
+                CATCH_INTERNAL_SUPPRESS_USELESS_CAST_WARNINGS \
+                static_cast<void>(expr); \
+                CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
+            } catch ( exceptionType const& ) { \
+                catchInternalCaughtExpected = true; \
+            } catch ( ... ) { \
+            } \
+            if ( !catchInternalCaughtExpected && \
+                 Catch::shouldTerminateOnFailure( resultDisposition ) ) { \
+                Catch::Detail::Unreachable(); \
+            } \
+        } while ( false )
+
+#endif // CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
 
 
 

--- a/src/catch2/internal/catch_test_macro_impl.hpp
+++ b/src/catch2/internal/catch_test_macro_impl.hpp
@@ -106,6 +106,8 @@ namespace Catch {
 
 #endif // CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
 
+#if !defined( CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT )
+
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_NO_THROW( macroName, resultDisposition, ... ) \
     do { \
@@ -122,6 +124,25 @@ namespace Catch {
         } \
         catchAssertionHandler.complete(); \
     } while( false )
+
+#else  // ^^ !CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT | vv CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
+
+///////////////////////////////////////////////////////////////////////////////
+#    define INTERNAL_CATCH_NO_THROW( macroName, resultDisposition, ... ) \
+        do { \
+            try { \
+                CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
+                CATCH_INTERNAL_SUPPRESS_USELESS_CAST_WARNINGS \
+                static_cast<void>(__VA_ARGS__); \
+                CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
+            } catch ( ... ) { \
+                if ( Catch::shouldTerminateOnFailure( resultDisposition ) ) { \
+                    Catch::Detail::Unreachable(); \
+                } \
+            } \
+        } while ( false )
+
+#endif // CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_THROWS( macroName, resultDisposition, ... ) \

--- a/src/catch2/internal/catch_test_macro_impl.hpp
+++ b/src/catch2/internal/catch_test_macro_impl.hpp
@@ -144,6 +144,8 @@ namespace Catch {
 
 #endif // CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
 
+#if !defined( CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT )
+
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_THROWS( macroName, resultDisposition, ... ) \
     do { \
@@ -164,6 +166,29 @@ namespace Catch {
             catchAssertionHandler.handleThrowingCallSkipped(); \
         catchAssertionHandler.complete(); \
     } while( false )
+
+#else  // ^^ !CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT | vv CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
+
+///////////////////////////////////////////////////////////////////////////////
+#    define INTERNAL_CATCH_THROWS( macroName, resultDisposition, ... ) \
+        do { \
+            bool catchInternalThrew = false; \
+            try { \
+                CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
+                CATCH_INTERNAL_SUPPRESS_UNUSED_RESULT \
+                CATCH_INTERNAL_SUPPRESS_USELESS_CAST_WARNINGS \
+                static_cast<void>(__VA_ARGS__); \
+                CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
+            } catch ( ... ) { \
+                catchInternalThrew = true; \
+            } \
+            if ( !catchInternalThrew && \
+                 Catch::shouldTerminateOnFailure( resultDisposition ) ) { \
+                Catch::Detail::Unreachable(); \
+            } \
+        } while ( false )
+
+#endif // CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_THROWS_AS( macroName, exceptionType, resultDisposition, expr ) \

--- a/src/catch2/internal/catch_test_macro_impl.hpp
+++ b/src/catch2/internal/catch_test_macro_impl.hpp
@@ -82,6 +82,8 @@ namespace Catch {
 
 #endif // CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
 
+#if !defined( CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT )
+
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_IF( macroName, resultDisposition, ... ) \
     INTERNAL_CATCH_TEST( macroName, resultDisposition, __VA_ARGS__ ); \
@@ -91,6 +93,18 @@ namespace Catch {
 #define INTERNAL_CATCH_ELSE( macroName, resultDisposition, ... ) \
     INTERNAL_CATCH_TEST( macroName, resultDisposition, __VA_ARGS__ ); \
     if( !Catch::Detail::lastAssertionPassed() )
+
+#else  // ^^ !CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT | vv CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
+
+///////////////////////////////////////////////////////////////////////////////
+#    define INTERNAL_CATCH_IF( macroName, resultDisposition, ... ) \
+        if ( __VA_ARGS__ )
+
+///////////////////////////////////////////////////////////////////////////////
+#    define INTERNAL_CATCH_ELSE( macroName, resultDisposition, ... ) \
+        if ( !( __VA_ARGS__ ) )
+
+#endif // CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_NO_THROW( macroName, resultDisposition, ... ) \

--- a/src/catch2/internal/catch_test_macro_impl.hpp
+++ b/src/catch2/internal/catch_test_macro_impl.hpp
@@ -10,9 +10,12 @@
 
 #include <catch2/catch_user_config.hpp>
 #include <catch2/internal/catch_assertion_handler.hpp>
+#include <catch2/internal/catch_config_static_analysis_support.hpp>
 #include <catch2/internal/catch_preprocessor_internal_stringify.hpp>
+#include <catch2/internal/catch_result_type.hpp>
 #include <catch2/internal/catch_stringref.hpp>
 #include <catch2/internal/catch_source_line_info.hpp>
+#include <catch2/internal/catch_unreachable.hpp>
 
 namespace Catch {
     namespace Detail {
@@ -44,6 +47,8 @@ namespace Catch {
 
 #endif
 
+#if !defined( CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT )
+
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_TEST( macroName, resultDisposition, ... ) \
     do { /* NOLINT(bugprone-infinite-loop) */ \
@@ -59,6 +64,23 @@ namespace Catch {
         catchAssertionHandler.complete(); \
     } while( (void)0, (false) && static_cast<const bool&>( !!(__VA_ARGS__) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
     // The double negation silences MSVC's C4800 warning, the static_cast forces short-circuit evaluation if the type has overloaded &&.
+
+#else  // ^^ !CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT | vv CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
+
+///////////////////////////////////////////////////////////////////////////////
+#    define INTERNAL_CATCH_TEST( macroName, resultDisposition, ... ) \
+        do { \
+            const bool catchInternalAssertionResult = static_cast<bool>( __VA_ARGS__ ); \
+            if ( Catch::shouldTerminateOnFailure( resultDisposition ) ) { \
+                if ( Catch::isFalseTest( resultDisposition ) ) { \
+                    if ( catchInternalAssertionResult ) { Catch::Detail::Unreachable(); } \
+                } else { \
+                    if ( !catchInternalAssertionResult ) { Catch::Detail::Unreachable(); } \
+                } \
+            } \
+        } while ( false )
+
+#endif // CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_IF( macroName, resultDisposition, ... ) \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -687,6 +687,21 @@ if(CATCH_ENABLE_CMAKE_HELPER_TESTS)
   )
 endif()
 
+if(CATCH_ENABLE_STATIC_ANALYSIS_TESTS)
+  add_test(NAME "StaticAnalysis::AssertionModelling"
+    COMMAND
+      Python3::Interpreter "${CMAKE_CURRENT_LIST_DIR}/TestScripts/testStaticAnalysisSupport.py" "${CATCH_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" "${CATCH_CLANG_TIDY_COMMAND}" "${CMAKE_CXX_COMPILER}"
+  )
+  set_tests_properties("StaticAnalysis::AssertionModelling"
+    PROPERTIES
+      COST 240
+      LABELS "uses-python"
+      # The script exits with 77 when clang-tidy is too old to model
+      # [[noreturn]], in which case the test cannot tell anything apart.
+      SKIP_RETURN_CODE 77
+  )
+endif()
+
 foreach(reporterName # "Automake" - the simple .trs format does not support any kind of comments/metadata
                        "compact"
                        "console"

--- a/tests/TestProjects/StaticAnalysis/.clang-tidy
+++ b/tests/TestProjects/StaticAnalysis/.clang-tidy
@@ -1,0 +1,10 @@
+---
+# This configuration deliberately does not inherit the repository-wide one.
+#
+InheritParentConfig: false
+Checks: '-*,bugprone-unchecked-optional-access'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle: none
+CheckOptions: []
+...

--- a/tests/TestProjects/StaticAnalysis/CMakeLists.txt
+++ b/tests/TestProjects/StaticAnalysis/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.16)
+project(static-analysis-tests LANGUAGES CXX)
+
+# std::optional, which is what bugprone-unchecked-optional-access reasons about
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_subdirectory(${CATCH2_PATH} catch2-build)
+
+set(SA_TEST_SOURCES
+  RequireTerminates.cpp
+  CheckedIf.cpp
+  NoThrowTerminates.cpp
+  ThrowsTerminates.cpp
+  ThrowsAsTerminates.cpp
+)
+
+# These TUs compile but never link. 
+# Per-target clang-tidy keeps Catch2 itself out of the analysis.
+foreach(sourceFile ${SA_TEST_SOURCES})
+  get_filename_component(targetName "${sourceFile}" NAME_WE)
+  add_library(${targetName} OBJECT "${sourceFile}")
+  target_link_libraries(${targetName} PRIVATE Catch2::Catch2)
+  set_target_properties(${targetName}
+    PROPERTIES
+      CXX_CLANG_TIDY "${STATIC_ANALYSIS_CLANG_TIDY}"
+  )
+endforeach()

--- a/tests/TestProjects/StaticAnalysis/CheckedIf.cpp
+++ b/tests/TestProjects/StaticAnalysis/CheckedIf.cpp
@@ -1,0 +1,24 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+
+// Deliberately not defined, so that the analysis cannot see through it.
+std::optional<int> maybe_value();
+
+TEST_CASE( "CHECKED_IF branches on the condition" ) {
+    std::optional<int> opt = maybe_value();
+    CHECKED_IF( opt.has_value() ) { CHECK( *opt == 42 ); }
+}
+
+TEST_CASE( "CHECKED_ELSE branches on the negated condition" ) {
+    std::optional<int> opt = maybe_value();
+    CHECKED_ELSE( opt.has_value() ) { CHECK( *opt == 42 ); } // expect-warning: bugprone-unchecked-optional-access
+}

--- a/tests/TestProjects/StaticAnalysis/NoThrowTerminates.cpp
+++ b/tests/TestProjects/StaticAnalysis/NoThrowTerminates.cpp
@@ -1,0 +1,24 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+#include <stdexcept>
+
+TEST_CASE( "REQUIRE_NOTHROW terminates the test case when the expression throws" ) {
+    std::optional<int> opt;
+    REQUIRE_NOTHROW( opt ? 0 : throw std::runtime_error("empty") );
+    CHECK( *opt == 42 );
+}
+
+TEST_CASE( "CHECK_NOTHROW keeps going when the expression throws" ) {
+    std::optional<int> opt;
+    CHECK_NOTHROW( opt ? 0 : throw std::runtime_error("empty") );
+    CHECK( *opt == 42 ); // expect-warning: bugprone-unchecked-optional-access
+}

--- a/tests/TestProjects/StaticAnalysis/RequireTerminates.cpp
+++ b/tests/TestProjects/StaticAnalysis/RequireTerminates.cpp
@@ -1,0 +1,32 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+
+// Deliberately not defined, so that the analysis cannot see through it.
+std::optional<int> maybe_value();
+
+TEST_CASE( "REQUIRE terminates the test case on failure" ) {
+    std::optional<int> opt = maybe_value();
+    REQUIRE( opt.has_value() );
+    CHECK( *opt == 42 );
+}
+
+TEST_CASE( "REQUIRE_FALSE terminates the test case on failure" ) {
+    std::optional<int> opt = maybe_value();
+    REQUIRE_FALSE( !opt.has_value() );
+    CHECK( *opt == 42 );
+}
+
+TEST_CASE( "CHECK does not terminate the test case on failure" ) {
+    std::optional<int> opt = maybe_value();
+    CHECK( opt.has_value() );
+    CHECK( *opt == 42 ); // expect-warning: bugprone-unchecked-optional-access
+}

--- a/tests/TestProjects/StaticAnalysis/ThrowsAsTerminates.cpp
+++ b/tests/TestProjects/StaticAnalysis/ThrowsAsTerminates.cpp
@@ -1,0 +1,31 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+#include <stdexcept>
+
+// Deliberately not defined, so that the analysis cannot see through it.
+bool should_throw();
+
+TEST_CASE( "REQUIRE_THROWS_AS terminates the test case on a missing exception" ) {
+    std::optional<int> opt = 42;
+    REQUIRE_THROWS_AS( should_throw() ? throw std::runtime_error( "boom" )
+                                      : opt.reset(),
+                       std::runtime_error );
+    CHECK( *opt == 42 );
+}
+
+TEST_CASE( "CHECK_THROWS_AS keeps going on a missing exception" ) {
+    std::optional<int> opt = 42;
+    CHECK_THROWS_AS( should_throw() ? throw std::runtime_error( "boom" )
+                                    : opt.reset(),
+                     std::runtime_error );
+    CHECK( *opt == 42 ); // expect-warning: bugprone-unchecked-optional-access
+}

--- a/tests/TestProjects/StaticAnalysis/ThrowsTerminates.cpp
+++ b/tests/TestProjects/StaticAnalysis/ThrowsTerminates.cpp
@@ -1,0 +1,29 @@
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+#include <stdexcept>
+
+// Deliberately not defined, so that the analysis cannot see through it.
+bool should_throw();
+
+TEST_CASE( "REQUIRE_THROWS terminates the test case when nothing is thrown" ) {
+    std::optional<int> opt = 42;
+    REQUIRE_THROWS( should_throw() ? throw std::runtime_error( "boom" )
+                                   : opt.reset() );
+    CHECK( *opt == 42 );
+}
+
+TEST_CASE( "CHECK_THROWS keeps going when nothing is thrown" ) {
+    std::optional<int> opt = 42;
+    CHECK_THROWS( should_throw() ? throw std::runtime_error( "boom" )
+                                 : opt.reset() );
+    CHECK( *opt == 42 ); // expect-warning: bugprone-unchecked-optional-access
+}

--- a/tests/TestScripts/testStaticAnalysisSupport.py
+++ b/tests/TestScripts/testStaticAnalysisSupport.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+
+#              Copyright Catch2 Authors
+# Distributed under the Boost Software License, Version 1.0.
+#   (See accompanying file LICENSE.txt or copy at
+#        https://www.boost.org/LICENSE_1_0.txt)
+
+# SPDX-License-Identifier: BSL-1.0
+
+"""
+Tests Catch2's static analysis support, by building the test project in
+`tests/TestProjects/StaticAnalysis` under clang-tidy and comparing the warnings
+against the `// expect-warning: <check>` markers in its sources.
+
+Requires 2 arguments, path to folder where the Catch2's main CMakeLists.txt
+exists, and path to where the output files should be stored. Optionally takes
+the clang-tidy binary as a third argument, and the C++ compiler as a fourth one.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from typing import Dict, Set
+
+# Catch2 models the early termination with a [[noreturn]] call, which
+# bugprone-unchecked-optional-access only started honouring in clang-tidy 17.
+MINIMAL_CLANG_TIDY_VERSION = 17
+
+# Reported as a skip by CTest, see the test's SKIP_RETURN_CODE property.
+SKIP_RETURN_CODE = 77
+
+EXPECTED_WARNING_MARKER = '// expect-warning: <check>'
+
+# Anchored, so that prose mentioning the marker is not mistaken for one.
+expected_warning_regex = re.compile(r'//\s*expect-warning:\s*(?P<check>[\w.-]+)\s*$')
+clang_tidy_version_regex = re.compile(r'LLVM version (\d+)\.')
+# `<path>:<line>:<column>: warning: <message> [<check>]`
+warning_regex = re.compile(
+    r'^(?P<path>.+?):(?P<line>\d+):\d+:\s+warning:\s+.*\[(?P<check>[\w.-]+)\]$')
+
+
+def get_clang_tidy_version(clang_tidy: str) -> int:
+    try:
+        result = subprocess.run([clang_tidy, '--version'],
+                                capture_output = True,
+                                check = True,
+                                text = True)
+    except OSError as err:
+        print(f"Could not run '{clang_tidy} --version': {err}")
+        exit(5)
+    except subprocess.CalledProcessError as err:
+        print(f"'{clang_tidy} --version' failed with {err.returncode}")
+        print(f'stderr: {err.stderr}')
+        print(f'stdout: {err.stdout}')
+        exit(5)
+
+    version_match = clang_tidy_version_regex.search(result.stdout)
+    if not version_match:
+        print('Could not find clang-tidy version in output')
+        print(f"output: '{result.stdout}'")
+        exit(5)
+    return int(version_match.group(1))
+
+
+def configure_and_build(sources_dir: str, build_dir: str, catch2_path: str,
+                        clang_tidy: str, cxx_compiler: str) -> str:
+    # An incremental build would only re-analyze what changed.
+    shutil.rmtree(build_dir, ignore_errors = True)
+
+    config_cmd = ['cmake',
+                  '-B', build_dir,
+                  '-S', sources_dir,
+                  f'-DCATCH2_PATH={catch2_path}',
+                  '-DCMAKE_BUILD_TYPE=Debug',
+                  f'-DSTATIC_ANALYSIS_CLANG_TIDY={clang_tidy}']
+
+    if cxx_compiler:
+        config_cmd.append(f'-DCMAKE_CXX_COMPILER={cxx_compiler}')
+
+    build_cmd = ['cmake',
+                 '--build', build_dir,
+                 '--config', 'Debug',
+                 '--parallel', str(os.cpu_count() or 1)]
+
+    try:
+        subprocess.run(config_cmd,
+                       capture_output = True,
+                       check = True,
+                       text = True)
+    except subprocess.CalledProcessError as err:
+        print('Error when configuring the test project')
+        print(f'cmd: {err.cmd}')
+        print(f'stderr: {err.stderr}')
+        print(f'stdout: {err.stdout}')
+        exit(3)
+
+    result = subprocess.run(build_cmd,
+                            stdout = subprocess.PIPE,
+                            stderr = subprocess.STDOUT,
+                            check = False,
+                            text = True)
+    if result.returncode != 0:
+        print('Error when building the test project')
+        print(f'cmd: {build_cmd}')
+        print(f'exit code: {result.returncode}')
+        print(f'output: {result.stdout}')
+        exit(6)
+    return result.stdout
+
+
+# Expectations and warnings are both `{file name: {line number: check name}}`,
+# keyed by the bare file name, so the sources have to stay in a flat directory.
+def parse_expectations(sources_dir: str) -> Dict[str, Dict[int, str]]:
+    expectations = {}
+    for entry in sorted(os.listdir(sources_dir)):
+        if not entry.endswith('.cpp'):
+            continue
+        marked = {}
+        with open(os.path.join(sources_dir, entry), mode = 'r', encoding = 'utf-8') as file:
+            for number, line in enumerate(file, start = 1):
+                match = expected_warning_regex.search(line.rstrip())
+                if match:
+                    marked[number] = match.group('check')
+        expectations[entry] = marked
+    return expectations
+
+
+def parse_warnings(build_output: str,
+                   known_files: Set[str]) -> Dict[str, Dict[int, str]]:
+    warnings = {file_name: {} for file_name in known_files}
+    for line in build_output.splitlines():
+        match = warning_regex.match(line.strip())
+        if not match:
+            continue
+        # The compiler's own diagnostics look just like clang-tidy's, except
+        # that they are tagged with a `-Wflag` instead of a check name.
+        check = match.group('check')
+        if check.startswith('-W'):
+            continue
+        # clang-tidy also reports through Catch2's own headers.
+        file_name = os.path.basename(match.group('path'))
+        if file_name not in warnings:
+            continue
+        warnings[file_name][int(match.group('line'))] = check
+    return warnings
+
+
+if __name__ == '__main__':
+    if len(sys.argv) not in (3, 4, 5):
+        print(f'Wrong number of arguments: {len(sys.argv)}')
+        print(f'Usage: {sys.argv[0]} catch2-top-level-dir base-build-output-dir '
+              '[clang-tidy-binary [cxx-compiler]]')
+        exit(2)
+
+    catch2_path = os.path.abspath(sys.argv[1])
+    build_dir = os.path.join(os.path.abspath(sys.argv[2]), 'StaticAnalysisTests')
+    # CMake passes an empty string for a cache variable that was blanked out.
+    clang_tidy = sys.argv[3] if len(sys.argv) >= 4 and sys.argv[3] else 'clang-tidy'
+    cxx_compiler = sys.argv[4] if len(sys.argv) == 5 else ''
+    sources_dir = os.path.join(catch2_path, 'tests', 'TestProjects', 'StaticAnalysis')
+
+    version = get_clang_tidy_version(clang_tidy)
+    if version < MINIMAL_CLANG_TIDY_VERSION:
+        print(f"'{clang_tidy}' is version {version}, but these tests need "
+              f'{MINIMAL_CLANG_TIDY_VERSION} or newer.')
+        print('bugprone-unchecked-optional-access ignores [[noreturn]] before '
+              'clang-tidy 17, so the REQUIRE cases would warn just like the '
+              'CHECK ones. Skipping.')
+        exit(SKIP_RETURN_CODE)
+
+    expectations = parse_expectations(sources_dir)
+    if not expectations:
+        print(f"Found no sources in '{sources_dir}'")
+        exit(4)
+
+    build_output = configure_and_build(sources_dir, build_dir, catch2_path,
+                                       clang_tidy, cxx_compiler)
+    warnings = parse_warnings(build_output, set(expectations))
+
+    total_warnings = sum(len(lines) for lines in warnings.values())
+    if total_warnings == 0:
+        # Every source is expected to warn, so this would pass silently.
+        print('clang-tidy reported no warnings at all, it likely did not run.')
+        print(f'build output: "{build_output}"')
+        exit(7)
+
+    mismatched = 0
+    for file_name in sorted(expectations):
+        expected = expectations[file_name]
+        actual = warnings[file_name]
+        for line in sorted(set(actual) - set(expected)):
+            print(f'{file_name}:{line}: unexpected [{actual[line]}] warning, '
+                  f'the line is not marked with "{EXPECTED_WARNING_MARKER}"')
+            mismatched += 1
+        for line in sorted(set(expected) - set(actual)):
+            print(f'{file_name}:{line}: missing [{expected[line]}] warning, '
+                  f'the line is marked with "{EXPECTED_WARNING_MARKER}"')
+            mismatched += 1
+        for line in sorted(set(expected) & set(actual)):
+            if expected[line] != actual[line]:
+                print(f'{file_name}:{line}: expected a [{expected[line]}] warning, '
+                      f'but got a [{actual[line]}] one')
+                mismatched += 1
+
+    if mismatched:
+        print(f'Found {mismatched} mismatched warnings!')
+        print(f'build output: "{build_output}"')
+        exit(1)
+
+    print(f'{total_warnings} warnings matched the expectations')


### PR DESCRIPTION
## Description

This patch adds separate implementations of several assertion macros under `CATCH_CONFIG_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT`, so that single-TU static analysis, such as clang-tidy's `bugprone-unchecked-optional-access`, can reason about Catch2's assertions. 

The goal is to remove a class of false positives (in particular for flow-sensitive analysers) that users currently get in every test that guards with `REQUIRE`.

The main idea is to model early termination in case of `REQUIRE` macro by using `Catch::Detail::Unreachable()`.

## Testing

I tried to do automated testing based on guidance from https://github.com/catchorg/Catch2/pull/3194#issuecomment-5400964184

Manual testing results are posted in https://github.com/catchorg/Catch2/pull/3194#issuecomment-5349279602

## GitHub Issues

Partially address https://github.com/catchorg/Catch2/issues/3170

Some discussed follow-ups have not been implemented yet:
- Support of `REQUIRE_THAT`
- Support of  `REQUIRE_THROWS_MATCHES`
- Support of `REQUIRE_THROWS_WITH`