### PR TITLE
Pass the parent toolchain to CMake configuration tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -645,6 +645,11 @@ if(CATCH_ENABLE_CONFIGURE_TESTS)
         COST 240
         LABELS "uses-python"
     )
+    if(CMAKE_TOOLCHAIN_FILE)
+      set_tests_properties("CMakeConfig::${testName}"
+        PROPERTIES ENVIRONMENT "CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+      )
+    endif()
   endforeach()
 endif()
 

--- a/tests/TestScripts/ConfigureTestsCommon.py
+++ b/tests/TestScripts/ConfigureTestsCommon.py
@@ -18,6 +18,10 @@ def configure_and_build(source_path: str, project_path: str, options: List[Tuple
                           '-S{}'.format(source_path),
                           '-DCMAKE_BUILD_TYPE=Debug',
                           '-DCATCH_DEVELOPMENT_BUILD=ON']
+    toolchain_file = os.environ.get('CMAKE_TOOLCHAIN_FILE')
+    if toolchain_file:
+        # CMake only reads this environment variable itself since 3.21.
+        base_configure_cmd.append('-DCMAKE_TOOLCHAIN_FILE={}'.format(toolchain_file))
     for option, value in options:
         base_configure_cmd.append('-D{}={}'.format(option, value))
     try:


### PR DESCRIPTION
## Description

When Catch2 is configured with a toolchain whose compiler is not on PATH, the CMake configuration tests start child builds without that toolchain and fail to find a compiler. Pass the parent's toolchain to those tests and forward it explicitly to CMake, including versions before 3.21 that do not read the environment variable automatically.

The existing behavior is preserved when no toolchain is configured.

## Validation

- Reproduced the original `CMakeConfig::Disable` failure with LLVM MinGW selected only through a toolchain and no compiler on PATH; all four configuration tests pass after the change.
- Independently checked 28 small C++ build/run cases with CMake 3.16.9 and 4.4.3: inherited and relative toolchain paths with spaces, absent/empty variables, explicit override and explicit clearing. The original helper fails compiler discovery on CMake 3.16; the corrected helper succeeds.
- Full `all-tests` build completed. CTest: 143/144 pass; the existing Windows `Reporters::CrashInJunitReporter` failure reproduces on the unmodified base. Two unrelated Clang 23 warnings were reproduced on the base and kept as warnings in the local validation toolchain.

Implemented and independently reviewed by automated agents before submission.

## GitHub Issues

Fixes #2743.
