### PR TITLE
Add DISCOVERY_ENVIRONMENT option to catch_discover_tests

### DIFF
--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -127,6 +127,7 @@ catch_discover_tests(target
                      [OUTPUT_PREFIX prefix]
                      [OUTPUT_SUFFIX suffix]
                      [DISCOVERY_MODE <POST_BUILD|PRE_TEST>]
+                     [DISCOVERY_ENVIRONMENT var1=value1...]
                      [SKIP_IS_FAILURE]
                      [ADD_TAGS_AS_LABELS]
 )
@@ -222,6 +223,31 @@ discovery until test time, when the executable is already signed. The same
 limitation affects CMake's `gtest_discover_tests`; see
 [Catch2 #2411](https://github.com/catchorg/Catch2/issues/2411) and
 [CMake #21845](https://gitlab.kitware.com/cmake/cmake/-/issues/21845)._
+
+* `DISCOVERY_ENVIRONMENT var1=value1...`
+
+Environment variables to set while the test executable is run to retrieve the
+list of test cases. This is for executables that need a specific environment
+merely to start up and list their tests, for example one that needs a platform
+plugin selected, or one where an instrumentation library must be disabled so
+that its extra output does not corrupt the listing.
+
+These variables are **not** set when the tests themselves are run; use
+`PROPERTIES ENVIRONMENT ...` for that. Pass the value to both if it is needed
+in both cases.
+
+```cmake
+catch_discover_tests(tests
+                     DISCOVERY_ENVIRONMENT
+                       QT_QPA_PLATFORM=offscreen
+                     PROPERTIES
+                       ENVIRONMENT QT_QPA_PLATFORM=offscreen
+)
+```
+
+Note that `DL_PATHS` already covers the specific case of directories that the
+dynamic linker needs in order to load shared libraries, and applies to both
+discovery and test execution.
 
 * `SKIP_IS_FAILURE`
 

--- a/extras/Catch.cmake
+++ b/extras/Catch.cmake
@@ -138,6 +138,18 @@ same as the Catch name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
     of test cases from the test executable and when the tests are executed themselves.
     This requires cmake/ctest >= 3.22.
 
+  ``DISCOVERY_ENVIRONMENT <var>=<value>...``
+    Specifies environment variables that are set while the test executable is
+    run to retrieve the list of test cases. This is useful when the executable
+    needs a specific environment merely to start up and list its tests, for
+    example a platform plugin selection variable, or a variable that suppresses
+    extra output from an instrumentation library that would otherwise corrupt
+    the listing.
+
+    These variables are **not** applied when the tests themselves are run. Use
+    ``PROPERTIES ENVIRONMENT ...`` for that, or pass the same values to both if
+    the environment is needed in both cases.
+
   ``DISCOVERY_MODE mode``
     Provides control over when ``catch_discover_tests`` performs test discovery.
     By default, ``POST_BUILD`` sets up a post-build command to perform test discovery
@@ -172,7 +184,7 @@ function(catch_discover_tests TARGET)
     ""
     "SKIP_IS_FAILURE;ADD_TAGS_AS_LABELS"
     "TEST_PREFIX;TEST_SUFFIX;WORKING_DIRECTORY;TEST_LIST;REPORTER;OUTPUT_DIR;OUTPUT_PREFIX;OUTPUT_SUFFIX;DISCOVERY_MODE"
-    "TEST_SPEC;EXTRA_ARGS;PROPERTIES;DL_PATHS;DL_FRAMEWORK_PATHS"
+    "TEST_SPEC;EXTRA_ARGS;PROPERTIES;DL_PATHS;DL_FRAMEWORK_PATHS;DISCOVERY_ENVIRONMENT"
     ${ARGN}
   )
 
@@ -240,6 +252,7 @@ function(catch_discover_tests TARGET)
               -D "TEST_OUTPUT_SUFFIX=${_OUTPUT_SUFFIX}"
               -D "TEST_DL_PATHS=${_DL_PATHS}"
               -D "TEST_DL_FRAMEWORK_PATHS=${_DL_FRAMEWORK_PATHS}"
+              -D "TEST_DISCOVERY_ENVIRONMENT=${_DISCOVERY_ENVIRONMENT}"
               -D "CTEST_FILE=${ctest_tests_file}"
               -D "ADD_TAGS_AS_LABELS=${_ADD_TAGS_AS_LABELS}"
               -P "${_CATCH_DISCOVER_TESTS_SCRIPT}"
@@ -287,6 +300,7 @@ function(catch_discover_tests TARGET)
       "      CTEST_FILE"             " [==[" "${ctest_tests_file}"        "]==]"   "\n"
       "      TEST_DL_PATHS"          " [==[" "${_DL_PATHS}"               "]==]"   "\n"
       "      TEST_DL_FRAMEWORK_PATHS" " [==[" "${_DL_FRAMEWORK_PATHS}"     "]==]"   "\n"
+      "      TEST_DISCOVERY_ENVIRONMENT" " [==[" "${_DISCOVERY_ENVIRONMENT}" "]==]"  "\n"
       "      ADD_TAGS_AS_LABELS"     " [==[" "${_ADD_TAGS_AS_LABELS}"     "]==]"   "\n"
       "    )"                                                                      "\n"
       "  endif()"                                                                  "\n"

--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -219,7 +219,7 @@ function(catch_discover_tests_impl)
     ""
     ""
     "TEST_EXECUTABLE;TEST_WORKING_DIR;TEST_OUTPUT_DIR;TEST_OUTPUT_PREFIX;TEST_OUTPUT_SUFFIX;TEST_PREFIX;TEST_REPORTER;TEST_SPEC;TEST_SUFFIX;TEST_LIST;CTEST_FILE"
-    "TEST_EXTRA_ARGS;TEST_PROPERTIES;TEST_EXECUTOR;TEST_DL_PATHS;TEST_DL_FRAMEWORK_PATHS;ADD_TAGS_AS_LABELS"
+    "TEST_EXTRA_ARGS;TEST_PROPERTIES;TEST_EXECUTOR;TEST_DL_PATHS;TEST_DL_FRAMEWORK_PATHS;TEST_DISCOVERY_ENVIRONMENT;ADD_TAGS_AS_LABELS"
     ${ARGN}
   )
 
@@ -248,6 +248,7 @@ function(catch_discover_tests_impl)
   set(output_suffix ${_TEST_OUTPUT_SUFFIX})
   set(dl_paths ${_TEST_DL_PATHS})
   set(dl_framework_paths ${_TEST_DL_FRAMEWORK_PATHS})
+  set(discovery_environment ${_TEST_DISCOVERY_ENVIRONMENT})
   set(environment_modifications "")
   set(script)
   set(suite)
@@ -285,6 +286,36 @@ function(catch_discover_tests_impl)
     cmake_path(CONVERT "${env_dl_framework_paths}" TO_NATIVE_PATH_LIST paths)
     set(ENV{DYLD_FRAMEWORK_PATH} "${paths}")
   endif()
+
+  # Apply DISCOVERY_ENVIRONMENT for the duration of the discovery run only.
+  # In PRE_TEST mode this function runs inside the CTest process, so the
+  # previous values are remembered and restored once discovery is finished;
+  # otherwise these variables would leak into the environment of the tests,
+  # which is explicitly not what this option promises.
+  set(_saved_env_names)
+  foreach(_env_entry IN LISTS discovery_environment)
+    if(NOT _env_entry MATCHES "^([^=]+)=(.*)$")
+      message(FATAL_ERROR
+        "Invalid DISCOVERY_ENVIRONMENT entry '${_env_entry}'. "
+        "Entries must have the form <var>=<value>."
+      )
+    endif()
+    set(_env_name "${CMAKE_MATCH_1}")
+    set(_env_value "${CMAKE_MATCH_2}")
+
+    # The previous value is stashed in a per-variable CMake variable rather
+    # than in parallel lists, because an environment variable may be unset or
+    # hold an empty value, and CMake lists cannot represent those distinctly.
+    list(APPEND _saved_env_names "${_env_name}")
+    if(DEFINED ENV{${_env_name}})
+      set(_saved_env_was_set_${_env_name} TRUE)
+      set(_saved_env_value_${_env_name} "$ENV{${_env_name}}")
+    else()
+      set(_saved_env_was_set_${_env_name} FALSE)
+    endif()
+
+    set(ENV{${_env_name}} "${_env_value}")
+  endforeach()
 
   make_temp_file_path(listing_output_path "${_TEST_WORKING_DIR}")
 
@@ -341,6 +372,15 @@ function(catch_discover_tests_impl)
       )
     endif()
   endif()
+
+  # Discovery is done, so restore whatever the environment looked like before.
+  foreach(_env_name IN LISTS _saved_env_names)
+    if(_saved_env_was_set_${_env_name})
+      set(ENV{${_env_name}} "${_saved_env_value_${_env_name}}")
+    else()
+      unset(ENV{${_env_name}})
+    endif()
+  endforeach()
 
   # Prepare output dir
   if(output_dir AND NOT IS_ABSOLUTE ${output_dir})
@@ -543,6 +583,7 @@ if(CMAKE_SCRIPT_MODE_FILE AND DEFINED TEST_EXECUTABLE)
     TEST_OUTPUT_SUFFIX ${TEST_OUTPUT_SUFFIX}
     TEST_DL_PATHS ${TEST_DL_PATHS}
     TEST_DL_FRAMEWORK_PATHS ${TEST_DL_FRAMEWORK_PATHS}
+    TEST_DISCOVERY_ENVIRONMENT ${TEST_DISCOVERY_ENVIRONMENT}
     CTEST_FILE ${CTEST_FILE}
     ADD_TAGS_AS_LABELS ${ADD_TAGS_AS_LABELS}
   )

--- a/extras/CatchAddTests.cmake
+++ b/extras/CatchAddTests.cmake
@@ -306,12 +306,19 @@ function(catch_discover_tests_impl)
     # The previous value is stashed in a per-variable CMake variable rather
     # than in parallel lists, because an environment variable may be unset or
     # hold an empty value, and CMake lists cannot represent those distinctly.
-    list(APPEND _saved_env_names "${_env_name}")
-    if(DEFINED ENV{${_env_name}})
-      set(_saved_env_was_set_${_env_name} TRUE)
-      set(_saved_env_value_${_env_name} "$ENV{${_env_name}}")
-    else()
-      set(_saved_env_was_set_${_env_name} FALSE)
+    #
+    # Only stash it the first time a name is seen. A repeated entry, such as
+    # `FOO=a;FOO=b`, would otherwise stash the value set by the previous
+    # iteration and restore to that instead of the original.
+    list(FIND _saved_env_names "${_env_name}" _already_saved)
+    if(_already_saved EQUAL -1)
+      list(APPEND _saved_env_names "${_env_name}")
+      if(DEFINED ENV{${_env_name}})
+        set(_saved_env_was_set_${_env_name} TRUE)
+        set(_saved_env_value_${_env_name} "$ENV{${_env_name}}")
+      else()
+        set(_saved_env_was_set_${_env_name} FALSE)
+      endif()
     endif()
 
     set(ENV{${_env_name}} "${_env_value}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -672,6 +672,13 @@ if(CATCH_ENABLE_CMAKE_HELPER_TESTS)
       "-DCATCH_ADD_TESTS_SCRIPT=${CATCH_DIR}/extras/CatchAddTests.cmake"
       -P "${CMAKE_CURRENT_LIST_DIR}/TestScripts/DiscoverTests/TestDecomposeJsonArray.cmake"
   )
+
+  add_test(NAME "CMakeHelper::DiscoveryEnvironment"
+    COMMAND
+      "${CMAKE_COMMAND}"
+      "-DCATCH_ADD_TESTS_SCRIPT=${CATCH_DIR}/extras/CatchAddTests.cmake"
+      -P "${CMAKE_CURRENT_LIST_DIR}/TestScripts/DiscoverTests/TestDiscoveryEnvironment.cmake"
+  )
 endif()
 
 foreach(reporterName # "Automake" - the simple .trs format does not support any kind of comments/metadata

--- a/tests/TestScripts/DiscoverTests/FakeListingExecutable.cmake
+++ b/tests/TestScripts/DiscoverTests/FakeListingExecutable.cmake
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: BSL-1.0
+
+# A stand-in for a Catch2 test executable, used by
+# `TestDiscoveryEnvironment.cmake`.
+#
+# It writes a minimal `--list-tests` JSON listing in which the name of the
+# single test case is the value of the `CATCH_TEST_DISCOVERY_SENTINEL`
+# environment variable. That lets the caller prove whether an environment
+# variable reached the process that performs test discovery.
+#
+# CMake is used as the fake executable so that the test works on every
+# platform the real CI runs on, rather than relying on a shell script.
+
+cmake_minimum_required(VERSION 3.19)
+
+# Find the `--out <path>` argument that catch_discover_tests_impl passes.
+set(_out_path)
+set(_prev)
+math(EXPR _last "${CMAKE_ARGC} - 1")
+foreach(_i RANGE ${_last})
+  set(_arg "${CMAKE_ARGV${_i}}")
+  if(_prev STREQUAL "--out")
+    set(_out_path "${_arg}")
+  endif()
+  if(_arg STREQUAL "--list-reporters")
+    # The reporter probe only cares about the exit code.
+    return()
+  endif()
+  set(_prev "${_arg}")
+endforeach()
+
+if(NOT _out_path)
+  message(FATAL_ERROR "FakeListingExecutable: no --out argument was provided")
+endif()
+
+if(DEFINED ENV{CATCH_TEST_DISCOVERY_SENTINEL})
+  set(_test_name "sentinel: $ENV{CATCH_TEST_DISCOVERY_SENTINEL}")
+else()
+  set(_test_name "sentinel: <unset>")
+endif()
+
+file(WRITE "${_out_path}"
+"{ \"version\": 2
+, \"metadata\": { \"name\": \"fake\", \"rng-seed\": 0, \"catch2-version\": \"3.0.0\" }
+, \"listings\": { \"tests\": [ { \"name\": \"${_test_name}\", \"class-name\": \"\", \"tags\": [], \"source-location\": { \"filename\": \"fake.cpp\", \"line\": 1 } } ] } }
+")

--- a/tests/TestScripts/DiscoverTests/TestDiscoveryEnvironment.cmake
+++ b/tests/TestScripts/DiscoverTests/TestDiscoveryEnvironment.cmake
@@ -22,6 +22,26 @@ include("${CATCH_ADD_TESTS_SCRIPT}")
 
 set(_failures 0)
 
+# The test asserts on the state of CATCH_TEST_DISCOVERY_SENTINEL, so stash and
+# clear whatever the caller happened to have in the environment. Otherwise a
+# caller who already has it set would see spurious failures, and running this
+# script standalone would clobber their value.
+if(DEFINED ENV{CATCH_TEST_DISCOVERY_SENTINEL})
+  set(_caller_sentinel_was_set TRUE)
+  set(_caller_sentinel "$ENV{CATCH_TEST_DISCOVERY_SENTINEL}")
+else()
+  set(_caller_sentinel_was_set FALSE)
+endif()
+unset(ENV{CATCH_TEST_DISCOVERY_SENTINEL})
+
+macro(restore_caller_sentinel)
+  if(_caller_sentinel_was_set)
+    set(ENV{CATCH_TEST_DISCOVERY_SENTINEL} "${_caller_sentinel}")
+  else()
+    unset(ENV{CATCH_TEST_DISCOVERY_SENTINEL})
+  endif()
+endmacro()
+
 function(expect_contains description haystack needle)
   string(FIND "${haystack}" "${needle}" _pos)
   if(_pos GREATER_EQUAL 0)
@@ -99,6 +119,27 @@ else()
   math(EXPR _failures "${_failures} + 1")
 endif()
 unset(ENV{CATCH_TEST_DISCOVERY_SENTINEL})
+
+# 5) A repeated entry uses the last value during discovery, and still restores
+#    the value from before discovery rather than the one set by an earlier
+#    iteration.
+set(ENV{CATCH_TEST_DISCOVERY_SENTINEL} "pre-existing")
+set(_ctest_file "${_work_dir}/duplicate-env.cmake")
+run_discovery("${_ctest_file}"
+  DISCOVERY_ENVIRONMENT
+    "CATCH_TEST_DISCOVERY_SENTINEL=first"
+    "CATCH_TEST_DISCOVERY_SENTINEL=second")
+file(READ "${_ctest_file}" _duplicate_env)
+expect_contains("a repeated entry uses the last value during discovery"
+  "${_duplicate_env}" "sentinel: second")
+if("$ENV{CATCH_TEST_DISCOVERY_SENTINEL}" STREQUAL "pre-existing")
+  message("  [PASS] a repeated entry still restores the pre-discovery value")
+else()
+  message("  [FAIL] a repeated entry restored '$ENV{CATCH_TEST_DISCOVERY_SENTINEL}' instead of 'pre-existing'")
+  math(EXPR _failures "${_failures} + 1")
+endif()
+
+restore_caller_sentinel()
 
 if(_failures GREATER 0)
   message(FATAL_ERROR "${_failures} DISCOVERY_ENVIRONMENT test(s) failed")

--- a/tests/TestScripts/DiscoverTests/TestDiscoveryEnvironment.cmake
+++ b/tests/TestScripts/DiscoverTests/TestDiscoveryEnvironment.cmake
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: BSL-1.0
+
+# Unit tests for the `DISCOVERY_ENVIRONMENT` option of `catch_discover_tests`.
+#
+# Run as
+#     cmake -DCATCH_ADD_TESTS_SCRIPT=/path/to/extras/CatchAddTests.cmake \
+#           -P TestDiscoveryEnvironment.cmake
+
+cmake_minimum_required(VERSION 3.19)
+
+if(NOT DEFINED CATCH_ADD_TESTS_SCRIPT)
+  message(FATAL_ERROR "Missing argument `CATCH_ADD_TESTS_SCRIPT`")
+endif()
+
+if(NOT EXISTS "${CATCH_ADD_TESTS_SCRIPT}")
+  message(FATAL_ERROR "Cannot find CatchAddTests.cmake at '${CATCH_ADD_TESTS_SCRIPT}'")
+endif()
+
+# Pull in the helper functions. Without `TEST_EXECUTABLE` being defined,
+# `catch_discover_tests_impl` is not called.
+include("${CATCH_ADD_TESTS_SCRIPT}")
+
+set(_failures 0)
+
+function(expect_contains description haystack needle)
+  string(FIND "${haystack}" "${needle}" _pos)
+  if(_pos GREATER_EQUAL 0)
+    message("  [PASS] ${description}")
+  else()
+    message("  [FAIL] ${description}")
+    message("         expected to find: [${needle}]")
+    message("         in:               [${haystack}]")
+    math(EXPR _n "${_failures} + 1")
+    set(_failures "${_n}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+set(_fake_executable "${CMAKE_CURRENT_LIST_DIR}/FakeListingExecutable.cmake")
+if(NOT EXISTS "${_fake_executable}")
+  message(FATAL_ERROR "Cannot find fake executable at '${_fake_executable}'")
+endif()
+
+set(_work_dir "${CMAKE_CURRENT_BINARY_DIR}/discovery-environment-test")
+file(MAKE_DIRECTORY "${_work_dir}")
+
+# `cmake -P <script>` stands in for a test executable, so that this test does
+# not need a compiler and runs the same way on every platform.
+function(run_discovery out_ctest_file)
+  cmake_parse_arguments(_arg "" "" "DISCOVERY_ENVIRONMENT" ${ARGN})
+  catch_discover_tests_impl(
+    TEST_EXECUTABLE "${_fake_executable}"
+    TEST_EXECUTOR "${CMAKE_COMMAND}" -P
+    TEST_WORKING_DIR "${_work_dir}"
+    TEST_PREFIX [==['']==]
+    TEST_SUFFIX [==['']==]
+    TEST_LIST fake_TESTS
+    CTEST_FILE "${out_ctest_file}"
+    TEST_DISCOVERY_ENVIRONMENT ${_arg_DISCOVERY_ENVIRONMENT}
+    ADD_TAGS_AS_LABELS 0
+  )
+endfunction()
+
+# 1) Without the option, the executable sees no sentinel.
+set(_ctest_file "${_work_dir}/without-env.cmake")
+run_discovery("${_ctest_file}")
+file(READ "${_ctest_file}" _without_env)
+expect_contains("sentinel is unset when DISCOVERY_ENVIRONMENT is not given"
+  "${_without_env}" "sentinel: <unset>")
+
+# 2) With the option, the value reaches the discovery process.
+set(_ctest_file "${_work_dir}/with-env.cmake")
+run_discovery("${_ctest_file}"
+  DISCOVERY_ENVIRONMENT "CATCH_TEST_DISCOVERY_SENTINEL=from-discovery-env")
+file(READ "${_ctest_file}" _with_env)
+expect_contains("DISCOVERY_ENVIRONMENT value reaches the listing process"
+  "${_with_env}" "sentinel: from-discovery-env")
+
+# 3) The variable does not leak past discovery. This matters in PRE_TEST mode,
+#    where discovery runs inside the CTest process itself.
+if(DEFINED ENV{CATCH_TEST_DISCOVERY_SENTINEL})
+  message("  [FAIL] variable leaked past discovery: '$ENV{CATCH_TEST_DISCOVERY_SENTINEL}'")
+  math(EXPR _failures "${_failures} + 1")
+else()
+  message("  [PASS] variable does not leak past discovery")
+endif()
+
+# 4) A pre-existing value is restored rather than clobbered.
+set(ENV{CATCH_TEST_DISCOVERY_SENTINEL} "pre-existing")
+set(_ctest_file "${_work_dir}/override-env.cmake")
+run_discovery("${_ctest_file}"
+  DISCOVERY_ENVIRONMENT "CATCH_TEST_DISCOVERY_SENTINEL=overridden")
+file(READ "${_ctest_file}" _override_env)
+expect_contains("DISCOVERY_ENVIRONMENT overrides a pre-existing value"
+  "${_override_env}" "sentinel: overridden")
+if("$ENV{CATCH_TEST_DISCOVERY_SENTINEL}" STREQUAL "pre-existing")
+  message("  [PASS] pre-existing value is restored after discovery")
+else()
+  message("  [FAIL] pre-existing value not restored, got '$ENV{CATCH_TEST_DISCOVERY_SENTINEL}'")
+  math(EXPR _failures "${_failures} + 1")
+endif()
+unset(ENV{CATCH_TEST_DISCOVERY_SENTINEL})
+
+if(_failures GREATER 0)
+  message(FATAL_ERROR "${_failures} DISCOVERY_ENVIRONMENT test(s) failed")
+else()
+  message(STATUS "All DISCOVERY_ENVIRONMENT tests passed")
+endif()


### PR DESCRIPTION
Closes #1810

## Description

Test discovery runs the test executable in a separate process, which does not inherit anything set through `PROPERTIES ENVIRONMENT` — those are applied by CTest to the tests themselves, not to the listing run. An executable that needs a particular environment just to start up and list its test cases therefore fails at discovery time, even though the tests would run fine.

The cases reported in #1810 are a missing shared library search path, a Qt platform plugin needing `offscreen` on a headless machine, and an instrumentation library whose extra output corrupts the JSON listing.

`DL_PATHS` already solves this for dynamic linker search paths specifically, and its documented behaviour ("set when retrieving the list of test cases ... and when the tests are executed") is exactly the semantic people want here. This adds `DISCOVERY_ENVIRONMENT` for arbitrary `<var>=<value>` pairs.

```cmake
catch_discover_tests(tests
                     DISCOVERY_ENVIRONMENT QT_QPA_PLATFORM=offscreen)
```

### Scope decision

The option applies to discovery only, not to test execution. Every case in the issue is discovery-side — the tests themselves already ran correctly via `PROPERTIES ENVIRONMENT`. Making it discovery-scoped keeps the naming unambiguous and changes no existing behaviour. Happy to widen it to cover both if you would rather it mirror `DL_PATHS` exactly.

### Restoring the previous environment

The variables are applied only for the duration of discovery and previous values are restored afterwards, including unsetting variables that were not previously defined. This matters in `PRE_TEST` mode, where `catch_discover_tests_impl` runs inside the CTest process — without the restore the variables would leak into the tests' environment, which is the opposite of what the option promises.

The saved values are kept in per-variable CMake variables rather than parallel lists, because an environment variable can be unset or hold an empty string and CMake lists cannot represent those two cases distinctly.

## Testing

Added `CMakeHelper::DiscoveryEnvironment`, a pure-CMake unit test alongside the existing `TestPrepareCommandFragment` / `TestDecomposeJsonArray` ones. It drives `catch_discover_tests_impl` against a fake listing executable that reports a sentinel environment variable back through the test name, and asserts:

- the sentinel is unset when the option is not given
- the value reaches the listing process when it is
- the variable does not leak past discovery
- a pre-existing value is overridden during discovery
- a pre-existing value is restored afterwards

The fake executable is a `cmake -P` script rather than a shell script, so the test runs unchanged on Windows.

All five assertions pass locally, and the two existing CMake helper tests still pass. Note that I ran these via `cmake -P` directly; I have not built the full test suite, so the wider CI run is the first check of the `tests/CMakeLists.txt` registration.

Worth flagging: `DL_PATHS` and `DL_FRAMEWORK_PATHS` are documented in the `Catch.cmake` header comment but missing from the option list in `docs/cmake-integration.md`. I only added the new option there rather than fix that separately — happy to do so in another PR if useful.
