### PR TITLE
Reject empty tag filters as invalid test specifications

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -111,6 +111,12 @@ complex specs:
     This allows any test case tagged with "[some-tag]". Remember that some
     tags are special, e.g. those that start with "." or with "!".
 
+    Empty tag filters (`[]`) are invalid, including when negated or combined
+    with other test specs.
+
+    > Empty tag rejection was [introduced](https://github.com/catchorg/Catch2/issues/2367#issuecomment-1046310279)
+    > in Catch2 X.Y.Z.
+
 
 You can also combine the basic test specs to create more complex test
 specs. You can:

--- a/src/catch2/internal/catch_test_spec_parser.cpp
+++ b/src/catch2/internal/catch_test_spec_parser.cpp
@@ -19,19 +19,21 @@ namespace Catch {
     TestSpecParser& TestSpecParser::parse( std::string const& arg ) {
         m_mode = None;
         m_exclusion = false;
+        m_isValid = true;
         m_arg = m_tagAliases->expandAliases( arg );
         m_escapeChars.clear();
         m_substring.reserve(m_arg.size());
         m_patternName.reserve(m_arg.size());
         m_realPatternPos = 0;
 
-        for( m_pos = 0; m_pos < m_arg.size(); ++m_pos )
-          //if visitChar fails
-           if( !visitChar( m_arg[m_pos] ) ){
-               m_testSpec.m_invalidSpecs.push_back(arg);
-               break;
-           }
+        for ( m_pos = 0; m_pos < m_arg.size(); ++m_pos ) {
+            if ( !visitChar( m_arg[m_pos] ) || !m_isValid ) {
+                m_isValid = false;
+                break;
+            }
+        }
         endMode();
+        if ( !m_isValid ) { m_testSpec.m_invalidSpecs.push_back( arg ); }
         return *this;
     }
     TestSpec TestSpecParser::testSpec() {
@@ -112,6 +114,7 @@ namespace Catch {
     }
     void TestSpecParser::startNewMode( Mode mode ) {
         m_mode = mode;
+        if ( mode == Tag ) { m_tagPatternStart = m_patternName.size(); }
     }
     void TestSpecParser::endMode() {
         switch( m_mode ) {
@@ -212,9 +215,12 @@ namespace Catch {
     }
 
     void TestSpecParser::addTagPattern() {
+        bool const isEmpty = m_patternName.size() == m_tagPatternStart;
         auto token = preprocessPattern();
 
-        if (!token.empty()) {
+        if ( isEmpty || token.empty() ) {
+            m_isValid = false;
+        } else {
             // If the tag pattern is the "hide and tag" shorthand (e.g. [.foo])
             // we have to create a separate hide tag and shorten the real one
             if (token.size() > 1 && token[0] == '.') {

--- a/src/catch2/internal/catch_test_spec_parser.hpp
+++ b/src/catch2/internal/catch_test_spec_parser.hpp
@@ -27,8 +27,10 @@ namespace Catch {
         Mode m_mode = None;
         Mode lastMode = None;
         bool m_exclusion = false;
+        bool m_isValid = true;
         std::size_t m_pos = 0;
         std::size_t m_realPatternPos = 0;
+        std::size_t m_tagPatternStart = 0;
         std::string m_arg;
         std::string m_substring;
         std::string m_patternName;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -535,6 +535,16 @@ set_tests_properties("ErrorHandling::InvalidTestSpecExitsEarly"
     FAIL_REGULAR_EXPRESSION "No tests ran"
 )
 
+add_test(NAME "ErrorHandling::EmptyTagFilterExitsEarly"
+  COMMAND
+    $<TARGET_FILE:SelfTest> "[]"
+)
+set_tests_properties("ErrorHandling::EmptyTagFilterExitsEarly"
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION "Invalid Filter: \\[\\]"
+    FAIL_REGULAR_EXPRESSION "No tests ran"
+)
+
 if(WIN32)
   set(_NullFile "NUL")
 else()

--- a/tests/SelfTest/IntrospectiveTests/TestSpec.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/TestSpec.tests.cpp
@@ -245,6 +245,7 @@ TEST_CASE( "Parse test names and tags", "[command-line][test-spec][approvals]" )
     }
     SECTION( "empty tag" ) {
         TestSpec spec = parseTestSpec( "[]" );
+        REQUIRE( spec.getInvalidSpecs() == std::vector<std::string>{ "[]" } );
         CHECK( spec.hasFilters() == false );
         CHECK( spec.matches( *tcA ) == false );
         CHECK( spec.matches( *tcB ) == false );

--- a/tests/SelfTest/IntrospectiveTests/TestSpecParser.tests.cpp
+++ b/tests/SelfTest/IntrospectiveTests/TestSpecParser.tests.cpp
@@ -53,3 +53,82 @@ TEST_CASE("Parsed tags are matched case insensitive",
 
     REQUIRE( spec.matches( testCase ) );
 }
+
+TEST_CASE( "Empty tag filters are invalid test specifications",
+           "[test-spec][test-spec-parser][approvals]" ) {
+    auto const& input = GENERATE( as<std::string>{},
+                                  "[]",
+                                  "~[]",
+                                  "exclude:[]",
+                                  "[][valid]",
+                                  "[valid][]",
+                                  "[],[valid]",
+                                  "[valid],[]",
+                                  "[][]" );
+    CAPTURE( input );
+    Catch::TagAliasRegistry registry;
+    auto spec = Catch::TestSpecParser( registry ).parse( input ).testSpec();
+    REQUIRE( spec.getInvalidSpecs() == std::vector<std::string>{ input } );
+}
+
+TEST_CASE( "Invalid empty tags retain the original argument across aliases",
+           "[test-spec][test-spec-parser][approvals]" ) {
+    Catch::TagAliasRegistry registry;
+    registry.add( "[@empty]", "[]", dummySourceLineInfo );
+    Catch::TestSpecParser parser( registry );
+    parser.parse( "[@empty]" ).parse( "[valid]" ).parse( "~[]" );
+    auto spec = parser.testSpec();
+    REQUIRE( spec.getInvalidSpecs() ==
+             std::vector<std::string>{ "[@empty]", "~[]" } );
+}
+
+TEST_CASE( "Empty names and literal brackets are not empty tag filters",
+           "[test-spec][test-spec-parser][approvals]" ) {
+    auto const& input = GENERATE( as<std::string>{},
+                                  "",
+                                  "\"\"",
+                                  "\"[]\"",
+                                  "\\[\\]",
+                                  "[ ]",
+                                  "[.]",
+                                  "[valid]" );
+    CAPTURE( input );
+    Catch::TagAliasRegistry registry;
+    auto spec = Catch::TestSpecParser( registry ).parse( input ).testSpec();
+    REQUIRE( spec.getInvalidSpecs().empty() );
+}
+
+TEST_CASE(
+    "Empty tag filters do not inherit pattern text from earlier arguments",
+    "[test-spec][test-spec-parser][approvals]" ) {
+    auto const& previous =
+        GENERATE( as<std::string>{}, "\\[\\]", "foo\\", "[foo\\" );
+    auto const& input = GENERATE(
+        as<std::string>{}, "[]", "~[]", "[][valid]", "[],[valid]", "[]*" );
+    CAPTURE( previous, input );
+    Catch::TagAliasRegistry registry;
+    Catch::TestSpecParser parser( registry );
+    parser.parse( previous ).parse( input );
+    auto spec = parser.testSpec();
+    REQUIRE( spec.getInvalidSpecs() == std::vector<std::string>{ input } );
+}
+
+TEST_CASE( "Literal bracket names can be combined with tag filters",
+           "[test-spec][test-spec-parser][approvals]" ) {
+    Catch::TagAliasRegistry registry;
+    Catch::TestSpecParser parser( registry );
+    SECTION( "Name before tag" ) { parser.parse( "\"[]\"" ).parse( "[valid]" ); }
+    SECTION( "Tag before name" ) { parser.parse( "[valid]" ).parse( "\"[]\"" ); }
+    SECTION( "Name and tag in one argument" ) { parser.parse( "\"[]\"[valid]" ); }
+    auto spec = parser.testSpec();
+    REQUIRE( spec.getInvalidSpecs().empty() );
+    Catch::TestCaseInfo bracketName(
+        "", { "[]", "[valid]" }, dummySourceLineInfo );
+    Catch::TestCaseInfo ordinaryName(
+        "", { "ordinary", "[valid]" }, dummySourceLineInfo );
+    Catch::TestCaseInfo otherTag(
+        "", { "[]", "[other]" }, dummySourceLineInfo );
+    REQUIRE( spec.matches( bracketName ) );
+    REQUIRE_FALSE( spec.matches( ordinaryName ) );
+    REQUIRE_FALSE( spec.matches( otherTag ) );
+}


### PR DESCRIPTION
## Description

Passing `[]` to SelfTest currently runs all default tests because the empty tag is silently discarded. Reject it as an invalid test specification (exit code 5), including negated filters, combined filters, and empty tags expanded from aliases.

Report the original argument once. Track whether the current tag contains any characters so that text left by an earlier argument cannot hide an empty tag. Add parser regressions, a CLI error-handling test, and a versioned documentation note.

Validation on Windows with LLVM-MinGW:

- 224 parser assertions and all 83 basic CTest tests pass, including approvals. A separate review reran all 83 tests and compared 261 CLI argument vectors with the original build.
- An eight-test fixture checked 1,230 argument combinations: 411 empty-tag combinations are rejected and 819 other combinations retain their original selections and exit codes.
- The all-tests build succeeds; 143 of 145 CTest tests pass. The same two failures reproduce on unchanged upstream: ExperimentalRedirect's unused private field warning and the JUnit crash reporter's missing closing element. Builds use a local `-Wno-error=pointer-bool-conversion` flag for an existing Clang 23 warning; no compiler settings are changed in this PR.

Prepared with Codex and independently reviewed by a separate agent before submission.

## GitHub Issues

Addresses the [CLI follow-up in #2367](https://github.com/catchorg/Catch2/issues/2367#issuecomment-1046310279). The original JUnit assertion crash is outside this change.
