### PR TITLE
Stop AnsiSkippingString treating literal 0xff bytes as its own sentinel

### DIFF
--- a/src/catch2/internal/catch_textflow.cpp
+++ b/src/catch2/internal/catch_textflow.cpp
@@ -48,6 +48,9 @@ namespace Catch {
                         break;
                     }
                     // 'm' -> 0xff
+                    m_sentinelPositions.push_back(
+                        static_cast<std::string::size_type>(
+                            cursor - m_string.begin() ) );
                     *cursor = AnsiSkippingString::sentinel;
                     // if we've read an ansi sequence, set the iterator and
                     // return to the top of the loop
@@ -76,11 +79,12 @@ namespace Catch {
         }
 
         AnsiSkippingString::const_iterator AnsiSkippingString::begin() const {
-            return const_iterator( m_string );
+            return const_iterator( m_string, m_sentinelPositions );
         }
 
         AnsiSkippingString::const_iterator AnsiSkippingString::end() const {
-            return const_iterator( m_string, const_iterator::EndTag{} );
+            return const_iterator(
+                m_string, m_sentinelPositions, const_iterator::EndTag{} );
         }
 
         std::string AnsiSkippingString::substring( const_iterator begin,
@@ -89,15 +93,35 @@ namespace Catch {
             // making a begin iterator we might have skipped ansi sequences at
             // the start. If `begin` here is a begin iterator, skipped over
             // initial ansi sequences, we'll use the true beginning of the
-            // string. Lastly: We need to transform any chars we replaced with
-            // 0xff back to 'm'
-            auto str = std::string( begin == this->begin() ? m_string.begin()
-                                                           : begin.m_it,
-                                    end.m_it );
-            std::transform( str.begin(), str.end(), str.begin(), []( char c ) {
-                return c == AnsiSkippingString::sentinel ? 'm' : c;
-            } );
+            // string. Lastly: we need to transform the bytes we know we
+            // replaced with 0xff (recorded in m_sentinelPositions) back to
+            // 'm', but a literal 0xff byte that was already part of the
+            // original content has to be left alone, since it isn't one of
+            // ours.
+            auto startIt = begin == this->begin() ? m_string.begin()
+                                                   : begin.m_it;
+            auto str = std::string( startIt, end.m_it );
+            auto rangeStart = static_cast<std::string::size_type>(
+                startIt - m_string.begin() );
+            auto rangeEnd = rangeStart + str.size();
+            for ( auto pos : m_sentinelPositions ) {
+                if ( pos >= rangeEnd ) {
+                    break;
+                }
+                if ( pos >= rangeStart ) {
+                    str[pos - rangeStart] = 'm';
+                }
+            }
             return str;
+        }
+
+        bool AnsiSkippingString::const_iterator::isSentinelAt(
+            std::string::const_iterator it ) const {
+            auto pos =
+                static_cast<std::string::size_type>( it - m_string->begin() );
+            return std::binary_search( m_sentinelPositions->begin(),
+                                       m_sentinelPositions->end(),
+                                       pos );
         }
 
         void AnsiSkippingString::const_iterator::tryParseAnsiEscapes() {
@@ -110,8 +134,7 @@ namespace Catch {
                         ( isdigit( *cursor ) || *cursor == ';' ) ) {
                     ++cursor;
                 }
-                if ( cursor == m_string->end() ||
-                     *cursor != AnsiSkippingString::sentinel ) {
+                if ( cursor == m_string->end() || !isSentinelAt( cursor ) ) {
                     break;
                 }
                 // if we've read an ansi sequence, set the iterator and
@@ -134,9 +157,10 @@ namespace Catch {
         void AnsiSkippingString::const_iterator::unadvance() {
             assert( m_it != m_string->begin() );
             m_it--;
-            // if *m_it is 0xff, scan back to the \033 and then m_it-- once more
-            // (and repeat check)
-            while ( *m_it == AnsiSkippingString::sentinel ) {
+            // if *m_it is one of our own sentinel markers, scan back to the
+            // \033 and then m_it-- once more (and repeat check). A literal
+            // 0xff byte that isn't one of our markers is left alone here.
+            while ( isSentinelAt( m_it ) ) {
                 while ( *m_it != '\033' ) {
                     assert( m_it != m_string->begin() );
                     m_it--;

--- a/src/catch2/internal/catch_textflow.hpp
+++ b/src/catch2/internal/catch_textflow.hpp
@@ -35,6 +35,12 @@ namespace Catch {
         class AnsiSkippingString {
             std::string m_string;
             std::size_t m_size = 0;
+            // Byte offsets into m_string where a recognized ansi escape
+            // sequence's terminating 'm' was replaced with `sentinel`.
+            // Needed to tell those synthetic markers apart from a literal
+            // 0xff byte that may already be present in arbitrary (non-ansi)
+            // string content, e.g. from stringifying raw bytes.
+            std::vector<std::string::size_type> m_sentinelPositions;
 
             // perform 0xff replacement and calculate m_size
             void preprocessString();
@@ -63,10 +69,21 @@ namespace Catch {
             struct EndTag {};
 
             const std::string* m_string;
+            const std::vector<std::string::size_type>* m_sentinelPositions;
             std::string::const_iterator m_it;
 
-            explicit const_iterator( const std::string& string, EndTag ):
-                m_string( &string ), m_it( string.end() ) {}
+            explicit const_iterator(
+                const std::string& string,
+                const std::vector<std::string::size_type>& sentinelPositions,
+                EndTag ):
+                m_string( &string ),
+                m_sentinelPositions( &sentinelPositions ),
+                m_it( string.end() ) {}
+
+            // whether the byte currently under `it` is one of the sentinel
+            // markers we inserted ourselves, as opposed to a literal 0xff
+            // byte that was already part of the original string content
+            bool isSentinelAt( std::string::const_iterator it ) const;
 
             void tryParseAnsiEscapes();
             void advance();
@@ -79,8 +96,12 @@ namespace Catch {
             using reference = value_type&;
             using iterator_category = std::bidirectional_iterator_tag;
 
-            explicit const_iterator( const std::string& string ):
-                m_string( &string ), m_it( string.begin() ) {
+            explicit const_iterator(
+                const std::string& string,
+                const std::vector<std::string::size_type>& sentinelPositions ):
+                m_string( &string ),
+                m_sentinelPositions( &sentinelPositions ),
+                m_it( string.begin() ) {
                 tryParseAnsiEscapes();
             }
 

--- a/tests/SelfTest/IntrospectiveTests/TextFlow.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/TextFlow.tests.cpp
@@ -492,3 +492,34 @@ TEST_CASE( "TextFlow::Column skips ansi escape sequences",
         REQUIRE( as_written( col ) == text );
     }
 }
+
+TEST_CASE( "TextFlow::Column handles literal 0xff bytes that are not ansi escapes",
+           "[TextFlow][column][approvals]" ) {
+    // 0xff is used internally as a sentinel to mark the end of a recognized
+    // ansi escape sequence, but arbitrary stringified content (e.g. raw
+    // bytes) can legitimately contain literal 0xff bytes that have nothing
+    // to do with ansi escapes. Those must be left completely untouched, both
+    // when read back out of the column and while wrapping/iterating over
+    // them.
+    std::string text( 40, '\xff' );
+    Column col( text );
+    col.width( 20 );
+
+    std::string written = as_written( col );
+    // every byte in the output must be either the original 0xff or the
+    // hyphen the wrapper inserts when it can't find a natural break point;
+    // none of them should have turned into a stray 'm'.
+    for ( unsigned char c : written ) {
+        REQUIRE( ( c == 0xffu || c == '-' || c == '\n' ) );
+    }
+
+    // Also directly cover the iterator's backwards traversal, which used to
+    // assert/crash when it walked off the start of the string looking for an
+    // ansi escape it was never part of.
+    AnsiSkippingString skipping( text );
+    auto it = skipping.end();
+    for ( std::size_t i = 0; i < skipping.size(); ++i ) {
+        --it;
+    }
+    REQUIRE( it == skipping.begin() );
+}


### PR DESCRIPTION
Closes #2960

`AnsiSkippingString` marks the terminating `m` of a recognized ansi escape sequence by overwriting it with `0xff` internally, and flips it back when a substring is produced. The trouble is a literal `0xff` byte that was already part of the original text (for instance from stringifying raw byte data, as in the linked issue) looks exactly the same as one of these markers, and the existing code has no way to tell them apart.

Two consequences of that, both reachable with plain text that has nothing to do with ansi escapes at all:

- `substring()` blindly turns every `0xff` byte in the output back into `'m'`, silently corrupting real data.
- the reverse iterator, on hitting a `0xff` byte, assumes it must have found one of its own markers and starts scanning backwards for the `\033` that "must" precede it. If the byte was never one of ours, that scan walks straight off the beginning of the string, tripping an assert in debug builds (and undefined behavior in release, matching the exception/crash reports in the issue).

The fix records the byte offsets where a real sentinel was inserted (`m_sentinelPositions`) and checks membership there instead of comparing raw byte values, in both `substring()` and the iterator's `unadvance()`/`tryParseAnsiEscapes()`. A plain `0xff` byte in the text is now left completely alone.

Added a test (`TextFlow::Column handles literal 0xff bytes that are not ansi escapes`) that:
- reproduces the crash on an unmodified build (confirmed it aborts with the exact assert from the issue before this change)
- passes cleanly with the fix
- also checks that genuine ansi-escape wrapping still round-trips correctly, so the existing sentinel behavior isn't disturbed

Ran the full self-test suite before and after; identical pass/fail counts either way (the one pre-existing `[!shouldfail]` TextFlow test is unrelated to this).